### PR TITLE
Don't use revoked keys

### DIFF
--- a/OpenPGP-Keychain/src/org/sufficientlysecure/keychain/pgp/PgpKeyHelper.java
+++ b/OpenPGP-Keychain/src/org/sufficientlysecure/keychain/pgp/PgpKeyHelper.java
@@ -137,7 +137,7 @@ public class PgpKeyHelper {
         PGPPublicKey masterKey = null;
         for (int i = 0; i < encryptKeys.size(); ++i) {
             PGPPublicKey key = encryptKeys.get(i);
-            if (!isExpired(key)) {
+            if (!isExpired(key)  && !key.isRevoked()) {
                 if (key.isMasterKey()) {
                     masterKey = key;
                 } else {


### PR DESCRIPTION
Check if keys are revoked when getting usable encryption keys. Only use keys which are not expired and not revoked.
