### PR TITLE
set mainUserIdRest visible after GONE in previous key

### DIFF
--- a/OpenPGP-Keychain/src/org/sufficientlysecure/keychain/ui/widget/KeyListAdapter.java
+++ b/OpenPGP-Keychain/src/org/sufficientlysecure/keychain/ui/widget/KeyListAdapter.java
@@ -92,6 +92,8 @@ public class KeyListAdapter extends CursorTreeAdapter {
 
         if (mainUserIdRest.getText().length() == 0) {
             mainUserIdRest.setVisibility(View.GONE);
+        } else {
+            mainUserIdRest.setVisibility(View.VISIBLE);
         }
     }
 


### PR DESCRIPTION
I see kalkin is working on a new keylist design (issue 66), but I fixed this earlier and it's a small thing which might be worth remembering if there is code copying at some point in redesign. I'll send a pull request rather than just merging.
