### PR TITLE
OpenPgpData minor Fix

### DIFF
--- a/OpenPGP-Keychain-API-Demo/src/org/openintents/openpgp/OpenPgpData.java
+++ b/OpenPGP-Keychain-API-Demo/src/org/openintents/openpgp/OpenPgpData.java
@@ -99,7 +99,7 @@ public class OpenPgpData implements Parcelable {
     }
 
     public void writeToParcel(Parcel dest, int flags) {
-    	dest.writeInt(type);
+        dest.writeInt(type);
         dest.writeString(string);
         dest.writeInt(bytes.length);
         dest.writeByteArray(bytes);

--- a/OpenPGP-Keychain/src/org/openintents/openpgp/OpenPgpData.java
+++ b/OpenPGP-Keychain/src/org/openintents/openpgp/OpenPgpData.java
@@ -99,7 +99,7 @@ public class OpenPgpData implements Parcelable {
     }
 
     public void writeToParcel(Parcel dest, int flags) {
-    	dest.writeInt(type);
+        dest.writeInt(type);
         dest.writeString(string);
         dest.writeInt(bytes.length);
         dest.writeByteArray(bytes);


### PR DESCRIPTION
The type is not saved in the OpenPgpData used in the service API. This leads to exceptions when using byte array input.
