### PR TITLE
add "never" for ttl for passphrase cache

### DIFF
--- a/OpenPGP-Keychain/res/values/arrays.xml
+++ b/OpenPGP-Keychain/res/values/arrays.xml
@@ -13,6 +13,7 @@
         <item>@string/choice_2hours</item>
         <item>@string/choice_4hours</item>
         <item>@string/choice_8hours</item>
+        <item>@string/choice_forever</item>
     </string-array>
     <string-array name="pass_phrase_cache_ttl_values" translatable="false">
         <item>15</item>
@@ -26,6 +27,7 @@
         <item>7200</item>
         <item>14400</item>
         <item>28800</item>
+        <item>-1</item>
     </string-array>
     <string-array name="key_size_spinner_values" translatable="false">
         <item>@string/key_size_512</item>

--- a/OpenPGP-Keychain/res/values/strings.xml
+++ b/OpenPGP-Keychain/res/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="choice_2hours">2 hours</string>
     <string name="choice_4hours">4 hours</string>
     <string name="choice_8hours">8 hours</string>
+    <string name="choice_forever">forever</string>
     <string name="dsa">DSA</string>
     <string name="elgamal">ElGamal</string>
     <string name="rsa">RSA</string>

--- a/OpenPGP-Keychain/src/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
+++ b/OpenPGP-Keychain/src/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
@@ -291,10 +291,12 @@ public class PassphraseCacheService extends Service {
                 // add keyId and passphrase to memory
                 mPassphraseCache.put(keyId, passphrase);
 
-                // register new alarm with keyId for this passphrase
-                long triggerTime = new Date().getTime() + (ttl * 1000);
-                AlarmManager am = (AlarmManager) this.getSystemService(Context.ALARM_SERVICE);
-                am.set(AlarmManager.RTC_WAKEUP, triggerTime, buildIntent(this, keyId));
+                if (ttl > 0) {
+                    // register new alarm with keyId for this passphrase
+                    long triggerTime = new Date().getTime() + (ttl * 1000);
+                    AlarmManager am = (AlarmManager) this.getSystemService(Context.ALARM_SERVICE);
+                    am.set(AlarmManager.RTC_WAKEUP, triggerTime, buildIntent(this, keyId));
+                }
             } else if (ACTION_PASSPHRASE_CACHE_GET.equals(intent.getAction())) {
                 long keyId = intent.getLongExtra(EXTRA_KEY_ID, -1);
                 Messenger messenger = intent.getParcelableExtra(EXTRA_MESSENGER);


### PR DESCRIPTION
to allow a never-expire for the passphase cache i added a simple "forever"-choice. i don't like this aproach as
- it doesn't distinguish per key
- it doesn't distinguish per client

which would be needed. the program should reset the timeout on any usage, not sure if it does already, but if not it should be added. if time allows i will dig into this.
