### PR TITLE
prevent null byte[] in case of encoding exc

### DIFF
--- a/OpenPGP-Keychain-API/example-app/src/main/java/org/sufficientlysecure/keychain/demo/IntentActivity.java
+++ b/OpenPGP-Keychain-API/example-app/src/main/java/org/sufficientlysecure/keychain/demo/IntentActivity.java
@@ -112,11 +112,11 @@ public class IntentActivity extends PreferenceActivity {
                     byte[] pubkey = null;
                     try {
                         pubkey = TEST_PUBKEY.getBytes("UTF-8");
+                        intent.putExtra(OpenKeychainIntents.IMPORT_KEY_EXTRA_KEY_BYTES, pubkey);
+                        startActivity(intent);
                     } catch (UnsupportedEncodingException e) {
-                        e.printStackTrace();
+                        Log.e(Constants.TAG, "UnsupportedEncodingException", e);
                     }
-                    intent.putExtra(OpenKeychainIntents.IMPORT_KEY_EXTRA_KEY_BYTES, pubkey);
-                    startActivity(intent);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(IntentActivity.this, "Activity not found!", Toast.LENGTH_LONG).show();
                 }


### PR DESCRIPTION
in theory the byte array could be null if an exception occures (which wont happen in praxis). i would additionally suggest to use "ascii" encoding as well for armoured stuff but i am no expert on that. i changed the printStackTrace as well as i considere this not correct for logging on android.
