### PR TITLE
Add travis ci support to OpenPGP-Keychain, Fix #156

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: java
+jdk: oraclejdk7
+before_install:
+    # Install base Android SDK
+    - sudo apt-get update -qq
+    - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs; fi
+    - wget http://dl.google.com/android/android-sdk_r22.3-linux.tgz
+    - tar xzf android-sdk_r22.3-linux.tgz
+    - export ANDROID_HOME=$PWD/android-sdk-linux
+    - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+
+    # Install required Android components.
+    - echo "y" | android update sdk -a --filter build-tools-19.0.1,android-19,platform-tools,extra-android-support,extra-android-m2repository,android-17 --no-ui --force
+install: echo "Installation done"
+script: gradle assemble -S -q
+

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Translations are hosted on Transifex, which is configured by ".tx/config".
 
 see http://help.transifex.net/features/client/index.html#user-client
 
+### Travis CI
+I am in the progress of adding travis ci, please be patient.
+
 ## Coding Style
 
 ### Code


### PR DESCRIPTION
Currently only correct assembly is tested since upstream
Spongycastle fails some of its tests.
Further improvements:
- sort out correct ia32-libs and speed up the setup process
- Provide a way to access the generated lint files or disable lint
  alltogether
