### PR TITLE
Issue #178 - Hide advanced options in EncryptActivity

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptActivity.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptActivity.java
@@ -52,17 +52,21 @@ import android.os.Message;
 import android.os.Messenger;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.animation.AlphaAnimation;
+import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ViewFlipper;
 
 import com.beardedhen.androidbootstrap.BootstrapButton;
+import com.beardedhen.androidbootstrap.FontAwesomeText;
 import com.devspark.appmsg.AppMsg;
 
 public class EncryptActivity extends DrawerActivity {
@@ -114,6 +118,11 @@ public class EncryptActivity extends DrawerActivity {
     private String mInputFilename = null;
     private String mOutputFilename = null;
 
+    private Integer mShortAnimationDuration = null;
+    private boolean mFileAdvancedSettingsVisible = false;
+    private TextView mFileAdvancedSettings = null;
+    private LinearLayout mFileAdvancedSettingsContainer = null;
+    private FontAwesomeText mAdvancedSettingsIcon;
     private boolean mAsciiArmorDemand = false;
     private boolean mOverrideAsciiArmor = false;
 
@@ -148,6 +157,9 @@ public class EncryptActivity extends DrawerActivity {
         updateMode();
 
         updateActionBarButtons();
+
+        // retrieve and cache the system's short animation time
+        mShortAnimationDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
     }
 
     /**
@@ -790,6 +802,50 @@ public class EncryptActivity extends DrawerActivity {
             public void onClick(View v) {
                 FileHelper.openFile(EncryptActivity.this, mFilename.getText().toString(), "*/*",
                         Id.request.filename);
+            }
+        });
+
+        mAdvancedSettingsIcon = (FontAwesomeText) findViewById(R.id.advancedSettingsIcon);
+        mFileAdvancedSettingsContainer = (LinearLayout) findViewById(R.id.fileAdvancedSettingsContainer);
+        mFileAdvancedSettings = (TextView) findViewById(R.id.advancedSettings);
+
+        LinearLayout advancedSettingsControl = (LinearLayout) findViewById(R.id.advancedSettingsControl);
+        advancedSettingsControl.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mFileAdvancedSettingsVisible = !mFileAdvancedSettingsVisible;
+                if (mFileAdvancedSettingsVisible) {
+                    mAdvancedSettingsIcon.setIcon("fa-chevron-down");
+                    mFileAdvancedSettingsContainer.setVisibility(View.VISIBLE);
+                    AlphaAnimation animation = new AlphaAnimation(0f, 1f);
+                    animation.setDuration(mShortAnimationDuration);
+                    mFileAdvancedSettingsContainer.startAnimation(animation);
+                    mFileAdvancedSettings.setText(R.string.btn_encryption_advanced_settings_hide);
+
+                } else {
+                    mAdvancedSettingsIcon.setIcon("fa-chevron-right");
+                    AlphaAnimation animation = new AlphaAnimation(1f, 0f);
+                    animation.setDuration(mShortAnimationDuration);
+                    animation.setAnimationListener(new Animation.AnimationListener() {
+                        @Override
+                        public void onAnimationStart(Animation animation) {
+                            // do nothing
+                        }
+
+                        @Override
+                        public void onAnimationEnd(Animation animation) {
+                            // making sure that at the end the container is completely removed from view
+                            mFileAdvancedSettingsContainer.setVisibility(View.GONE);
+                        }
+
+                        @Override
+                        public void onAnimationRepeat(Animation animation) {
+                            // do nothing
+                        }
+                    });
+                    mFileAdvancedSettingsContainer.startAnimation(animation);
+                    mFileAdvancedSettings.setText(R.string.btn_encryption_advanced_settings_show);
+                }
             }
         });
 

--- a/OpenPGP-Keychain/src/main/res/layout/encrypt_activity.xml
+++ b/OpenPGP-Keychain/src/main/res/layout/encrypt_activity.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:bootstrapbutton="http://schemas.android.com/apk/res-auto"
+    xmlns:fontawesometext="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -251,64 +252,97 @@
                     </LinearLayout>
 
                     <LinearLayout
+                        android:id="@+id/advancedSettingsControl"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal">
-
+                        android:orientation="horizontal"
+                        android:clickable="true">
+                        <com.beardedhen.androidbootstrap.FontAwesomeText
+                            android:id="@+id/advancedSettingsIcon"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginRight="10dp"
+                            android:textSize="12sp"
+                            android:paddingTop="@dimen/padding_medium"
+                            android:paddingBottom="@dimen/padding_medium"
+                            fontawesometext:fa_icon="fa-chevron-right"/>
                         <TextView
-                            android:id="@+id/label_fileCompression"
-                            android:layout_width="0dip"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:layout_weight="1"
-                            android:paddingRight="10dip"
-                            android:text="@string/label_file_compression"
-                            android:textAppearance="?android:attr/textAppearanceSmall" />
-
-                        <Spinner
-                            android:id="@+id/fileCompression"
+                            android:id="@+id/advancedSettings"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical" />
+                            android:text="@string/btn_encryption_advanced_settings_show"
+                            android:paddingTop="@dimen/padding_medium"
+                            android:paddingBottom="@dimen/padding_medium"
+                            android:textColor="@color/emphasis"/>
                     </LinearLayout>
 
                     <LinearLayout
+                        android:id="@+id/fileAdvancedSettingsContainer"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal">
+                        android:orientation="vertical"
+                        android:visibility="gone">
 
-                        <CheckBox
-                            android:id="@+id/deleteAfterEncryption"
-                            android:layout_width="wrap_content"
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:text="@string/label_delete_after_encryption" />
-                    </LinearLayout>
+                            android:orientation="horizontal">
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal">
+                            <TextView
+                                android:id="@+id/label_fileCompression"
+                                android:layout_width="0dip"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical"
+                                android:layout_weight="1"
+                                android:paddingRight="10dip"
+                                android:text="@string/label_file_compression"
+                                android:textAppearance="?android:attr/textAppearanceSmall" />
 
-                        <CheckBox
-                            android:id="@+id/shareAfterEncryption"
-                            android:layout_width="wrap_content"
+                            <Spinner
+                                android:id="@+id/fileCompression"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:text="@string/label_share_after_encryption" />
-                    </LinearLayout>
+                            android:orientation="horizontal">
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal">
+                            <CheckBox
+                                android:id="@+id/deleteAfterEncryption"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical"
+                                android:text="@string/label_delete_after_encryption" />
+                        </LinearLayout>
 
-                        <CheckBox
-                            android:id="@+id/asciiArmour"
-                            android:layout_width="wrap_content"
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_gravity="center_vertical"
-                            android:text="@string/label_ascii_armor" />
+                            android:orientation="horizontal">
+
+                            <CheckBox
+                                android:id="@+id/shareAfterEncryption"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical"
+                                android:text="@string/label_share_after_encryption" />
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+
+                            <CheckBox
+                                android:id="@+id/asciiArmour"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical"
+                                android:text="@string/label_ascii_armor" />
+                        </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>
             </ViewFlipper>

--- a/OpenPGP-Keychain/src/main/res/values/strings.xml
+++ b/OpenPGP-Keychain/src/main/res/values/strings.xml
@@ -67,6 +67,8 @@
     <string name="btn_clipboard">Clipboard</string>
     <string name="btn_share">Share with…</string>
     <string name="btn_lookup_key">Lookup key</string>
+    <string name="btn_encryption_advanced_settings_show">Show advanced settings</string>
+    <string name="btn_encryption_advanced_settings_hide">Hide advanced settings</string>
 
     <!-- menu -->
     <string name="menu_preferences">Settings</string>


### PR DESCRIPTION
This is a commit trying to fix issue #178.

For now I've made the Show/hide advanced settings button as a text only button in order to not over clutter the UI. If you prefer to have a button instead of a text, I can also do that :) 

Let me know if this seems ok.

// I really like this project and I would like to participate in GSoC 2014
