### PR TITLE
Issue #378 ( private keys are no longer red ): Fixed

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysListEntry.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysListEntry.java
@@ -155,6 +155,9 @@ public class ImportKeysListEntry implements Serializable, Parcelable {
         if ( !(pgpKeyRing instanceof PGPSecretKeyRing) ) {
             secretKey = false;
         }
+        else{
+            secretKey = true;
+        }
 
         userIds = new ArrayList<String>();
         for (String userId : new IterableIterator<String>(pgpKeyRing.getPublicKey().getUserIDs())) {


### PR DESCRIPTION
secretKey is set to false if pgpKeyRing is not an instance of PGPSecretKeyRing. But the opposite was not handled anywhere. So i added a simple else case. To my understanding the logic is not broken.
