### PR TITLE
 Reset cursor query when closing search view #386 

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListPublicFragment.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListPublicFragment.java
@@ -368,13 +368,17 @@ public class KeyListPublicFragment extends Fragment implements SearchView.OnQuer
         mSearchView.setOnQueryTextListener(this);
 
         //Erase search result without focus
-        mSearchView.setOnQueryTextFocusChangeListener(new View.OnFocusChangeListener() {
+        MenuItemCompat.setOnActionExpandListener(searchItem, new MenuItemCompat.OnActionExpandListener() {
             @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                if (!hasFocus) {
-                    mCurQuery = null;
-                    getLoaderManager().restartLoader(0, null, KeyListPublicFragment.this);
-                }
+            public boolean onMenuItemActionExpand(MenuItem item) {
+                return true;
+            }
+
+            @Override
+            public boolean onMenuItemActionCollapse(MenuItem item) {
+                mCurQuery = null;
+                getLoaderManager().restartLoader(0, null, KeyListPublicFragment.this);
+                return true;
             }
         });
 


### PR DESCRIPTION
OnFocusChangeListener replaced with OnActionExpandListener
For same behaviour like contacts app #386 #387
