### PR TITLE
Fix for Issue #393 ( PublicKeyListFragment: Query not really resetted )

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListPublicFragment.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListPublicFragment.java
@@ -377,6 +377,7 @@ public class KeyListPublicFragment extends Fragment implements SearchView.OnQuer
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
                 mCurQuery = null;
+                mSearchView.setQuery("", true);
                 getLoaderManager().restartLoader(0, null, KeyListPublicFragment.this);
                 return true;
             }


### PR DESCRIPTION
clearing the query in mSearchView when onMenuItemActionCollapse is called
