### PR TITLE
Specifying connection port in KeyServer

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/util/HkpKeyServer.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/util/HkpKeyServer.java
@@ -232,7 +232,7 @@ public class HkpKeyServer extends KeyServer {
         HttpClient client = new DefaultHttpClient();
         try {
             HttpGet get = new HttpGet("http://" + mHost + ":" + mPort
-                    + "/pks/lookup?op=get&search=0x" + PgpKeyHelper.convertKeyIdToHex(keyId));
+                    + "/pks/lookup?op=get&search=" + PgpKeyHelper.convertKeyIdToHex(keyId));
 
             HttpResponse response = client.execute(get);
             if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {


### PR DESCRIPTION
This is reference to issue https://github.com/openpgp-keychain/openpgp-keychain/issues/97. I have made specifying connection port possible in KeyServer. Please verify and let me know if any changes are required.
