### PR TITLE
Added FAQ: specifying connection port for Keyserver.

### DIFF
--- a/OpenPGP-Keychain/src/main/res/raw/help_faq.html
+++ b/OpenPGP-Keychain/src/main/res/raw/help_faq.html
@@ -5,8 +5,9 @@ And don't add newlines before or after p tags because of transifex -->
 <head>
 </head>
 <body>
-<h2>TODO</h2>
-<p>text</p>
+<h2>How can I specify connection port for Keyserver?</h2>
+<p>Add a new Keyserver (or modify existing one) by going to Preferences -> General -> Keyservers. Enter the port number after the Keyserver address and preceded it by a colon. For example, "p80.pool.sks-keyservers.net:80" (without quotation marks) means that server "p80.pool.sks-keyservers.net" is working on a port 80.</p>
+<p>Default connection port is 11371 and it doesn't need to be specified.</p>
 
 </body>
 </html>


### PR DESCRIPTION
Added FAQ entry about using special port to connect to a Keyserver, as mentioned in https://github.com/openpgp-keychain/openpgp-keychain/pull/408
