### PR TITLE
Close Activity Dialog

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/EditKeyActivity.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/EditKeyActivity.java
@@ -18,6 +18,8 @@
 package org.sufficientlysecure.keychain.ui;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.DialogFragment;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -50,6 +52,7 @@ import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
 import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
 import org.sufficientlysecure.keychain.service.PassphraseCacheService;
+import org.sufficientlysecure.keychain.ui.dialog.CloseActivityDialog;
 import org.sufficientlysecure.keychain.ui.dialog.DeleteKeyDialogFragment;
 import org.sufficientlysecure.keychain.ui.dialog.PassphraseDialogFragment;
 import org.sufficientlysecure.keychain.ui.dialog.SetPassphraseDialogFragment;
@@ -68,7 +71,7 @@ public class EditKeyActivity extends ActionBarActivity {
     // Actions for internal use only:
     public static final String ACTION_CREATE_KEY = Constants.INTENT_PREFIX + "CREATE_KEY";
     public static final String ACTION_EDIT_KEY = Constants.INTENT_PREFIX + "EDIT_KEY";
-
+    public String ACTION;
     // possible extra keys
     public static final String EXTRA_USER_IDS = "user_ids";
     public static final String EXTRA_NO_PASSPHRASE = "no_passphrase";
@@ -116,8 +119,10 @@ public class EditKeyActivity extends ActionBarActivity {
         Intent intent = getIntent();
         String action = intent.getAction();
         if (ACTION_CREATE_KEY.equals(action)) {
+            ACTION = ACTION_CREATE_KEY;
             handleActionCreateKey(intent);
         } else if (ACTION_EDIT_KEY.equals(action)) {
+            ACTION = ACTION_EDIT_KEY;
             handleActionEditKey(intent);
         }
     }
@@ -691,6 +696,17 @@ public class EditKeyActivity extends ActionBarActivity {
     private void updatePassPhraseButtonText() {
         mChangePassphrase.setText(isPassphraseSet() ? getString(R.string.btn_change_passphrase)
                 : getString(R.string.btn_set_passphrase));
+    }
+
+    @Override
+    public void onBackPressed() {
+        if(ACTION.equals(ACTION_CREATE_KEY)) {
+            CloseActivityDialog dialog = new CloseActivityDialog();
+            getSupportFragmentManager().beginTransaction().add(dialog, "Close Dialog").commit();
+        }
+        else{
+            super.onBackPressed();
+        }
     }
 
 }

--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/CloseActivityDialog.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/CloseActivityDialog.java
@@ -1,0 +1,53 @@
+package org.sufficientlysecure.keychain.ui.dialog;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.ActionBarActivity;
+
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.ui.EditKeyActivity;
+
+/**
+ * Created by sreeram on 17/3/14.
+ */
+public class CloseActivityDialog extends DialogFragment {
+    private ActionBarActivity activity;
+
+    public static CloseActivityDialog newInstance() {
+        CloseActivityDialog fragment = new CloseActivityDialog();
+        return fragment;
+    }
+
+    public CloseActivityDialog(){}
+
+    public CloseActivityDialog(ActionBarActivity mActivity){
+        activity = mActivity;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreateDialog(savedInstanceState);
+        AlertDialog.Builder dialog = new AlertDialog.Builder(getActivity())
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle("Closing Window")
+                .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        getActivity().finish();
+                    }
+
+                })
+                .setNegativeButton("No", null);
+        if(getActivity() instanceof EditKeyActivity) {
+            dialog.setMessage(getString(R.string.closing_edit_key_activity));
+        }
+        else{
+            dialog.setMessage(getString(R.string.closing_activity));
+        }
+        return dialog.create();
+    }
+}

--- a/OpenPGP-Keychain/src/main/res/values/strings.xml
+++ b/OpenPGP-Keychain/src/main/res/values/strings.xml
@@ -219,7 +219,8 @@
     <string name="key_deletion_confirmation">Do you really want to delete the key \'%s\'?\nYou can\'t undo this!</string>
     <string name="key_deletion_confirmation_multi">Do you really want to delete all selected keys?\nYou can\'t undo this!</string>
     <string name="secret_key_deletion_confirmation">Do you really want to delete the SECRET key \'%s\'?\nYou can\'t undo this!</string>
-
+    <string name="closing_edit_key_activity">The key generated will be lost, Do you want to quit?</string>
+    <string name="closing_activity">Do you want to close this Window?</string>
     <plurals name="keys_added_and_updated_1">
         <item quantity="one">Successfully added %d key</item>
         <item quantity="other">Successfully added %d keys</item>


### PR DESCRIPTION
Each key creation by default takes 2 minutes on nexus 4. If the user accidentally presses back button. Key generated is lost and user has to go through entire process again.

P.S: I do not know why it is giving me merge conflicts.
