### PR TITLE
Can_Encrypt Check added to hide Button

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyMainFragment.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyMainFragment.java
@@ -266,8 +266,8 @@ public class ViewKeyMainFragment extends Fragment implements
                 if (data.moveToFirst()) {
                     // get key id from MASTER_KEY_ID
                     long keyId = data.getLong(KEYS_INDEX_KEY_ID);
-                    long can_encrypt = data.getLong(KEYS_INDEX_CAN_ENCRYPT);
-                    if(can_encrypt == 0){
+                    long canEncrypt = data.getLong(KEYS_INDEX_CAN_ENCRYPT);
+                    if(canEncrypt == 0){
                         mActionEncrypt.setVisibility(View.GONE);
                     }
                     String keyIdStr = PgpKeyHelper.convertKeyIdToHex(keyId);


### PR DESCRIPTION
Issue #379 .

If the master key cannot encrypt. Then encrypt button is disabled.
