### PR TITLE
fix emails not showing up in import keyserver search

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/util/HkpKeyServer.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/util/HkpKeyServer.java
@@ -257,8 +257,7 @@ public class HkpKeyServer extends KeyServer {
             final String uidLines = matcher.group(7);
             final Matcher uidMatcher = UID_LINE.matcher(uidLines);
             while (uidMatcher.find()) {
-                String tmp = uidMatcher.group(1).replaceAll("<.*?>", "");
-                tmp = Html.fromHtml(tmp).toString().trim();
+                String tmp = uidMatcher.group(1).trim();
                 if (tmp.contains("%")) {
                     try {
                         // converts Strings like "Universit%C3%A4t" to a proper encoding form "Universität".


### PR DESCRIPTION
Fixes #438 
In HkpKeyServer userids were preprocessed even though the normal processing happens in methods in Provider/ProviderHelper. 
Tested it now and it seems to show mails and work as expected. :) 
