### PR TITLE
CertifyKeyActivity sets error if no key is selected

### DIFF
--- a/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/SelectSecretKeyLayoutFragment.java
+++ b/OpenPGP-Keychain/src/main/java/org/sufficientlysecure/keychain/ui/SelectSecretKeyLayoutFragment.java
@@ -119,8 +119,8 @@ public class SelectSecretKeyLayoutFragment extends Fragment {
     }
 
     public void setError(String error) {
-        mKeyUserId.requestFocus();
-        mKeyUserId.setError(error);
+        mNoKeySelected.requestFocus();
+        mNoKeySelected.setError(error);
     }
 
     /**


### PR DESCRIPTION
Fixes #442
I'm not 100% sure that this is what you meant. 
In setError mKeyUserId was VISIBLE_GONE when there was not key selected so I changed that to mNoKeySelected. 
It displays an error mark now when no key is selected. 
