### PR TITLE
Empty list flash

### DIFF
--- a/OpenPGP-Keychain/src/main/res/layout/key_list_fragment.xml
+++ b/OpenPGP-Keychain/src/main/res/layout/key_list_fragment.xml
@@ -11,7 +11,7 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone"
+        android:visibility="visible"
         android:gravity="center">
 
         <ProgressBar
@@ -51,7 +51,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:visibility="gone">
 
             <TextView
                 android:layout_width="wrap_content"


### PR DESCRIPTION
See #364. 

Maybe just a configuration change in `key_list_fragment.xml` does the job? I'm not really sure if we have to do more programmatically.

Tested on Nexus 4 with Android 4.4.2 without flashing up empty-list frame
