### PR TITLE
Add recent contributors to credits

### DIFF
--- a/OpenPGP-Keychain/src/main/res/raw-cs-rCZ/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-cs-rCZ/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-de/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-de/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Entwickler APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-el/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-el/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-es-rCO/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-es-rCO/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-es/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-es/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (Parches cryptográficos)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Desarrolladores de APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-fa-rIR/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-fa-rIR/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-fr/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-fr/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (correctif crypto)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar « kalkin » Gadimov (interface utilisateur)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Les développeurs d'APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-it-rIT/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-it-rIT/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (Patch crittografia)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (Interfaccia Utente)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Sviluppatori APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-ja/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-ja/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (暗号関係パッチ提供)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>APG 1.xの開発者達</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-nl-rNL/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-nl-rNL/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-pl/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-pl/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (łatki crypto)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (Interfejs Użytkownika)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Deweloperzy APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-pt-rBR/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-pt-rBR/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-ru/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-ru/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (патчи криптографии)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Разработчики APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-sl-rSI/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-sl-rSI/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-tr/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-tr/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (kripto yamaları)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (Arayüz)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Geliştiriciler APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-uk/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-uk/help_about.html
@@ -11,6 +11,12 @@
 <li>Аш Гюдж (латки шифрування)</li>
 <li>Браян С. Барнс</li>
 <li>Бахтіяр 'kalkin' Ґадімов (інтерфейс)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Розробники APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-zh-rTW/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-zh-rTW/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw-zh/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw-zh/help_about.html
@@ -11,6 +11,12 @@
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (介面)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>

--- a/OpenPGP-Keychain/src/main/res/raw/help_about.html
+++ b/OpenPGP-Keychain/src/main/res/raw/help_about.html
@@ -15,6 +15,12 @@ And don't add newlines before or after p tags because of transifex -->
 <li>Ash Hughes (crypto patches)</li>
 <li>Brian C. Barnes</li>
 <li>Bahtiar 'kalkin' Gadimov (UI)</li>
+<li>Daniel Hammann</li>
+<li>Daniel Haß</li>
+<li>Greg Witczak</li>
+<li>Miroojin Bakshi</li>
+<li>Paul Sarbinowski</li>
+<li>Vincent Breitmoser</li>
 
 </ul>
 <h2>Developers APG 1.x</h2>


### PR DESCRIPTION
I trust none of the contributors object to being mentioned. So I took stats of the last few hundred commits and the top contributors:
git log --format='%an - %ae' | head -n 500 | sort | uniq -c | sort -nk 1

No doubt it isn't complete, but if anyone was forgotten, then no doubt he/she will be added next time around. :)

I also will credit those contributors in APG, unless someone doesn't want to be mentioned for some reason.
I'll send an email to everybody regarding that.
