### PR TITLE
Modified Spinner values for CreateKeyDialog. Added info for user about custom key length restrictions.

### DIFF
--- a/OpenKeychain/src/main/res/layout/create_key_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/create_key_dialog.xml
@@ -74,6 +74,13 @@
                 android:inputType="number"
                 android:visibility="gone"/>
 
+        <TextView
+                android:id="@+id/custom_key_size_info"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:padding="4dp" />
+
     </TableLayout>
 
 </ScrollView>

--- a/OpenKeychain/src/main/res/values/arrays.xml
+++ b/OpenKeychain/src/main/res/values/arrays.xml
@@ -29,12 +29,23 @@
         <item>28800</item>
         <item>-1</item>
     </string-array>
-    <string-array name="key_size_spinner_values" translatable="false">
-        <item>@string/key_size_512</item>
-        <item>@string/key_size_1024</item>
+    <string-array name="rsa_key_size_spinner_values" translatable="false">
         <item>@string/key_size_2048</item>
         <item>@string/key_size_4096</item>
         <item>@string/key_size_8192</item>
+        <item>@string/key_size_custom</item>
+    </string-array>
+    <string-array name="elgamal_key_size_spinner_values" translatable="false">
+        <item>@string/key_size_1536</item>
+        <item>@string/key_size_2048</item>
+        <item>@string/key_size_3072</item>
+        <item>@string/key_size_4096</item>
+        <item>@string/key_size_8192</item>
+    </string-array>
+    <string-array name="dsa_key_size_spinner_values" translatable="false">
+        <item>@string/key_size_512</item>
+        <item>@string/key_size_768</item>
+        <item>@string/key_size_1024</item>
         <item>@string/key_size_custom</item>
     </string-array>
     <string-array name="import_action_list" translatable="false">

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -249,7 +249,7 @@
     <string name="key_exported">Successfully exported 1 key.</string>
     <string name="keys_exported">Successfully exported %d keys.</string>
     <string name="no_keys_exported">No keys exported.</string>
-    <string name="key_creation_el_gamal_info">Note: only subkeys support ElGamal, and for ElGamal the nearest keysize of 1536, 2048, 3072, 4096, or 8192 will be used.</string>
+    <string name="key_creation_el_gamal_info">Note: only subkeys support ElGamal.</string>
     <string name="key_creation_weak_rsa_info">Note: generating RSA key with length 1024-bit and less is considered unsafe and it\'s disabled for generating new keys.</string>
     <string name="key_not_found">Couldn\'t find key %08X.</string>
 
@@ -375,12 +375,17 @@
 
     <!-- key bit length selections -->
     <string name="key_size_512">512</string>
+    <string name="key_size_768">768</string>
     <string name="key_size_1024">1024</string>
+    <string name="key_size_1536">1536</string>
     <string name="key_size_2048">2048</string>
+    <string name="key_size_3072">3072</string>
     <string name="key_size_4096">4096</string>
     <string name="key_size_8192">8192</string>
     <string name="key_size_custom">Custom key size</string>
     <string name="key_size_custom_info">Type custom key length (in bits):</string>
+    <string name="key_size_custom_info_rsa">RSA key length must be greater than 1024 and at most 8192. Also it must be multiplicity of 8.</string>
+    <string name="key_size_custom_info_dsa">DSA key length must be at least 512 and at most 1024. Also it must be multiplicity of 64.</string>
 
     <!-- compression -->
     <string name="compression_fast">fast</string>


### PR DESCRIPTION
This is a reference to additional feature mentioned on pull request https://github.com/open-keychain/open-keychain/pull/536. 

I've added custom `Spinner` values for every algorithm. RSA and DSA have value "custom", that displays `EditText` below. There is a small bug here: when user has selected RSA/DSA and custom key length and he decides to switch to ElGamal, custom key length EditText disappears (as expected), but keyboard remains on screen). That does not affect functionality, but it's just "not cool" for user experience. 
I've tried to hide keyboard before, on my own project, and I had a lot of trouble with it. Is there any smart way for doing that?
