### PR TITLE
Select*KeyFragment rewrites

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -112,6 +112,8 @@ public class KeychainContract {
         public static final String IS_REVOKED = KeysColumns.IS_REVOKED;
         public static final String VERIFIED = CertsColumns.VERIFIED;
         public static final String HAS_SECRET = "has_secret";
+        public static final String HAS_ENCRYPT = "has_encrypt";
+        public static final String HAS_SIGN = "has_encrypt";
 
         public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
                 .appendPath(BASE_KEY_RINGS).build();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
@@ -265,6 +265,10 @@ public class KeyListFragment extends Fragment
     static final int INDEX_VERIFIED = 5;
     static final int INDEX_HAS_SECRET = 6;
 
+    static final String ORDER = // IN THE COURT
+            KeyRings.HAS_SECRET + " DESC, " + KeyRings.USER_ID + " ASC";
+
+
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
         // This is called when a new Loader needs to be created. This
@@ -276,9 +280,10 @@ public class KeyListFragment extends Fragment
             where = KeyRings.USER_ID + " LIKE ?";
             whereArgs = new String[]{"%" + mCurQuery + "%"};
         }
+
         // Now create and return a CursorLoader that will take care of
         // creating a Cursor for the data being displayed.
-        return new CursorLoader(getActivity(), baseUri, PROJECTION, where, whereArgs, null);
+        return new CursorLoader(getActivity(), baseUri, PROJECTION, where, whereArgs, ORDER);
     }
 
     @Override

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -523,5 +523,7 @@
     <string name="label_revocation">Revocation Reason</string>
     <string name="label_verify_status">Verification Status</string>
     <string name="label_cert_type">Type</string>
+    <string name="can_certify">can certify</string>
+    <string name="can_certify_not">cannot certify</string>
 
 </resources>


### PR DESCRIPTION
- moved all specific Public/Secret logic from the Adapter class into
  inner subclasses in the Fragments
- more versatile status display ("revoked", "expired", "can certify"...)
- applied view holder pattern
- query logic, including subqueries, moved into provider classes

Closes #375
