### PR TITLE
Update JUnit version

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile project(':extern:dnsjava')
 
     // Dependencies for the `instrumentTest` task, make sure to list all your global dependencies here as well
-    androidTestCompile 'junit:junit:4.10'
+    androidTestCompile 'junit:junit:4.11'
     androidTestCompile 'org.robolectric:robolectric:2.3'
     androidTestCompile 'com.squareup:fest-android:1.0.8'
     androidTestCompile 'com.google.android:android:4.1.1.4'


### PR DESCRIPTION
Later version of Junit prevents 'Multiple dex files define Lorg/hamcrest..../Description' error. Hoping to add some unit/integration tests once the build environment settles down a bit
