### PR TITLE
Fix for #687

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyShareFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyShareFragment.java
@@ -152,7 +152,11 @@ public class ViewKeyShareFragment extends LoaderFragment implements
                         KeyRings.buildUnifiedKeyRingUri(dataUri),
                         Keys.FINGERPRINT, ProviderHelper.FIELD_TYPE_BLOB);
                 String fingerprint = PgpKeyHelper.convertFingerprintToHex(data);
-                content = Constants.FINGERPRINT_SCHEME + ":" + fingerprint;
+                if(!toClipboard){
+                    content = Constants.FINGERPRINT_SCHEME + ":" + fingerprint;
+                } else {
+                    content = fingerprint;
+                }
             } else {
                 // get public keyring as ascii armored string
                 Uri uri = KeychainContract.KeyRingData.buildPublicKeyRingUri(dataUri);


### PR DESCRIPTION
Now when copying a keys fingerprint, only the fingerprint itself without the scheme is copied.
