### PR TITLE
Skip spongycastle tests in root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,3 +24,12 @@ subprojects {
         maxParallelForks = 1
     }
 }
+
+// Ignore tests for external dependency
+project(':extern:spongycastle') {
+    subprojects {
+        // Need to re-apply the plugin here otherwise the test property below can't be set.
+        apply plugin: 'java'
+        test.enabled = false
+    }
+}


### PR DESCRIPTION
This will make moving back to a pure SC/BC upstream easier since
we don't need to change their source code
