### PR TITLE
Use beautified form of Key ID

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/ImportKeysListEntry.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/ImportKeysListEntry.java
@@ -108,11 +108,11 @@ public class ImportKeysListEntry implements Serializable, Parcelable {
         return super.hashCode();
     }
 
-    public boolean hasSameKeyAs(Object o) {
-        if (mFingerprintHex == null || o == null || !(o instanceof ImportKeysListEntry)) {
+    public boolean hasSameKeyAs(ImportKeysListEntry other) {
+        if (mFingerprintHex == null || other == null) {
             return false;
         }
-        return mFingerprintHex.equals(((ImportKeysListEntry) o).mFingerprintHex);
+        return mFingerprintHex.equals(other.mFingerprintHex);
     }
 
     public String getKeyIdHex() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpKeyHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpKeyHelper.java
@@ -246,6 +246,39 @@ public class PgpKeyHelper {
         return hexString;
     }
 
+    /**
+     * Makes a human-readable version of a key ID, which is usually 64 bits: lower-case, no
+     *  leading 0x, space-separated quartets (for keys whose length in hex is divisible by 4)
+     *
+     * @param idHex - the key id
+     * @return - the beautified form
+     */
+    public static String beautifyKeyId(String idHex) {
+        if (idHex.startsWith("0x")) {
+            idHex = idHex.substring(2);
+        }
+        if ((idHex.length() % 4) == 0) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < idHex.length(); i += 4) {
+                if (i != 0) {
+                    sb.appendCodePoint(0x2008); // U+2008 PUNCTUATION SPACE
+                }
+                sb.append(idHex.substring(i, i + 4).toLowerCase(Locale.US));
+            }
+            idHex = sb.toString();
+        }
+        return idHex;
+    }
+    /**
+     * Makes a human-readable version of a key ID, which is usually 64 bits: lower-case, no
+     *  leading 0x, space-separated quartets (for keys whose length in hex is divisible by 4)
+     *
+     * @param keyId - the key id
+     * @return - the beautified form
+     */
+    public static String beautifyKeyId(long keyId) {
+        return beautifyKeyId(convertKeyIdToHex(keyId));
+    }
 
     public static SpannableStringBuilder colorizeFingerprint(String fingerprint) {
         // split by 4 characters

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyKeyFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyKeyFragment.java
@@ -238,7 +238,7 @@ public class CertifyKeyFragment extends LoaderFragment
                 if (data.moveToFirst()) {
                     mPubKeyId = data.getLong(INDEX_MASTER_KEY_ID);
                     mCertifyKeySpinner.setHiddenMasterKeyId(mPubKeyId);
-                    String keyIdStr = PgpKeyHelper.convertKeyIdToHex(mPubKeyId);
+                    String keyIdStr = PgpKeyHelper.beautifyKeyId(mPubKeyId);
                     mInfoKeyId.setText(keyIdStr);
 
                     String mainUserId = data.getString(INDEX_USER_ID);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
@@ -120,8 +120,7 @@ public abstract class DecryptFragment extends Fragment {
             if (userIdSplit[1] != null) {
                 mUserIdRest.setText(userIdSplit[1]);
             } else {
-                mUserIdRest.setText(getString(R.string.label_key_id) + ": "
-                        + PgpKeyHelper.convertKeyIdToHex(mSignatureKeyId));
+                mUserIdRest.setText(getString(R.string.label_key_id) + ": " + PgpKeyHelper.beautifyKeyId(mSignatureKeyId));
             }
 
             switch (signatureResult.getStatus()) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewCertActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewCertActivity.java
@@ -120,7 +120,7 @@ public class ViewCertActivity extends ActionBarActivity
     @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
         if (data.moveToFirst()) {
-            String signeeKey = PgpKeyHelper.convertKeyIdToHex(data.getLong(INDEX_MASTER_KEY_ID));
+            String signeeKey = PgpKeyHelper.beautifyKeyId(data.getLong(INDEX_MASTER_KEY_ID));
             mSigneeKey.setText(signeeKey);
 
             String signeeUid = data.getString(INDEX_USER_ID);
@@ -130,7 +130,7 @@ public class ViewCertActivity extends ActionBarActivity
             mCreation.setText(DateFormat.getDateFormat(getApplicationContext()).format(creationDate));
 
             mCertifierKeyId = data.getLong(INDEX_KEY_ID_CERTIFIER);
-            String certifierKey = PgpKeyHelper.convertKeyIdToHex(mCertifierKeyId);
+            String certifierKey = PgpKeyHelper.beautifyKeyId(mCertifierKeyId);
             mCertifierKey.setText(certifierKey);
 
             String certifierUid = data.getString(INDEX_SIGNER_UID);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysAdapter.java
@@ -33,6 +33,7 @@ import android.widget.TextView;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.keyimport.ImportKeysListEntry;
 import org.sufficientlysecure.keychain.pgp.KeyRing;
+import org.sufficientlysecure.keychain.pgp.PgpKeyHelper;
 import org.sufficientlysecure.keychain.util.Highlighter;
 
 import java.util.ArrayList;
@@ -150,7 +151,9 @@ public class ImportKeysAdapter extends ArrayAdapter<ImportKeysListEntry> {
             holder.mainUserIdRest.setVisibility(View.GONE);
         }
 
-        holder.keyId.setText(entry.getKeyIdHex());
+        String keyLabel = getContext().getString(R.string.label_key_id) + ": " +
+                PgpKeyHelper.beautifyKeyId(entry.getKeyIdHex());
+        holder.keyId.setText(keyLabel);
 
         // don't show full fingerprint on key import
         holder.fingerprint.setVisibility(View.GONE);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SelectKeyCursorAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SelectKeyCursorAdapter.java
@@ -128,7 +128,7 @@ abstract public class SelectKeyCursorAdapter extends CursorAdapter {
         }
 
         long masterKeyId = cursor.getLong(mIndexMasterKeyId);
-        h.keyId.setText(PgpKeyHelper.convertKeyIdToHex(masterKeyId));
+        h.keyId.setText(context.getString(R.string.label_key_id) + ": " + PgpKeyHelper.beautifyKeyId(masterKeyId));
 
         boolean enabled = true;
         if (cursor.getInt(mIndexRevoked) != 0) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SubkeysAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SubkeysAdapter.java
@@ -145,7 +145,7 @@ public class SubkeysAdapter extends CursorAdapter {
         deleteImage.setVisibility(View.GONE);
 
         long keyId = cursor.getLong(INDEX_KEY_ID);
-        String keyIdStr = PgpKeyHelper.convertKeyIdToHex(keyId);
+        String keyIdStr = context.getString(R.string.label_key_id) + ": " + PgpKeyHelper.beautifyKeyId(keyId);
         vKeyId.setText(keyIdStr);
 
         // may be set with additional "stripped" later on

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/EncryptKeyCompletionView.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/EncryptKeyCompletionView.java
@@ -239,7 +239,7 @@ public class EncryptKeyCompletionView extends TokenCompleteTextView {
         }
 
         public String getKeyIdHex() {
-            return PgpKeyHelper.convertKeyIdToHex(mKeyId);
+            return PgpKeyHelper.beautifyKeyId(mKeyId);
         }
 
         public String getKeyIdHexShort() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/KeySpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/KeySpinner.java
@@ -144,7 +144,7 @@ public abstract class KeySpinner extends Spinner implements LoaderManager.Loader
                     TextView vKeyStatus = ((TextView) view.findViewById(R.id.keyspinner_key_status));
                     vKeyName.setText(userId[2] == null ? userId[0] : (userId[0] + " (" + userId[2] + ")"));
                     ((TextView) view.findViewById(R.id.keyspinner_key_email)).setText(userId[1]);
-                    ((TextView) view.findViewById(R.id.keyspinner_key_id)).setText(PgpKeyHelper.convertKeyIdToHex(cursor.getLong(mIndexKeyId)));
+                    ((TextView) view.findViewById(R.id.keyspinner_key_id)).setText(PgpKeyHelper.beautifyKeyId(cursor.getLong(mIndexKeyId)));
                     String status = getStatus(getContext(), cursor);
                     if (status == null) {
                         vKeyName.setTextColor(Color.BLACK);

--- a/OpenKeychain/src/main/res/layout/certify_key_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/certify_key_fragment.xml
@@ -61,8 +61,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:paddingRight="5dip"
-                        android:text=""
-                        android:typeface="monospace" />
+                        android:text="0123 4567 89ab cdef" />
                 </TableRow>
 
                 <TableRow

--- a/OpenKeychain/src/main/res/layout/import_keys_list_entry.xml
+++ b/OpenKeychain/src/main/res/layout/import_keys_list_entry.xml
@@ -105,9 +105,8 @@
             android:id="@+id/subkey_item_key_id"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="0xBBBBBBBBBBBBBBBB"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:typeface="monospace" />
+            android:text="0123 4567 89AB CDEF"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
         <TextView
             android:id="@+id/view_key_fingerprint"

--- a/OpenKeychain/src/main/res/layout/select_key_item.xml
+++ b/OpenKeychain/src/main/res/layout/select_key_item.xml
@@ -13,6 +13,7 @@
         android:layout_height="match_parent"
         android:clickable="false"
         android:focusable="false"
+        android:gravity="top|center"
         android:focusableInTouchMode="false" />
 
     <LinearLayout
@@ -41,9 +42,8 @@
             android:id="@+id/subkey_item_key_id"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="0xBBBBBBBBBBBBBBB"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:typeface="monospace" />
+            android:text="0123 4567 89ab cdef"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
     </LinearLayout>
 
 

--- a/OpenKeychain/src/main/res/layout/view_cert_activity.xml
+++ b/OpenKeychain/src/main/res/layout/view_cert_activity.xml
@@ -61,8 +61,7 @@
                     android:id="@+id/signee_key"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:paddingRight="5dip"
-                    android:typeface="monospace" />
+                    android:paddingRight="5dip" />
             </TableRow>
 
             <TableRow>
@@ -183,8 +182,7 @@
                     android:id="@+id/signer_key_id"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingRight="5dip"
-                    android:typeface="monospace" />
+                    android:paddingRight="5dip" />
             </TableRow>
 
             <TableRow>

--- a/OpenKeychain/src/main/res/layout/view_key_subkey_item.xml
+++ b/OpenKeychain/src/main/res/layout/view_key_subkey_item.xml
@@ -52,9 +52,8 @@
                 android:id="@+id/subkey_item_key_id"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="0x00000000"
+                android:text="Key ID: 0123 4567 89ab cdef"
                 android:textAppearance="?android:attr/textAppearanceMedium"
-                android:typeface="monospace"
                 android:layout_weight="1" />
 
             <ImageView


### PR DESCRIPTION
The only problem is that for a couple of these, I couldn’t figure out how to get to that screen to visually check the effect, but it was OK on all the ones I could try.  The beautified key looks a little better in a proportional rather than monospace font, and I couldn’t find the xml styling for the key ids in a couple places, most notably the encryption drop-down keyspinner.  But it still looks better than before.
