### PR TITLE
Handle absence of personal information in Keybase search result

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/KeybaseKeyserver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/KeybaseKeyserver.java
@@ -82,7 +82,10 @@ public class KeybaseKeyserver extends Keyserver {
         entry.setAlgorithm(KeyFormattingUtils.getAlgorithmInfo(algorithmId, bitStrength, null));
 
         ArrayList<String> userIds = new ArrayList<String>();
-        String name = fullName + " <keybase.io/" + username + ">";
+        String name = "<keybase.io/" + username + ">";
+        if (fullName != null) {
+            name = fullName + " " + name;
+        }
         userIds.add(name);
 
         List<String> proofLabels = match.getProofLabels();


### PR DESCRIPTION
I’m pretty sure that if anything is missing in the keybase result, it's actually a bug.
