### PR TITLE
Fix spelling of 'K-9 Mail' in FAQ

### DIFF
--- a/OpenKeychain/src/main/res/raw/help_faq.html
+++ b/OpenKeychain/src/main/res/raw/help_faq.html
@@ -12,10 +12,10 @@ And don't add newlines before or after p tags because of transifex -->
 <h2>A wrong primary user id is shown when searching on a Keyserver</h2>
 <p>Unfortunately, this is a bug in the SKS Keyserver software. Its machine-readable output returns the user ids in an arbitrary order. Read the <a href="https://bitbucket.org/skskeyserver/sks-keyserver/issue/28/primary-uid-in-machine-readable-index">related bug report</a> for more information.</p>
 
-<h2>How do I activate OpenKeychain in K9-Mail?</h2>
-<p>To use OpenKeychain with K9-Mail, you want to follow these steps:</p>
+<h2>How do I activate OpenKeychain in K-9 Mail?</h2>
+<p>To use OpenKeychain with K-9 Mail, you want to follow these steps:</p>
 <ol>
-    <li>Open K9-Mail and long-tap on the account you want to use OpenKeychain with.</li>
+    <li>Open K-9 Mail and long-tap on the account you want to use OpenKeychain with.</li>
     <li>Select "Account settings" and scroll to the very bottom and click "Cryptography".</li>
     <li>Click on "OpenPGP Provider" and select OpenKeychain from the list.</li>
 </ol>


### PR DESCRIPTION
Replace occurrences of "K9-Mail" with the correct spelling "K-9 Mail".
