### PR TITLE
Add ability to compile with java8

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion '21.1.1'
+    buildToolsVersion '21.1.2'
 
     defaultConfig {
         minSdkVersion 15

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -683,7 +683,7 @@ public class KeychainProvider extends ContentProvider {
                         )) {
                         throw new AssertionError("Incorrect type for user packet! This is a bug!");
                     }
-                    if (values.get(UserPacketsColumns.RANK) == 0 && values.get(UserPacketsColumns.USER_ID) == null) {
+                    if (((Number)values.get(UserPacketsColumns.RANK)).intValue() == 0 && values.get(UserPacketsColumns.USER_ID) == null) {
                         throw new AssertionError("Rank 0 user packet must be a user id!");
                     }
                     db.insertOrThrow(Tables.USER_PACKETS, null, values);


### PR DESCRIPTION
otherwise we get:

```
:OpenKeychain:compileDebugJava
/home/ligi/git/3rd/open-keychain/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java:686: error: incomparable types: Object and int
                    if (values.get(UserPacketsColumns.RANK) == 0 && values.get(UserPacketsColumns.USER_ID) == null) {
                                                            ^
Note: Some input files use or override a deprecated API.
```