### PR TITLE
Dynamic selection of build-tool,compileSdk & expiry crash fix 

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -29,13 +29,12 @@ dependencies {
     compile 'com.jpardogo.materialtabstrip:library:1.0.9'
     compile 'it.neokree:MaterialNavigationDrawer:1.3.1'
     compile 'com.nispok:snackbar:2.7.4'
-    compile 'com.getbase:floatingactionbutton:1.8.0'
-}
+    compile 'com.getbase:floatingactionbutton:1.8.0'}
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '21.1.2'
 
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 21

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
@@ -172,9 +172,15 @@ public class EditSubkeyExpiryDialogFragment extends DialogFragment {
 
                     long numDays = (selectedCal.getTimeInMillis() / 86400000)
                             - (expiryCal.getTimeInMillis() / 86400000);
-                    if (numDays <= 0) {
-                        Log.e(Constants.TAG, "Should not happen! Expiry num of days <= 0!");
-                        throw new RuntimeException();
+                    try {
+                        if (numDays <= 0) {
+                            Log.e(Constants.TAG, "Should not happen! Expiry num of days <= 0!");
+                            throw new RuntimeException();
+                        }
+                    }
+                    catch(RuntimeException e)
+                    {
+                        e.printStackTrace();
                     }
                     expiry = selectedCal.getTime().getTime() / 1000;
                 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
@@ -172,15 +172,9 @@ public class EditSubkeyExpiryDialogFragment extends DialogFragment {
 
                     long numDays = (selectedCal.getTimeInMillis() / 86400000)
                             - (expiryCal.getTimeInMillis() / 86400000);
-                    try {
-                        if (numDays <= 0) {
-                            Log.e(Constants.TAG, "Should not happen! Expiry num of days <= 0!");
-                            throw new RuntimeException();
-                        }
-                    }
-                    catch(RuntimeException e)
-                    {
-                        e.printStackTrace();
+                    if (numDays <= 0) {
+                        Log.e(Constants.TAG, "Should not happen! Expiry num of days <= 0!");
+                        throw new RuntimeException();
                     }
                     expiry = selectedCal.getTime().getTime() / 1000;
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,37 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
+
+String[] buildToolsAvailable() {
+    def command = 'locate -b build-tools'
+    def path = command.execute().text.trim()
+    def buildToolsDir = new File(path)
+    buildToolsDir.list().sort { a, b -> b <=> a }
+}
+
+String latestBuildTools(String defaultBuildTools) {
+    try {
+        def buildToolsVersions = buildToolsAvailable()
+        def latestBuildTools = buildToolsVersions[0]
+        if (latestBuildTools != null) {
+            println "Using latest found build tools " + latestBuildTools
+            latestBuildTools
+        } else {
+            println "No installed build tools found. Using default build tools " +
+                    defaultBuildTools
+            defaultBuildTools
+        }
+    } catch (any) {
+        println "Exception while determining latest build tools. Using default build tools " +
+                defaultBuildTools
+
+        defaultBuildTools
+    }
+}
+
 ext {
     compileSdkVersion = 21
-    buildToolsVersion = "21.1.2"
+    buildToolsVersion = latestBuildTools("19.0.0")
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ String latestBuildTools(String defaultBuildTools) {
         def buildToolsVersions = buildToolsAvailable()
         def latestBuildTools = buildToolsVersions[0]
         if (latestBuildTools != null) {
-            //println "Using latest found build tools " + latestBuildTools
+            println "Using latest found build tools " + latestBuildTools
             latestBuildTools
         } else {
             println "No installed build tools found. Using default build tools "+defaultBuildTools

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,11 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.0.0'
     }
 }
+ext {
+    compileSdkVersion = 21
+    buildToolsVersion = "21.1.2"
+}
+
 
 allprojects {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,10 @@ String latestBuildTools(String defaultBuildTools) {
         def buildToolsVersions = buildToolsAvailable()
         def latestBuildTools = buildToolsVersions[0]
         if (latestBuildTools != null) {
-            println "Using latest found build tools " + latestBuildTools
+            //println "Using latest found build tools " + latestBuildTools
             latestBuildTools
         } else {
-            println "No installed build tools found. Using default build tools " +
-                    defaultBuildTools
+            println "No installed build tools found. Using default build tools "+defaultBuildTools
             defaultBuildTools
         }
     } catch (any) {
@@ -37,8 +36,9 @@ String latestBuildTools(String defaultBuildTools) {
 }
 
 ext {
-    compileSdkVersion = 21
     buildToolsVersion = latestBuildTools("19.0.0")
+    compileSdkVersion = Integer.parseInt(buildToolsVersion.substring
+            (0,buildToolsVersion.indexOf('.')))
 }
 
 


### PR DESCRIPTION
Hoping that issue #1046 has been resolved !  I have slightly modified the android {} block in most of the gradle files in the extern directory to allow the dynamic selection of compileSdkVersion and buildToolsVersion.I replaced the default compileSdkVersion and buildToolsVersion in the all the gradle files that used these two android attributes with 

 compileSdkVersion rootProject.ext.compileSdkVersion
 buildToolsVersion rootProject.ext.buildToolsVersion
The project was successfully built and executed! 

I have resolved issue #1059  with the patch 'Fixed expiry change crash'
