### PR TITLE
Fixes Issue #1081

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAddedAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAddedAdapter.java
@@ -24,7 +24,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.CheckBox;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -73,10 +72,8 @@ public class UserIdsAddedAdapter extends ArrayAdapter<String> {
             holder.vDelete.setVisibility(View.VISIBLE); // always visible
 
             // not used:
-            CheckBox checkBox = (CheckBox) convertView.findViewById(R.id.user_id_item_check_box);
             View certifiedLayout = convertView.findViewById(R.id.user_id_item_certified_layout);
             ImageView editImage = (ImageView) convertView.findViewById(R.id.user_id_item_edit_image);
-            checkBox.setVisibility(View.GONE);
             certifiedLayout.setVisibility(View.GONE);
             editImage.setVisibility(View.GONE);
 


### PR DESCRIPTION
The App crashed because the Adapter was trying to call a method on a
null object.

Where was the null object?
CheckBox was null because in the Layout file
view_key_adv_user_id_item.xml

There is no such widget with id = user_id_item_check_box

Fix :
I removed the two lines which were causing the bug, and now the screen
loads perfectly.