### PR TITLE
Fixed expiry change crash(for Android L as well)

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
@@ -19,6 +19,7 @@ package org.sufficientlysecure.keychain.ui.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.os.Message;
@@ -30,6 +31,7 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.DatePicker;
+import android.widget.Toast;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
@@ -170,7 +172,18 @@ public class EditSubkeyExpiryDialogFragment extends DialogFragment {
                     long numDays = (selectedCal.getTimeInMillis() / 86400000)
                             - (todayCal.getTimeInMillis() / 86400000);
                     if (numDays <= 0) {
+                        CharSequence text = "Invalid date! Please choose a valid one.";
+                        int duration = Toast.LENGTH_SHORT;
+                        Toast toast = Toast.makeText(activity.getApplicationContext(), text, duration);
+                        toast.show();
                         //set to previous expiry date
+                        datePicker.init(
+                                expiryCal.get(Calendar.YEAR),
+                                expiryCal.get(Calendar.MONTH),
+                                expiryCal.get(Calendar.DAY_OF_MONTH),
+                                null
+                        );
+
                         expiry=expiryCal.getTime().getTime()/1000;
                     }
                     else expiry = selectedCal.getTime().getTime() / 1000;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
@@ -79,6 +79,7 @@ public class EditSubkeyExpiryDialogFragment extends DialogFragment {
         Calendar creationCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         creationCal.setTime(new Date(creation * 1000));
         final Calendar expiryCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        final Calendar todayCal = Calendar.getInstance(TimeZone.getDefault());
         expiryCal.setTime(new Date(expiry * 1000));
 
         // date picker works with default time zone, we need to convert from UTC to default timezone
@@ -113,8 +114,6 @@ public class EditSubkeyExpiryDialogFragment extends DialogFragment {
         if (expiry == 0L) {
             noExpiry.setChecked(true);
             datePicker.setVisibility(View.GONE);
-
-            Calendar todayCal = Calendar.getInstance(TimeZone.getDefault());
             if (creationCal.after(todayCal)) {
                 // Note: This is just for the rare cases where creation is _after_ today
 
@@ -169,12 +168,12 @@ public class EditSubkeyExpiryDialogFragment extends DialogFragment {
                     selectedCal.setTimeZone(TimeZone.getTimeZone("UTC"));
 
                     long numDays = (selectedCal.getTimeInMillis() / 86400000)
-                            - (expiryCal.getTimeInMillis() / 86400000);
+                            - (todayCal.getTimeInMillis() / 86400000);
                     if (numDays <= 0) {
-                        Log.e(Constants.TAG, "Should not happen! Expiry num of days <= 0!");
-                        throw new RuntimeException();
+                        //set to previous expiry date
+                        expiry=expiryCal.getTime().getTime()/1000;
                     }
-                    expiry = selectedCal.getTime().getTime() / 1000;
+                    else expiry = selectedCal.getTime().getTime() / 1000;
                 }
 
                 Bundle data = new Bundle();


### PR DESCRIPTION
@dschuermann  Hopefully I have fixed this issue #1059  this time. If an invalid date is selected then the expiry date is set to the previous expiry date.
![case1](https://cloud.githubusercontent.com/assets/5908368/6465350/8c69017a-c1e6-11e4-9e91-4749f26bf02b.png)
//invalid date
![case2](https://cloud.githubusercontent.com/assets/5908368/6465351/8c6e72a4-c1e6-11e4-87d1-237471e0b5b0.png)
If an invalid date is selected then last expiry date is set.
![case1](https://cloud.githubusercontent.com/assets/5908368/6465360/9c28d072-c1e6-11e4-888b-a9ced6fbd569.png)


