### PR TITLE
Avoid doing bad things to adb (now with rebase)

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -649,15 +649,6 @@ public class KeychainProvider extends ContentProvider {
             // Tell the cursor what uri to watch, so it knows when its source data changes
             cursor.setNotificationUri(getContext().getContentResolver(), uri);
         }
-
-        if (Constants.DEBUG) {
-            Log.d(Constants.TAG,
-                    "Query: "
-                            + qb.buildQuery(projection, selection, selectionArgs, null, null,
-                            orderBy, null));
-            Log.d(Constants.TAG, "Cursor: " + DatabaseUtils.dumpCursorToString(cursor));
-        }
-
         return cursor;
     }
 


### PR DESCRIPTION
Dumping the cursor to the debug log over and over is a real resource hog
and tends to have the negative side effect of your logs being 2-3 minutes
out of sync with reality.