### PR TITLE
EmailEditText, PasswordEditText issue #1106

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
@@ -20,9 +20,6 @@ package org.sufficientlysecure.keychain.ui;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.text.Editable;
-import android.text.TextWatcher;
-import android.util.Patterns;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -33,10 +30,10 @@ import android.widget.EditText;
 
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.CreateKeyActivity.FragAction;
+import org.sufficientlysecure.keychain.ui.widget.EmailEditText;
+import org.sufficientlysecure.keychain.ui.widget.PasswordEditText;
 import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthView;
 import org.sufficientlysecure.keychain.util.ContactHelper;
-
-import java.util.regex.Matcher;
 
 public class CreateKeyInputFragment extends Fragment {
 
@@ -44,8 +41,8 @@ public class CreateKeyInputFragment extends Fragment {
 
     PasswordStrengthView mPassphraseStrengthView;
     AutoCompleteTextView mNameEdit;
-    AutoCompleteTextView mEmailEdit;
-    EditText mPassphraseEdit;
+    EmailEditText mEmailEdit;
+    PasswordEditText mPassphraseEdit;
     EditText mPassphraseEditAgain;
     View mCreateButton;
 
@@ -74,8 +71,8 @@ public class CreateKeyInputFragment extends Fragment {
         mPassphraseStrengthView = (PasswordStrengthView) view.findViewById(R.id
                 .create_key_passphrase_strength);
         mNameEdit = (AutoCompleteTextView) view.findViewById(R.id.create_key_name);
-        mEmailEdit = (AutoCompleteTextView) view.findViewById(R.id.create_key_email);
-        mPassphraseEdit = (EditText) view.findViewById(R.id.create_key_passphrase);
+        mEmailEdit = (EmailEditText) view.findViewById(R.id.create_key_email);
+        mPassphraseEdit = (PasswordEditText) view.findViewById(R.id.create_key_passphrase);
         mPassphraseEditAgain = (EditText) view.findViewById(R.id.create_key_passphrase_again);
         mCreateButton = view.findViewById(R.id.create_key_button);
 
@@ -99,33 +96,7 @@ public class CreateKeyInputFragment extends Fragment {
                                 ContactHelper.getPossibleUserEmails(getActivity())
                         )
         );
-        mEmailEdit.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i2, int i3) {
-            }
 
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i2, int i3) {
-            }
-
-            @Override
-            public void afterTextChanged(Editable editable) {
-                String email = editable.toString();
-                if (email.length() > 0) {
-                    Matcher emailMatcher = Patterns.EMAIL_ADDRESS.matcher(email);
-                    if (emailMatcher.matches()) {
-                        mEmailEdit.setCompoundDrawablesWithIntrinsicBounds(0, 0,
-                                R.drawable.uid_mail_ok, 0);
-                    } else {
-                        mEmailEdit.setCompoundDrawablesWithIntrinsicBounds(0, 0,
-                                R.drawable.uid_mail_bad, 0);
-                    }
-                } else {
-                    // remove drawable if email is empty
-                    mEmailEdit.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
-                }
-            }
-        });
 
         mNameEdit.setThreshold(1); // Start working from first character
         mNameEdit.setAdapter(
@@ -141,21 +112,8 @@ public class CreateKeyInputFragment extends Fragment {
                 mPassphraseEdit.getPaddingTop(),
                 (int) (56 * getResources().getDisplayMetrics().density),
                 mPassphraseEdit.getPaddingBottom());
-        mPassphraseEdit.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            }
 
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-            }
-
-            @Override
-            public void afterTextChanged(Editable editable) {
-                String passphrase = editable.toString();
-                mPassphraseStrengthView.setPassword(passphrase);
-            }
-        });
+       mPassphraseEdit.setPasswordStrengthView(mPassphraseStrengthView);
 
         mCreateButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddUserIdDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddUserIdDialogFragment.java
@@ -28,9 +28,6 @@ import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
 import android.support.v4.app.DialogFragment;
-import android.text.Editable;
-import android.text.TextWatcher;
-import android.util.Patterns;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -46,10 +43,9 @@ import android.widget.TextView.OnEditorActionListener;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.pgp.KeyRing;
+import org.sufficientlysecure.keychain.ui.widget.EmailEditText;
 import org.sufficientlysecure.keychain.util.ContactHelper;
 import org.sufficientlysecure.keychain.util.Log;
-
-import java.util.regex.Matcher;
 
 public class AddUserIdDialogFragment extends DialogFragment implements OnEditorActionListener {
     private static final String ARG_MESSENGER = "messenger";
@@ -62,7 +58,7 @@ public class AddUserIdDialogFragment extends DialogFragment implements OnEditorA
 
     private Messenger mMessenger;
     private AutoCompleteTextView mName;
-    private AutoCompleteTextView mEmail;
+    private EmailEditText mEmail;
     private EditText mComment;
 
     public static AddUserIdDialogFragment newInstance(Messenger messenger, String predefinedName) {
@@ -99,38 +95,12 @@ public class AddUserIdDialogFragment extends DialogFragment implements OnEditorA
         alert.setView(view);
 
         mName = (AutoCompleteTextView) view.findViewById(R.id.add_user_id_name);
-        mEmail = (AutoCompleteTextView) view.findViewById(R.id.add_user_id_address);
+        mEmail = (EmailEditText) view.findViewById(R.id.add_user_id_address);
         mComment = (EditText) view.findViewById(R.id.add_user_id_comment);
 
         mName.setText(predefinedName);
 
-        mEmail.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            }
 
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-            }
-
-            @Override
-            public void afterTextChanged(Editable editable) {
-                String email = editable.toString();
-                if (email.length() > 0) {
-                    Matcher emailMatcher = Patterns.EMAIL_ADDRESS.matcher(email);
-                    if (emailMatcher.matches()) {
-                        mEmail.setCompoundDrawablesWithIntrinsicBounds(0, 0,
-                                R.drawable.uid_mail_ok, 0);
-                    } else {
-                        mEmail.setCompoundDrawablesWithIntrinsicBounds(0, 0,
-                                R.drawable.uid_mail_bad, 0);
-                    }
-                } else {
-                    // remove drawable if email is empty
-                    mEmail.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
-                }
-            }
-        });
         mEmail.setThreshold(1); // Start working from first character
         mEmail.setAdapter(autoCompleteEmailAdapter);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
@@ -43,6 +43,8 @@ import android.widget.Toast;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.ui.widget.PasswordEditText;
+import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthView;
 import org.sufficientlysecure.keychain.util.Log;
 
 public class SetPassphraseDialogFragment extends DialogFragment implements OnEditorActionListener {
@@ -55,9 +57,10 @@ public class SetPassphraseDialogFragment extends DialogFragment implements OnEdi
     public static final String MESSAGE_NEW_PASSPHRASE = "new_passphrase";
 
     private Messenger mMessenger;
-    private EditText mPassphraseEditText;
+    private PasswordEditText mPassphraseEditText;
     private EditText mPassphraseAgainEditText;
     private CheckBox mNoPassphraseCheckBox;
+    private PasswordStrengthView mPassphraseStrengthView;
 
     /**
      * Creates new instance of this dialog fragment
@@ -97,9 +100,12 @@ public class SetPassphraseDialogFragment extends DialogFragment implements OnEdi
         View view = inflater.inflate(R.layout.passphrase_repeat_dialog, null);
         alert.setView(view);
 
-        mPassphraseEditText = (EditText) view.findViewById(R.id.passphrase_passphrase);
+        mPassphraseEditText = (PasswordEditText) view.findViewById(R.id.passphrase_passphrase);
         mPassphraseAgainEditText = (EditText) view.findViewById(R.id.passphrase_passphrase_again);
         mNoPassphraseCheckBox = (CheckBox) view.findViewById(R.id.passphrase_no_passphrase);
+        mPassphraseStrengthView = (PasswordStrengthView) view.findViewById(R.id.passphrase_repeat_passphrase_strength);
+        mPassphraseEditText.setPasswordStrengthView(mPassphraseStrengthView);
+
 
         if (TextUtils.isEmpty(oldPassphrase)) {
             mNoPassphraseCheckBox.setChecked(true);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/EmailEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/EmailEditText.java
@@ -1,0 +1,80 @@
+package org.sufficientlysecure.keychain.ui.widget;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.util.Patterns;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
+
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.util.ContactHelper;
+
+import java.util.regex.Matcher;
+
+public class EmailEditText extends AutoCompleteTextView {
+    EmailEditText emailEditText;
+
+    public EmailEditText(Context context) {
+        super(context);
+        emailEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+        this.addTextChangedListener(textWatcher);
+    }
+
+    public EmailEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        emailEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+        this.addTextChangedListener(textWatcher);
+    }
+
+    public EmailEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        emailEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+        this.addTextChangedListener(textWatcher);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public EmailEditText(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        emailEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+        this.addTextChangedListener(textWatcher);
+    }
+
+    TextWatcher textWatcher = new TextWatcher() {
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+        }
+
+        @Override
+        public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+        }
+
+        @Override
+        public void afterTextChanged(Editable editable) {
+            String email = editable.toString();
+            if (email.length() > 0) {
+                Matcher emailMatcher = Patterns.EMAIL_ADDRESS.matcher(email);
+                if (emailMatcher.matches()) {
+                    emailEditText.setCompoundDrawablesWithIntrinsicBounds(0, 0,
+                            R.drawable.uid_mail_ok, 0);
+                } else {
+                    emailEditText.setCompoundDrawablesWithIntrinsicBounds(0, 0,
+                            R.drawable.uid_mail_bad, 0);
+                }
+            } else {
+                // remove drawable if email is empty
+                emailEditText.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
+            }
+        }
+    };
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/EmailEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/EmailEditText.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2014 Dominik Schürmann <dominik@dominikschuermann.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.sufficientlysecure.keychain.ui.widget;
 
 import android.annotation.TargetApi;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PasswordEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PasswordEditText.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2014 Dominik Schürmann <dominik@dominikschuermann.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.sufficientlysecure.keychain.ui.widget;
 
 import android.annotation.TargetApi;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PasswordEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PasswordEditText.java
@@ -1,0 +1,84 @@
+package org.sufficientlysecure.keychain.ui.widget;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.widget.EditText;
+
+import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthView;
+
+/**
+ * Developer: chipset
+ * Package : org.sufficientlysecure.keychain.layouts
+ * Project : open-keychain
+ * Date : 6/3/15
+ */
+public class PasswordEditText extends EditText {
+
+    PasswordEditText passwordEditText;
+    PasswordStrengthView passwordStrengthView;
+
+    public PasswordEditText(Context context) {
+        super(context);
+        passwordEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT |
+                InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        this.addTextChangedListener(textWatcher);
+    }
+
+    public PasswordEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        passwordEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT |
+                InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        this.addTextChangedListener(textWatcher);
+    }
+
+    public PasswordEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        passwordEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT |
+                InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        this.addTextChangedListener(textWatcher);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public PasswordEditText(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        passwordEditText = this;
+        this.setInputType(InputType.TYPE_CLASS_TEXT |
+                InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        this.addTextChangedListener(textWatcher);
+    }
+
+
+    TextWatcher textWatcher = new TextWatcher() {
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+        }
+
+        @Override
+        public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+        }
+
+        @Override
+        public void afterTextChanged(Editable editable) {
+            String passphrase = editable.toString();
+            passwordStrengthView.setPassword(passphrase);
+        }
+    };
+
+//    public PasswordStrengthView getPasswordStrengthView() {
+//        return passwordStrengthView;
+//    }
+
+    public void setPasswordStrengthView(PasswordStrengthView mPasswordStrengthView) {
+        this.passwordStrengthView = mPasswordStrengthView;
+    }
+}

--- a/OpenKeychain/src/main/res/layout/add_user_id_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/add_user_id_dialog.xml
@@ -8,13 +8,12 @@
     android:paddingLeft="24dp"
     android:paddingRight="24dp">
 
-    <org.sufficientlysecure.keychain.ui.widget.AutoCorrectAutoCompleteTextView
+    <org.sufficientlysecure.keychain.ui.widget.EmailEditText
         android:id="@+id/add_user_id_address"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/label_email"
         android:imeOptions="actionNext"
-        android:inputType="textAutoCorrect|textEmailAddress"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <org.sufficientlysecure.keychain.ui.widget.AutoCorrectAutoCompleteTextView

--- a/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:custom="http://schemas.android.com/apk/res-auto"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -43,13 +43,12 @@
                 android:hint="@string/create_key_hint_full_name"
                 android:ems="10" />
 
-            <org.sufficientlysecure.keychain.ui.widget.AutoCorrectAutoCompleteTextView
+            <org.sufficientlysecure.keychain.ui.widget.EmailEditText
                 android:id="@+id/create_key_email"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
                 android:imeOptions="actionNext"
-                android:inputType="textAutoCorrect|textEmailAddress"
                 android:hint="@string/label_email"
                 android:ems="10" />
 
@@ -65,15 +64,14 @@
                 android:layout_marginTop="8dp"
                 android:layout_marginBottom="8dp">
 
-                <EditText
+                <org.sufficientlysecure.keychain.ui.widget.PasswordEditText
                     android:id="@+id/create_key_passphrase"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:imeOptions="actionNext"
-                    android:inputType="textPassword"
                     android:hint="@string/label_passphrase"
                     android:ems="10"
-                    android:layout_gravity="center_horizontal"  />
+                    android:layout_gravity="center_horizontal" />
 
                 <org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthBarView
                     android:id="@+id/create_key_passphrase_strength"
@@ -84,7 +82,7 @@
                     custom:showGuides="false"
                     custom:color_fail="@color/android_red_light"
                     custom:color_weak="@color/android_orange_light"
-                    custom:color_strong="@color/android_green_light"/>
+                    custom:color_strong="@color/android_green_light" />
 
             </FrameLayout>
 

--- a/OpenKeychain/src/main/res/layout/passphrase_repeat_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_repeat_dialog.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -14,17 +15,35 @@
         android:layout_height="wrap_content"
         android:text="@string/label_no_passphrase" />
 
-    <EditText
-        android:id="@+id/passphrase_passphrase"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        android:imeOptions="actionNext"
-        android:inputType="textPassword"
-        android:hint="@string/label_passphrase"
-        android:ems="10"
-        android:layout_gravity="center_horizontal" />
+        android:layout_marginBottom="8dp">
+
+        <org.sufficientlysecure.keychain.ui.widget.PasswordEditText
+            android:id="@+id/passphrase_passphrase"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:imeOptions="actionNext"
+            android:hint="@string/label_passphrase"
+            android:ems="10"
+            android:layout_gravity="center_horizontal" />
+
+        <org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthBarView
+            android:id="@+id/passphrase_repeat_passphrase_strength"
+            android:layout_width="48dp"
+            android:layout_height="8dp"
+            android:layout_gravity="end|center_vertical"
+            custom:strength="medium"
+            custom:showGuides="false"
+            custom:color_fail="@color/android_red_light"
+            custom:color_weak="@color/android_orange_light"
+            custom:color_strong="@color/android_green_light" />
+
+    </FrameLayout>
 
     <EditText
         android:id="@+id/passphrase_passphrase_again"


### PR DESCRIPTION
Created EmailEditText extending AutoCompleteTextView with TextWatcher to validate email.
Created PasswordEditeText extending EditText with TextWatcher & Wrapper for PasswordStrengthView.
Implemented them in CreateKeyInputFragment, AddUserIdDialogFragment, SetPassphraseDialogFragment along with required XML changes.
All done in accordance with issue #1106 

![EmaiEditText with Suggestions](https://cloud.githubusercontent.com/assets/6591617/6520836/2a300ee0-c3f3-11e4-9b99-158f0f0d65b7.png)
![PasswordEditText with passphrase strength indicator](https://cloud.githubusercontent.com/assets/6591617/6520838/2f5d99d2-c3f3-11e4-8133-4b7f4d52a3cd.png)
![PasswordEditText with passphrase strength indicator in SetPassphraseDialogFragment](https://cloud.githubusercontent.com/assets/6591617/6520851/504af964-c3f3-11e4-805c-ac522fea3ad3.png)
![EmaiEditText with Suggestions in AddUserIdDialogFragment](https://cloud.githubusercontent.com/assets/6591617/6520852/504b66c4-c3f3-11e4-9a99-99ac1353c541.png)





