### PR TITLE
Passphrase strength indicator

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
@@ -20,6 +20,8 @@ package org.sufficientlysecure.keychain.ui;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -32,6 +34,7 @@ import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.CreateKeyActivity.FragAction;
 import org.sufficientlysecure.keychain.ui.widget.EmailEditText;
 import org.sufficientlysecure.keychain.ui.widget.PasswordEditText;
+import org.sufficientlysecure.keychain.ui.widget.PassphraseEditText;
 import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthView;
 import org.sufficientlysecure.keychain.util.ContactHelper;
 
@@ -39,10 +42,9 @@ public class CreateKeyInputFragment extends Fragment {
 
     CreateKeyActivity mCreateKeyActivity;
 
-    PasswordStrengthView mPassphraseStrengthView;
     AutoCompleteTextView mNameEdit;
     EmailEditText mEmailEdit;
-    PasswordEditText mPassphraseEdit;
+    PassphraseEditText mPassphraseEdit;
     EditText mPassphraseEditAgain;
     View mCreateButton;
 
@@ -68,11 +70,9 @@ public class CreateKeyInputFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.create_key_input_fragment, container, false);
 
-        mPassphraseStrengthView = (PasswordStrengthView) view.findViewById(R.id
-                .create_key_passphrase_strength);
         mNameEdit = (AutoCompleteTextView) view.findViewById(R.id.create_key_name);
+        mPassphraseEdit = (PassphraseEditText) view.findViewById(R.id.create_key_passphrase);
         mEmailEdit = (EmailEditText) view.findViewById(R.id.create_key_email);
-        mPassphraseEdit = (PasswordEditText) view.findViewById(R.id.create_key_passphrase);
         mPassphraseEditAgain = (EditText) view.findViewById(R.id.create_key_passphrase_again);
         mCreateButton = view.findViewById(R.id.create_key_button);
 
@@ -105,15 +105,6 @@ public class CreateKeyInputFragment extends Fragment {
                                 ContactHelper.getPossibleUserNames(getActivity())
                         )
         );
-
-        // Edit text padding doesn't work via xml (http://code.google.com/p/android/issues/detail?id=77982)
-        // so we set the right padding programmatically.
-        mPassphraseEdit.setPadding(mPassphraseEdit.getPaddingLeft(),
-                mPassphraseEdit.getPaddingTop(),
-                (int) (56 * getResources().getDisplayMetrics().density),
-                mPassphraseEdit.getPaddingBottom());
-
-       mPassphraseEdit.setPasswordStrengthView(mPassphraseStrengthView);
 
         mCreateButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
@@ -27,6 +27,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.EditText;
+
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.CreateKeyActivity.FragAction;
 import org.sufficientlysecure.keychain.ui.widget.EmailEditText;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyInputFragment.java
@@ -20,8 +20,6 @@ package org.sufficientlysecure.keychain.ui;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -29,27 +27,22 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
 import android.widget.EditText;
-
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.CreateKeyActivity.FragAction;
 import org.sufficientlysecure.keychain.ui.widget.EmailEditText;
-import org.sufficientlysecure.keychain.ui.widget.PasswordEditText;
 import org.sufficientlysecure.keychain.ui.widget.PassphraseEditText;
-import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthView;
 import org.sufficientlysecure.keychain.util.ContactHelper;
 
 public class CreateKeyInputFragment extends Fragment {
 
+    public static final String ARG_NAME = "name";
+    public static final String ARG_EMAIL = "email";
     CreateKeyActivity mCreateKeyActivity;
-
     AutoCompleteTextView mNameEdit;
     EmailEditText mEmailEdit;
     PassphraseEditText mPassphraseEdit;
     EditText mPassphraseEditAgain;
     View mCreateButton;
-
-    public static final String ARG_NAME = "name";
-    public static final String ARG_EMAIL = "email";
 
     /**
      * Creates new instance of this fragment
@@ -64,6 +57,40 @@ public class CreateKeyInputFragment extends Fragment {
         frag.setArguments(args);
 
         return frag;
+    }
+
+    /**
+     * Checks if text of given EditText is not empty. If it is empty an error is
+     * set and the EditText gets the focus.
+     *
+     * @param context
+     * @param editText
+     * @return true if EditText is not empty
+     */
+    private static boolean isEditTextNotEmpty(Context context, EditText editText) {
+        boolean output = true;
+        if (editText.getText().toString().length() == 0) {
+            editText.setError(context.getString(R.string.create_key_empty));
+            editText.requestFocus();
+            output = false;
+        } else {
+            editText.setError(null);
+        }
+
+        return output;
+    }
+
+    private static boolean areEditTextsEqual(Context context, EditText editText1, EditText editText2) {
+        boolean output = true;
+        if (!editText1.getText().toString().equals(editText2.getText().toString())) {
+            editText2.setError(context.getString(R.string.create_key_passphrases_not_equal));
+            editText2.requestFocus();
+            output = false;
+        } else {
+            editText2.setError(null);
+        }
+
+        return output;
     }
 
     @Override
@@ -154,40 +181,6 @@ public class CreateKeyInputFragment extends Fragment {
             return;
 
         inputManager.hideSoftInputFromWindow(v.getWindowToken(), 0);
-    }
-
-    /**
-     * Checks if text of given EditText is not empty. If it is empty an error is
-     * set and the EditText gets the focus.
-     *
-     * @param context
-     * @param editText
-     * @return true if EditText is not empty
-     */
-    private static boolean isEditTextNotEmpty(Context context, EditText editText) {
-        boolean output = true;
-        if (editText.getText().toString().length() == 0) {
-            editText.setError(context.getString(R.string.create_key_empty));
-            editText.requestFocus();
-            output = false;
-        } else {
-            editText.setError(null);
-        }
-
-        return output;
-    }
-
-    private static boolean areEditTextsEqual(Context context, EditText editText1, EditText editText2) {
-        boolean output = true;
-        if (!editText1.getText().toString().equals(editText2.getText().toString())) {
-            editText2.setError(context.getString(R.string.create_key_passphrases_not_equal));
-            editText2.requestFocus();
-            output = false;
-        } else {
-            editText2.setError(null);
-        }
-
-        return output;
     }
 
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
@@ -43,6 +43,7 @@ import android.widget.Toast;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.ui.widget.PassphraseEditText;
 import org.sufficientlysecure.keychain.ui.widget.PasswordEditText;
 import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthView;
 import org.sufficientlysecure.keychain.util.Log;
@@ -57,10 +58,9 @@ public class SetPassphraseDialogFragment extends DialogFragment implements OnEdi
     public static final String MESSAGE_NEW_PASSPHRASE = "new_passphrase";
 
     private Messenger mMessenger;
-    private PasswordEditText mPassphraseEditText;
+    private PassphraseEditText mPassphraseEditText;
     private EditText mPassphraseAgainEditText;
     private CheckBox mNoPassphraseCheckBox;
-    private PasswordStrengthView mPassphraseStrengthView;
 
     /**
      * Creates new instance of this dialog fragment
@@ -100,11 +100,9 @@ public class SetPassphraseDialogFragment extends DialogFragment implements OnEdi
         View view = inflater.inflate(R.layout.passphrase_repeat_dialog, null);
         alert.setView(view);
 
-        mPassphraseEditText = (PasswordEditText) view.findViewById(R.id.passphrase_passphrase);
+        mPassphraseEditText = (PassphraseEditText) view.findViewById(R.id.passphrase_passphrase);
         mPassphraseAgainEditText = (EditText) view.findViewById(R.id.passphrase_passphrase_again);
         mNoPassphraseCheckBox = (CheckBox) view.findViewById(R.id.passphrase_no_passphrase);
-        mPassphraseStrengthView = (PasswordStrengthView) view.findViewById(R.id.passphrase_repeat_passphrase_strength);
-        mPassphraseEditText.setPasswordStrengthView(mPassphraseStrengthView);
 
 
         if (TextUtils.isEmpty(oldPassphrase)) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
@@ -33,8 +33,14 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.*;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
+import android.widget.Toast;
+
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.widget.PassphraseEditText;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
@@ -33,19 +33,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.EditText;
-import android.widget.TextView;
+import android.widget.*;
 import android.widget.TextView.OnEditorActionListener;
-import android.widget.Toast;
-
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.widget.PassphraseEditText;
-import org.sufficientlysecure.keychain.ui.widget.PasswordEditText;
-import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthView;
 import org.sufficientlysecure.keychain.util.Log;
 
 public class SetPassphraseDialogFragment extends DialogFragment implements OnEditorActionListener {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
@@ -48,6 +48,8 @@ public class PassphraseEditText extends EditText {
                 getPaddingRight() + (int) barGap + mPasswordBarWidth, getPaddingBottom());
 
         mPasswordStrengthBarView = new PasswordStrengthBarView(context, attrs);
+        mPasswordStrengthBarView.setShowGuides(false);
+
         this.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014 Dominik Schürmann <dominik@dominikschuermann.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.ui.widget;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.widget.EditText;
+import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthBarView;
+
+/**
+ * Created by abraham on 6/3/15.
+ */
+public class PassphraseEditText extends EditText {
+
+    PasswordStrengthBarView mPasswordStrengthBarView;
+    int mPasswordBarWidth;
+    int mPasswordBarHeight;
+    float barGap;
+
+    public PassphraseEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mPasswordBarHeight = (int) (8 * getResources().getDisplayMetrics().density);
+        mPasswordBarWidth = (int) (50 * getResources().getDisplayMetrics().density);
+
+        barGap = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8,
+                getContext().getResources().getDisplayMetrics());
+        
+        this.setPadding(getPaddingLeft(), getPaddingTop(),
+                getPaddingRight() + (int) barGap + mPasswordBarWidth, getPaddingBottom());
+
+        mPasswordStrengthBarView = new PasswordStrengthBarView(context, attrs);
+        this.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                mPasswordStrengthBarView.setPassword(s.toString());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        mPasswordStrengthBarView.layout(0, 0, mPasswordBarWidth, mPasswordBarHeight);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        float translateX = getScrollX() + canvas.getWidth() - mPasswordBarWidth;
+        float translateY = (canvas.getHeight() - mPasswordBarHeight) / 2;
+        canvas.translate(translateX, translateY);
+        mPasswordStrengthBarView.draw(canvas);
+        canvas.translate(-translateX, -translateY);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
@@ -24,6 +24,7 @@ import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.widget.EditText;
+
 import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthBarView;
 
 public class PassphraseEditText extends EditText {
@@ -40,7 +41,7 @@ public class PassphraseEditText extends EditText {
 
         barGap = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8,
                 getContext().getResources().getDisplayMetrics());
-        
+
         this.setPadding(getPaddingLeft(), getPaddingTop(),
                 getPaddingRight() + (int) barGap + mPasswordBarWidth, getPaddingBottom());
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/PassphraseEditText.java
@@ -26,9 +26,6 @@ import android.util.TypedValue;
 import android.widget.EditText;
 import org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthBarView;
 
-/**
- * Created by abraham on 6/3/15.
- */
 public class PassphraseEditText extends EditText {
 
     PasswordStrengthBarView mPasswordStrengthBarView;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/passwordstrengthindicator/PasswordStrengthView.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/passwordstrengthindicator/PasswordStrengthView.java
@@ -56,9 +56,6 @@ import org.sufficientlysecure.keychain.R;
  */
 public class PasswordStrengthView extends View {
 
-    protected static final int COLOR_FAIL = Color.parseColor("#e74c3c");
-    protected static final int COLOR_WEAK = Color.parseColor("#e67e22");
-    protected static final int COLOR_STRONG = Color.parseColor("#2ecc71");
 
     protected int mMinWidth;
     protected int mMinHeight;
@@ -100,6 +97,11 @@ public class PasswordStrengthView extends View {
 
     public PasswordStrengthView(Context context, AttributeSet attrs) {
         super(context, attrs);
+
+        int COLOR_FAIL = context.getResources().getColor(R.color.android_red_light);
+        int COLOR_WEAK = context.getResources().getColor(R.color.android_orange_light);
+        int COLOR_STRONG = context.getResources().getColor(R.color.android_green_light);
+
         TypedArray style = context.getTheme().obtainStyledAttributes(
                 attrs,
                 R.styleable.PasswordStrengthView,

--- a/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
@@ -66,11 +66,7 @@
                     android:inputType="textPassword"
                     android:hint="@string/label_passphrase"
                     android:ems="10"
-                    android:layout_gravity="center_horizontal"
-                    custom:showGuides="false"
-                    custom:color_fail="@color/android_red_light"
-                    custom:color_weak="@color/android_orange_light"
-                    custom:color_strong="@color/android_green_light" />
+                    android:layout_gravity="center_horizontal" />
 
             <EditText
                 android:id="@+id/create_key_passphrase_again"

--- a/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
@@ -59,14 +59,14 @@
                 android:text="@string/label_passphrase" />
 
             <org.sufficientlysecure.keychain.ui.widget.PassphraseEditText
-                    android:id="@+id/create_key_passphrase"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:imeOptions="actionNext"
-                    android:inputType="textPassword"
-                    android:hint="@string/label_passphrase"
-                    android:ems="10"
-                    android:layout_gravity="center_horizontal" />
+                android:id="@+id/create_key_passphrase"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionNext"
+                android:inputType="textPassword"
+                android:hint="@string/label_passphrase"
+                android:ems="10"
+                android:layout_gravity="center_horizontal" />
 
             <EditText
                 android:id="@+id/create_key_passphrase_again"

--- a/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/create_key_input_fragment.xml
@@ -58,33 +58,19 @@
                 android:layout_height="wrap_content"
                 android:text="@string/label_passphrase" />
 
-            <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp">
-
-                <org.sufficientlysecure.keychain.ui.widget.PasswordEditText
+            <org.sufficientlysecure.keychain.ui.widget.PassphraseEditText
                     android:id="@+id/create_key_passphrase"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:imeOptions="actionNext"
+                    android:inputType="textPassword"
                     android:hint="@string/label_passphrase"
                     android:ems="10"
-                    android:layout_gravity="center_horizontal" />
-
-                <org.sufficientlysecure.keychain.ui.widget.passwordstrengthindicator.PasswordStrengthBarView
-                    android:id="@+id/create_key_passphrase_strength"
-                    android:layout_width="48dp"
-                    android:layout_height="8dp"
-                    android:layout_gravity="end|center_vertical"
-                    custom:strength="medium"
+                    android:layout_gravity="center_horizontal"
                     custom:showGuides="false"
                     custom:color_fail="@color/android_red_light"
                     custom:color_weak="@color/android_orange_light"
                     custom:color_strong="@color/android_green_light" />
-
-            </FrameLayout>
 
             <EditText
                 android:id="@+id/create_key_passphrase_again"

--- a/OpenKeychain/src/main/res/layout/passphrase_repeat_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_repeat_dialog.xml
@@ -29,6 +29,7 @@
             android:layout_marginBottom="8dp"
             android:imeOptions="actionNext"
             android:hint="@string/label_passphrase"
+            android:inputType="textPassword"
             android:ems="10"
             android:layout_gravity="center_horizontal" />
 

--- a/OpenKeychain/src/main/res/layout/passphrase_repeat_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_repeat_dialog.xml
@@ -21,7 +21,7 @@
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp">
 
-        <org.sufficientlysecure.keychain.ui.widget.PasswordEditText
+        <org.sufficientlysecure.keychain.ui.widget.PassphraseEditText
             android:id="@+id/passphrase_passphrase"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
The standalone PassphraseEditText mentioned in PR https://github.com/open-keychain/open-keychain/pull/1075, and now in Issue https://github.com/open-keychain/open-keychain/issues/1106 and PR https://github.com/open-keychain/open-keychain/pull/1107.

The PassphraseEditText has been added to the CreateKeyInputFragment and SetPassphraseDialogFragment.

Screenshots:
![screenshot_2015-03-06-22-20-02](https://cloud.githubusercontent.com/assets/5712241/6529714/a364fef8-c450-11e4-8e8d-3b1ff9fcc7b4.png)
![screenshot_2015-03-06-22-28-42](https://cloud.githubusercontent.com/assets/5712241/6529718/a75371e8-c450-11e4-9f6f-f4dfccb4a39c.png)


