### PR TITLE
Fixed contact deletion Issue #1120

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ContactHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ContactHelper.java
@@ -267,6 +267,35 @@ public class ContactHelper {
         return null;
     }
 
+    /**
+     * returns the CONTACT_ID of the raw contact to which a masterKeyId is associated, if the
+     * raw contact has not been marked for deletion
+     *
+     * @param resolver
+     * @param masterKeyId
+     * @return CONTACT_ID (id of aggregated contact) linked to masterKeyId
+     */
+    public static long findContactId(ContentResolver resolver, long masterKeyId) {
+        long contactId = -1;
+        Cursor raw = resolver.query(ContactsContract.RawContacts.CONTENT_URI,
+                new String[]{
+                        ContactsContract.RawContacts.CONTACT_ID
+                },
+                ContactsContract.RawContacts.ACCOUNT_TYPE + "=? AND " +
+                        ContactsContract.RawContacts.SOURCE_ID + "=? AND " +
+                        ContactsContract.RawContacts.DELETED + "=?",
+                new String[]{//"0" for "not deleted"
+                        Constants.ACCOUNT_TYPE, Long.toString(masterKeyId), "0"
+                }, null);
+        if (raw != null) {
+            if (raw.moveToNext()) {
+                contactId = raw.getLong(0);
+            }
+            raw.close();
+        }
+        return contactId;
+    }
+
     public static Bitmap getCachedPhotoByMasterKeyId(ContentResolver contentResolver, long masterKeyId) {
         if (masterKeyId == -1) {
             return null;
@@ -398,8 +427,13 @@ public class ContactHelper {
      * TODO: Does this work?
      */
     private static int debugDeleteRawContacts(ContentResolver resolver) {
+        //allows us to actually wipe the RawContact from the device, otherwise would be just flagged
+        //for deletion
+        Uri deleteUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().
+                appendQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, "true").build();
+
         Log.d(Constants.TAG, "Deleting all raw contacts associated to OK...");
-        return resolver.delete(ContactsContract.RawContacts.CONTENT_URI,
+        return resolver.delete(deleteUri,
                 ContactsContract.RawContacts.ACCOUNT_TYPE + "=?",
                 new String[]{
                         Constants.ACCOUNT_TYPE
@@ -407,7 +441,12 @@ public class ContactHelper {
     }
 
     private static int deleteRawContactById(ContentResolver resolver, long rawContactId) {
-        return resolver.delete(ContactsContract.RawContacts.CONTENT_URI,
+        //allows us to actually wipe the RawContact from the device, otherwise would be just flagged
+        //for deletion
+        Uri deleteUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().
+                appendQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, "true").build();
+
+        return resolver.delete(deleteUri,
                 ContactsContract.RawContacts.ACCOUNT_TYPE + "=? AND " + ContactsContract.RawContacts._ID + "=?",
                 new String[]{
                         Constants.ACCOUNT_TYPE, Long.toString(rawContactId)
@@ -415,7 +454,12 @@ public class ContactHelper {
     }
 
     private static int deleteRawContactByMasterKeyId(ContentResolver resolver, long masterKeyId) {
-        return resolver.delete(ContactsContract.RawContacts.CONTENT_URI,
+        //allows us to actually wipe the RawContact from the device, otherwise would be just flagged
+        //for deletion
+        Uri deleteUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().
+                appendQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, "true").build();
+
+        return resolver.delete(deleteUri,
                 ContactsContract.RawContacts.ACCOUNT_TYPE + "=? AND " + ContactsContract.RawContacts.SOURCE_ID + "=?",
                 new String[]{
                         Constants.ACCOUNT_TYPE, Long.toString(masterKeyId)


### PR DESCRIPTION
Refers to https://github.com/open-keychain/open-keychain/issues/1120
Added CALLER_IS_SYNCADAPTER query parameter, with value "true", to all deletion queries. This causes the RawContact to be actually wiped when deleted instead of just the "delete" flag being set. Solves the aforementioned issue of re-imported keys not being linked to system contacts.