### PR TITLE
Sync only confirmed keys and change 

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/CertifyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/CertifyOperation.java
@@ -20,6 +20,7 @@ import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.provider.ProviderHelper.NotFoundException;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel.CertifyAction;
+import org.sufficientlysecure.keychain.service.ContactSyncAdapterService;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.util.Log;
 
@@ -191,6 +192,9 @@ public class CertifyOperation extends BaseOperation {
         }
 
         log.add(LogType.MSG_CRT_SUCCESS, 0);
+        //since only verified keys are synced to contacts, we need to initiate a sync now
+        ContactSyncAdapterService.requestSync();
+        
         return new CertifyResult(CertifyResult.RESULT_OK, log, certifyOk, certifyError, uploadOk, uploadError);
 
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyFragment.java
@@ -53,7 +53,7 @@ public class ViewKeyFragment extends LoaderFragment implements
     //private ListView mLinkedSystemContact;
 
     boolean mIsSecret = false;
-    private String mName;
+    boolean mSystemContactLoaded = false;
 
     LinearLayout mSystemContactLayout;
     ImageView mSystemContactPicture;
@@ -120,17 +120,17 @@ public class ViewKeyFragment extends LoaderFragment implements
      * Checks if a system contact exists for given masterKeyId, and if it does, sets name, picture
      * and onClickListener for the linked system contact's layout
      *
-     * @param name
      * @param masterKeyId
      */
-    private void loadLinkedSystemContact(String name, final long masterKeyId) {
+    private void loadLinkedSystemContact(final long masterKeyId) {
         final Context context = mSystemContactName.getContext();
         final ContentResolver resolver = context.getContentResolver();
 
         final long contactId = ContactHelper.findContactId(resolver, masterKeyId);
+        final String contactName = ContactHelper.getContactName(resolver, contactId);
 
-        if (contactId != -1) {//contact exists for given master key
-            mSystemContactName.setText(name);
+        if (contactName != null) {//contact name exists for given master key
+            mSystemContactName.setText(contactName);
 
             Bitmap picture = ContactHelper.loadPhotoByMasterKeyId(resolver, masterKeyId, true);
             if (picture != null) mSystemContactPicture.setImageBitmap(picture);
@@ -141,6 +141,7 @@ public class ViewKeyFragment extends LoaderFragment implements
                     launchContactActivity(contactId, context);
                 }
             });
+            mSystemContactLoaded = true;
         }
     }
 
@@ -238,14 +239,14 @@ public class ViewKeyFragment extends LoaderFragment implements
         switch (loader.getId()) {
             case LOADER_ID_UNIFIED: {
                 if (data.moveToFirst()) {
+                    //TODO system to allow immediate refreshing of system contact on verification
+                    if (!mSystemContactLoaded) {//ensure we load linked system contact only once
+                        long masterKeyId = data.getLong(INDEX_MASTER_KEY_ID);
+                        loadLinkedSystemContact(masterKeyId);
+                    }
 
                     mIsSecret = data.getInt(INDEX_HAS_ANY_SECRET) != 0;
-                    if (mName == null) {//to ensure we load the linked system contact only once
-                        String[] mainUserId = KeyRing.splitUserId(data.getString(INDEX_USER_ID));
-                        mName = mainUserId[0];
-                        long masterKeyId = data.getLong(INDEX_MASTER_KEY_ID);
-                        loadLinkedSystemContact(mName, masterKeyId);
-                    }
+
                     // load user ids after we know if it's a secret key
                     mUserIdsAdapter = new UserIdsAdapter(getActivity(), null, 0, !mIsSecret, null);
                     mUserIds.setAdapter(mUserIdsAdapter);


### PR DESCRIPTION
Fixes https://github.com/open-keychain/open-keychain/issues/1125 and https://github.com/open-keychain/open-keychain/issues/1126. 

TODO: cause displayed system contact to be updated on confirmation of a key from KeyViewFragment, possibly by introducing a cursor returned by loader methods for system contact information, which would allow automatic updating on change in the contacts table?