### PR TITLE
Fix for Issue #1115

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/SignEncryptOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/SignEncryptOperation.java
@@ -48,6 +48,7 @@ public class SignEncryptOperation extends BaseOperation {
         byte[] inputBytes = input.getBytes();
         byte[] outputBytes = null;
 
+        int total = inputBytes != null ? 1 : inputUris.size(), count = 0;
         ArrayList<PgpSignEncryptResult> results = new ArrayList<>();
 
         do {
@@ -104,7 +105,7 @@ public class SignEncryptOperation extends BaseOperation {
             }
 
             PgpSignEncryptOperation op = new PgpSignEncryptOperation(mContext, mProviderHelper,
-                    new ProgressScaler(), mCancelled);
+                    new ProgressScaler(mProgressable, 100 * count / total, 100 * ++count / total, 100), mCancelled);
             PgpSignEncryptResult result = op.execute(input, inputData, outStream);
             results.add(result);
             log.add(result, 2);


### PR DESCRIPTION
Please use files of size 1mb+ while testing so that the progress can be viewed clearly.

This fixes enables the change of progress for both Encryption of Files(with and without ASCII armor) and Text.

![screenshot_2015-03-13-01-02-00](https://cloud.githubusercontent.com/assets/1645107/6626485/e4a49f10-c91c-11e4-890d-21fff8ac9f50.png)
