### PR TITLE
Show HKP server results first in key cloud search. Fixes #1066

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/ImportKeysList.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/ImportKeysList.java
@@ -70,6 +70,7 @@ public class ImportKeysList extends ArrayList<ImportKeysListEntry> {
             modified = true;
         }
 
+        boolean incomingFromHkpServer = true;
         // we’re going to want to try to fetch the key from everywhere we found it, so remember
         //  all the origins
         for (String origin : incoming.getOrigins()) {
@@ -78,13 +79,19 @@ public class ImportKeysList extends ArrayList<ImportKeysListEntry> {
             // to work properly, Keybase-sourced entries need to pass along the extra
             if (KeybaseKeyserver.ORIGIN.equals(origin)) {
                 existing.setExtraData(incoming.getExtraData());
+                incomingFromHkpServer = false;
             }
         }
+
         ArrayList<String> incomingIDs = incoming.getUserIds();
         ArrayList<String> existingIDs = existing.getUserIds();
         for (String incomingID : incomingIDs) {
             if (!existingIDs.contains(incomingID)) {
-                existingIDs.add(incomingID);
+                if (incomingFromHkpServer) {
+                    existingIDs.add(0, incomingID);
+                } else {
+                    existingIDs.add(incomingID);
+                }
                 modified = true;
             }
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/ImportKeysList.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/ImportKeysList.java
@@ -70,6 +70,7 @@ public class ImportKeysList extends ArrayList<ImportKeysListEntry> {
             modified = true;
         }
 
+        // keep track if this key result is from a HKP keyserver
         boolean incomingFromHkpServer = true;
         // we’re going to want to try to fetch the key from everywhere we found it, so remember
         //  all the origins
@@ -79,6 +80,7 @@ public class ImportKeysList extends ArrayList<ImportKeysListEntry> {
             // to work properly, Keybase-sourced entries need to pass along the extra
             if (KeybaseKeyserver.ORIGIN.equals(origin)) {
                 existing.setExtraData(incoming.getExtraData());
+                // one of the origins is not a HKP keyserver
                 incomingFromHkpServer = false;
             }
         }
@@ -87,6 +89,10 @@ public class ImportKeysList extends ArrayList<ImportKeysListEntry> {
         ArrayList<String> existingIDs = existing.getUserIds();
         for (String incomingID : incomingIDs) {
             if (!existingIDs.contains(incomingID)) {
+                // prepend  HKP server results to the start of the list,
+                // so that the UI (for cloud key search, which is picking the first list item)
+                // shows the right main email address, as mail addresses returned by HKP servers
+                // are preferred over keybase.io IDs
                 if (incomingFromHkpServer) {
                     existingIDs.add(0, incomingID);
                 } else {


### PR DESCRIPTION
Previously, the cloud key search showed either a keyserver email or a keybase ID as the user's main email, depending on which server request was answered faster.
Now results returned from HKP keyservers will be sorted in front of keybase IDs to show the correct email address in the dialog.