### PR TITLE
Added a blank footer view to the list of keys

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
@@ -169,6 +169,22 @@ public class KeyListFragment extends LoaderFragment
         mStickyList.setDrawingListUnderStickyHeader(false);
         mStickyList.setFastScrollEnabled(true);
 
+        // Adds an empty footer view so that the Floating Action Button won't block content
+        // in last few rows.
+        View footer = new View(getActivity());
+
+        int spacing = (int) android.util.TypedValue.applyDimension(
+                android.util.TypedValue.COMPLEX_UNIT_DIP, 72, getResources().getDisplayMetrics()
+        );
+
+        android.widget.AbsListView.LayoutParams params = new android.widget.AbsListView.LayoutParams(
+                android.widget.AbsListView.LayoutParams.MATCH_PARENT,
+                spacing
+        );
+
+        footer.setLayoutParams(params);
+        mStickyList.addFooterView(footer, null, false);
+
         /*
          * Multi-selection
          */
@@ -369,7 +385,7 @@ public class KeyListFragment extends LoaderFragment
     /**
      * Show dialog to delete key
      *
-     * @param hasSecret    must contain whether the list of masterKeyIds contains a secret key or not
+     * @param hasSecret must contain whether the list of masterKeyIds contains a secret key or not
      */
     public void showDeleteKeyDialog(final ActionMode mode, long[] masterKeyIds, boolean hasSecret) {
         // Can only work on singular secret keys
@@ -907,7 +923,6 @@ public class KeyListFragment extends LoaderFragment
         }
 
     }
-
 
 
 }


### PR DESCRIPTION
When the list of key is long, the Floating Action Button blocks the content of the last few rows. A blank footer (with height `72dp`) is added to the bottom to prevent this (and to follow the [Material Design's Guidelines](http://www.google.com/design/spec/components/buttons.html#buttons-floating-action-button): *the content should have enough padding at the bottom so the button does not block content in last row.*)

Before & After: 

![Screenshot](http://i.imgur.com/qMgvvAi.png) ![Screenshot](http://i.imgur.com/f7osPDI.png)