### PR TITLE
Fixed #1152: NullPointerException when signing with YubiKey

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptOperation.java
@@ -62,19 +62,19 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/** This class supports a single, low-level, sign/encrypt operation.
- *
+/**
+ * This class supports a single, low-level, sign/encrypt operation.
+ * <p/>
  * The operation of this class takes an Input- and OutputStream plus a
  * PgpSignEncryptInput, and signs and/or encrypts the stream as
  * parametrized in the PgpSignEncryptInput object. It returns its status
  * and a possible detached signature as a SignEncryptResult.
- *
+ * <p/>
  * For a high-level operation based on URIs, see SignEncryptOperation.
  *
  * @see org.sufficientlysecure.keychain.pgp.PgpSignEncryptInput
  * @see org.sufficientlysecure.keychain.operations.results.PgpSignEncryptResult
  * @see org.sufficientlysecure.keychain.operations.SignEncryptOperation
- *
  */
 public class PgpSignEncryptOperation extends BaseOperation {
 
@@ -100,7 +100,7 @@ public class PgpSignEncryptOperation extends BaseOperation {
      * Signs and/or encrypts data based on parameters of class
      */
     public PgpSignEncryptResult execute(PgpSignEncryptInput input,
-                                     InputData inputData, OutputStream outputStream) {
+                                        InputData inputData, OutputStream outputStream) {
 
         int indent = 0;
         OperationLog log = new OperationLog();
@@ -487,6 +487,12 @@ public class PgpSignEncryptOperation extends BaseOperation {
                     log.add(LogType.MSG_PSE_PENDING_NFC, indent);
                     PgpSignEncryptResult result =
                             new PgpSignEncryptResult(PgpSignEncryptResult.RESULT_PENDING_NFC, log);
+
+                    // SignatureSubKeyId can be null.
+                    if (input.getSignatureSubKeyId() == null) {
+                        return new PgpSignEncryptResult(PgpSignEncryptResult.RESULT_ERROR, log);
+                    }
+
                     // Note that the checked key here is the master key, not the signing key
                     // (although these are always the same on Yubikeys)
                     result.setNfcData(input.getSignatureSubKeyId(), e.hashToSign, e.hashAlgo, e.creationTimestamp, input.getSignaturePassphrase());


### PR DESCRIPTION
This is due to `input.getSignatureSubKeyId()` (which is a `Long`) can be `null`. 

`result.setNfcData` tries to cast the `null` into a primitive `long` and thus this error appears: `Attempt to invoke virtual method 'long java.lang.Long.longValue()' on a null object reference`.

Fix: If the value is `null`, return `PgpSignEncryptResult` with `PgpSignEncryptResult.RESULT_ERROR` as the `result`.
