### PR TITLE
Multi-threaded key import, update all feature

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -697,6 +697,9 @@
         <service
             android:name=".service.KeychainIntentService"
             android:exported="false" />
+        <service
+            android:name=".service.CloudImportService"
+            android:exported="false" />
 
         <provider
             android:name=".provider.KeychainProvider"

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/CloudImportService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/CloudImportService.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (C) 2012-2013 Dominik Schürmann <dominik@dominikschuermann.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.service;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.Message;
+import android.os.Messenger;
+import android.os.RemoteException;
+
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.keyimport.ParcelableKeyRing;
+import org.sufficientlysecure.keychain.operations.ImportExportOperation;
+import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
+import org.sufficientlysecure.keychain.operations.results.OperationResult;
+import org.sufficientlysecure.keychain.pgp.Progressable;
+import org.sufficientlysecure.keychain.provider.ProviderHelper;
+import org.sufficientlysecure.keychain.util.Log;
+import org.sufficientlysecure.keychain.util.ParcelableFileCache;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * When this service is started it will initiate a multi-threaded key import and when done it will
+ * shut itself down.
+ */
+public class CloudImportService extends Service implements Progressable {
+
+    //required as extras from intent
+    public static final String EXTRA_MESSENGER = "messenger";
+    public static final String EXTRA_DATA = "data";
+
+    //required by data bundle
+    public static final String IMPORT_KEY_LIST = "import_key_list";
+    public static final String IMPORT_KEY_SERVER = "import_key_server";
+
+    // indicates a request to cancel the import
+    public static final String ACTION_CANCEL = Constants.INTENT_PREFIX + "CANCEL";
+
+    //tells the spawned threads whether the user has requested a cancel
+    private static AtomicBoolean mActionCancelled = new AtomicBoolean(false);
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    /**
+     * Used to accumulate the results of individual key imports
+     */
+    private class KeyImportAccumulator {
+        private OperationResult.OperationLog mImportLog = new OperationResult.OperationLog();
+        private int mTotalKeys;
+        private int mImportedKeys = 0;
+        private Progressable mImportProgressable;
+        ArrayList<Long> mImportedMasterKeyIds = new ArrayList<Long>();
+        private int mBadKeys = 0;
+        private int mNewKeys = 0;
+        private int mUpdatedKeys = 0;
+        private int mSecret = 0;
+        private int mResultType = 0;
+
+        public KeyImportAccumulator(int totalKeys) {
+            mTotalKeys = totalKeys;
+            //ignore updates from ImportExportOperation for now
+            mImportProgressable = new Progressable() {
+                @Override
+                public void setProgress(String message, int current, int total) {
+
+                }
+
+                @Override
+                public void setProgress(int resourceId, int current, int total) {
+
+                }
+
+                @Override
+                public void setProgress(int current, int total) {
+
+                }
+
+                @Override
+                public void setPreventCancel() {
+
+                }
+            };
+        }
+
+        public Progressable getImportProgressable() {
+            return mImportProgressable;
+        }
+
+        public int getTotalKeys() {
+            return mTotalKeys;
+        }
+
+        public int getImportedKeys() {
+            return mImportedKeys;
+        }
+
+        public synchronized void accumulateKeyImport(ImportKeyResult result) {
+            mImportedKeys++;
+            mImportLog.addAll(result.getLog().toList());//accumulates log
+            mBadKeys += result.mBadKeys;
+            mNewKeys += result.mNewKeys;
+            mUpdatedKeys += result.mUpdatedKeys;
+            mSecret += result.mSecret;
+
+            long[] masterKeyIds = result.getImportedMasterKeyIds();
+            for (int i = 0; i < masterKeyIds.length; i++) {
+                mImportedMasterKeyIds.add(masterKeyIds[i]);
+            }
+
+            // if any key import has been cancelled, set result type to cancelled
+            // resultType is added to in getConsolidatedKayImport to account for remaining factors
+            mResultType |= result.getResult() & ImportKeyResult.RESULT_CANCELLED;
+
+        }
+
+        /**
+         * returns accumulated result of all imports so far
+         *
+         * @return
+         */
+        public ImportKeyResult getConsolidatedImportKeyResult() {
+
+            // adding required information to mResultType
+            // special case,no keys requested for import
+            if (mBadKeys == 0 && mNewKeys == 0 && mUpdatedKeys == 0) {
+                mResultType = ImportKeyResult.RESULT_FAIL_NOTHING;
+            } else {
+                if (mNewKeys > 0) {
+                    mResultType |= ImportKeyResult.RESULT_OK_NEWKEYS;
+                }
+                if (mUpdatedKeys > 0) {
+                    mResultType |= ImportKeyResult.RESULT_OK_UPDATED;
+                }
+                if (mBadKeys > 0) {
+                    mResultType |= ImportKeyResult.RESULT_WITH_ERRORS;
+                    if (mNewKeys == 0 && mUpdatedKeys == 0) {
+                        mResultType |= ImportKeyResult.RESULT_ERROR;
+                    }
+                }
+                if (mImportLog.containsWarnings()) {
+                    mResultType |= ImportKeyResult.RESULT_WARNINGS;
+                }
+            }
+
+            long masterKeyIds[] = new long[mImportedMasterKeyIds.size()];
+            for (int i = 0; i < masterKeyIds.length; i++) {
+                masterKeyIds[i] = mImportedMasterKeyIds.get(i);
+            }
+
+            return new ImportKeyResult(mResultType, mImportLog, mNewKeys, mUpdatedKeys, mBadKeys,
+                    mSecret, masterKeyIds);
+        }
+
+        public boolean isImportFinished() {
+            return mTotalKeys == mImportedKeys;
+        }
+    }
+
+    private KeyImportAccumulator mKeyImportAccumulator;
+
+    Messenger mMessenger;
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+
+        if (ACTION_CANCEL.equals(intent.getAction())) {
+            mActionCancelled.set(true);
+            return Service.START_NOT_STICKY;
+        }
+
+        mActionCancelled.set(false);//we haven't been cancelled, yet
+
+        Bundle extras = intent.getExtras();
+
+        mMessenger = (Messenger) extras.get(EXTRA_MESSENGER);
+
+        Bundle data = extras.getBundle(EXTRA_DATA);
+
+        final String keyServer = data.getString(IMPORT_KEY_SERVER);
+        //keyList being null (in case key list to be reaad from cache) is checked by importKeys
+        final ArrayList<ParcelableKeyRing> keyList = data.getParcelableArrayList(IMPORT_KEY_LIST);
+
+        // Adding keys to the ThreadPoolExecutor takes time, we don't want to block the main thread
+        Thread baseImportThread = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                importKeys(keyList, keyServer);
+            }
+        });
+        baseImportThread.start();
+        return Service.START_NOT_STICKY;
+    }
+
+    public void importKeys(ArrayList<ParcelableKeyRing> keyList, final String keyServer) {
+        ParcelableFileCache<ParcelableKeyRing> cache =
+                new ParcelableFileCache<>(this, "key_import.pcl");
+        int totKeys = 0;
+        Iterator<ParcelableKeyRing> keyListIterator = null;
+        //either keyList or cache must be null, no guarantees otherwise
+        if (keyList == null) {//export from cache, copied from ImportExportOperation.importKeyRings
+
+            try {
+                ParcelableFileCache.IteratorWithSize<ParcelableKeyRing> it = cache.readCache();
+                keyListIterator = it;
+                totKeys = it.getSize();
+            } catch (IOException e) {
+
+                // Special treatment here, we need a lot
+                OperationResult.OperationLog log = new OperationResult.OperationLog();
+                log.add(OperationResult.LogType.MSG_IMPORT, 0, 0);
+                log.add(OperationResult.LogType.MSG_IMPORT_ERROR_IO, 0, 0);
+
+                keyImportFailed(new ImportKeyResult(ImportKeyResult.RESULT_ERROR, log));
+            }
+        } else {
+            keyListIterator = keyList.iterator();
+            totKeys = keyList.size();
+        }
+
+
+        if (keyListIterator != null) {
+            mKeyImportAccumulator = new KeyImportAccumulator(totKeys);
+            setProgress(0, totKeys);
+
+            final int maxThreads = 200;
+            ExecutorService importExecutor = new ThreadPoolExecutor(0, maxThreads,
+                    30L, TimeUnit.SECONDS,
+                    new SynchronousQueue<Runnable>());
+
+            while (keyListIterator.hasNext()) {
+
+                final ParcelableKeyRing pkRing = keyListIterator.next();
+
+                Runnable importOperationRunnable = new Runnable() {
+
+                    @Override
+                    public void run() {
+                        ImportKeyResult result = null;
+                        try {
+                            ImportExportOperation importExportOperation = new ImportExportOperation(
+                                    CloudImportService.this,
+                                    new ProviderHelper(CloudImportService.this),
+                                    mKeyImportAccumulator.getImportProgressable(),
+                                    mActionCancelled);
+
+                            ArrayList<ParcelableKeyRing> list = new ArrayList<>();
+                            list.add(pkRing);
+                            result = importExportOperation.importKeyRings(list,
+                                    keyServer);
+                        } finally {
+                            // in the off-chance that importKeyRings does something to crash the
+                            // thread before it can call singleKeyRingImportCompleted, our imported
+                            // key count will go wrong. This will cause the service to never die,
+                            // and the progress dialog to stay displayed. The finally block was
+                            // originally meant to ensure singleKeyRingImportCompleted was called,
+                            // and checks for null were to be introduced, but in such a scenario,
+                            // knowing an uncaught error exists in importKeyRings is more important.
+
+                            // if a null gets passed, something wrong is happening. We want a crash.
+
+                            singleKeyRingImportCompleted(result);
+                        }
+                    }
+                };
+
+                importExecutor.execute(importOperationRunnable);
+            }
+        }
+    }
+
+    private synchronized void singleKeyRingImportCompleted(ImportKeyResult result) {
+        // increase imported key count and accumulate log and bad, new etc. key counts from result
+        mKeyImportAccumulator.accumulateKeyImport(result);
+
+        setProgress(mKeyImportAccumulator.getImportedKeys(), mKeyImportAccumulator.getTotalKeys());
+
+        if (mKeyImportAccumulator.isImportFinished()) {
+            ContactSyncAdapterService.requestSync();
+
+            sendMessageToHandler(ServiceProgressHandler.MessageStatus.OKAY,
+                    mKeyImportAccumulator.getConsolidatedImportKeyResult());
+
+            stopSelf();//we're done here
+        }
+    }
+
+    private void keyImportFailed(ImportKeyResult result) {
+        sendMessageToHandler(ServiceProgressHandler.MessageStatus.OKAY, result);
+    }
+
+    private void sendMessageToHandler(ServiceProgressHandler.MessageStatus status, Integer arg2, Bundle data) {
+
+        Message msg = Message.obtain();
+        assert msg != null;
+        msg.arg1 = status.ordinal();
+        if (arg2 != null) {
+            msg.arg2 = arg2;
+        }
+        if (data != null) {
+            msg.setData(data);
+        }
+
+        try {
+            mMessenger.send(msg);
+        } catch (RemoteException e) {
+            Log.w(Constants.TAG, "Exception sending message, Is handler present?", e);
+        } catch (NullPointerException e) {
+            Log.w(Constants.TAG, "Messenger is null!", e);
+        }
+    }
+
+    private void sendMessageToHandler(ServiceProgressHandler.MessageStatus status, OperationResult data) {
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(OperationResult.EXTRA_RESULT, data);
+        sendMessageToHandler(status, null, bundle);
+    }
+
+    private void sendMessageToHandler(ServiceProgressHandler.MessageStatus status, Bundle data) {
+        sendMessageToHandler(status, null, data);
+    }
+
+    private void sendMessageToHandler(ServiceProgressHandler.MessageStatus status) {
+        sendMessageToHandler(status, null, null);
+    }
+
+    /**
+     * Set progress of ProgressDialog by sending message to handler on UI thread
+     */
+    @Override
+    public synchronized void setProgress(String message, int progress, int max) {
+        Log.d(Constants.TAG, "Send message by setProgress with progress=" + progress + ", max="
+                + max);
+
+        Bundle data = new Bundle();
+        if (message != null) {
+            data.putString(ServiceProgressHandler.DATA_MESSAGE, message);
+        }
+        data.putInt(ServiceProgressHandler.DATA_PROGRESS, progress);
+        data.putInt(ServiceProgressHandler.DATA_PROGRESS_MAX, max);
+
+        sendMessageToHandler(ServiceProgressHandler.MessageStatus.UPDATE_PROGRESS, null, data);
+    }
+
+    @Override
+    public synchronized void setProgress(int resourceId, int progress, int max) {
+        setProgress(getString(resourceId), progress, max);
+    }
+
+    @Override
+    public synchronized void setProgress(int progress, int max) {
+        setProgress(null, progress, max);
+    }
+
+    @Override
+    public synchronized void setPreventCancel() {
+        sendMessageToHandler(ServiceProgressHandler.MessageStatus.PREVENT_CANCEL);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ServiceProgressHandler.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ServiceProgressHandler.java
@@ -30,7 +30,7 @@ import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.Log;
 
-public class KeychainIntentServiceHandler extends Handler {
+public class ServiceProgressHandler extends Handler {
 
     // possible messages sent from this service to handler on ui
     public static enum MessageStatus{
@@ -67,28 +67,34 @@ public class KeychainIntentServiceHandler extends Handler {
     Activity mActivity;
     ProgressDialogFragment mProgressDialogFragment;
 
-    public KeychainIntentServiceHandler(Activity activity) {
+    public ServiceProgressHandler(Activity activity) {
         this.mActivity = activity;
     }
 
-    public KeychainIntentServiceHandler(Activity activity,
-                                        ProgressDialogFragment progressDialogFragment) {
+    public ServiceProgressHandler(Activity activity,
+                                  ProgressDialogFragment progressDialogFragment) {
         this.mActivity = activity;
         this.mProgressDialogFragment = progressDialogFragment;
     }
 
-    public KeychainIntentServiceHandler(Activity activity, String progressDialogMessage,
-                                        int progressDialogStyle) {
-        this(activity, progressDialogMessage, progressDialogStyle, false);
+    public ServiceProgressHandler(Activity activity,
+                                  String progressDialogMessage,
+                                  int progressDialogStyle,
+                                  ProgressDialogFragment.ServiceType serviceType) {
+        this(activity, progressDialogMessage, progressDialogStyle, false, serviceType);
     }
 
-    public KeychainIntentServiceHandler(Activity activity, String progressDialogMessage,
-                                        int progressDialogStyle, boolean cancelable) {
+    public ServiceProgressHandler(Activity activity,
+                                  String progressDialogMessage,
+                                  int progressDialogStyle,
+                                  boolean cancelable,
+                                  ProgressDialogFragment.ServiceType serviceType) {
         this.mActivity = activity;
         this.mProgressDialogFragment = ProgressDialogFragment.newInstance(
                 progressDialogMessage,
                 progressDialogStyle,
-                cancelable);
+                cancelable,
+                serviceType);
     }
 
     public void showProgressDialog(FragmentActivity activity) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyKeyFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyKeyFragment.java
@@ -55,9 +55,10 @@ import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel.CertifyAction;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
 import org.sufficientlysecure.keychain.service.PassphraseCacheService;
 import org.sufficientlysecure.keychain.ui.adapter.MultiUserIdsAdapter;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.widget.CertifyKeySpinner;
 import org.sufficientlysecure.keychain.ui.widget.KeySpinner;
@@ -388,8 +389,12 @@ public class CertifyKeyFragment extends LoaderFragment
         } else {
 
             // Message is received after signing is done in KeychainIntentService
-            KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(getActivity(),
-                    getString(R.string.progress_certifying), ProgressDialog.STYLE_SPINNER, true) {
+            ServiceProgressHandler saveHandler = new ServiceProgressHandler(
+                    getActivity(),
+                    getString(R.string.progress_certifying),
+                    ProgressDialog.STYLE_SPINNER,
+                    true,
+                    ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
                 public void handleMessage(Message message) {
                     // handle messages by standard KeychainIntentServiceHandler first
                     super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ConsolidateDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ConsolidateDialogActivity.java
@@ -26,7 +26,8 @@ import android.support.v4.app.FragmentActivity;
 
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 
 /**
  * We can not directly create a dialog on the application context.
@@ -49,10 +50,11 @@ public class ConsolidateDialogActivity extends FragmentActivity {
 
     private void consolidateRecovery(boolean recovery) {
         // Message is received after importing is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
                 this,
                 getString(R.string.progress_importing),
-                ProgressDialog.STYLE_HORIZONTAL) {
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyFinalFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyFinalFragment.java
@@ -39,16 +39,15 @@ import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.pgp.KeyRing;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel.Algorithm;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel.ChangeUnlockParcel;
 import org.sufficientlysecure.keychain.ui.CreateKeyActivity.FragAction;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.util.Log;
-import org.sufficientlysecure.keychain.util.Passphrase;
 import org.sufficientlysecure.keychain.util.Preferences;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 
 public class CreateKeyFinalFragment extends Fragment {
@@ -195,10 +194,11 @@ public class CreateKeyFinalFragment extends Fragment {
         Intent intent = new Intent(getActivity(), KeychainIntentService.class);
         intent.setAction(KeychainIntentService.ACTION_EDIT_KEYRING);
 
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
                 getActivity(),
                 getString(R.string.progress_building_key),
-                ProgressDialog.STYLE_HORIZONTAL) {
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);
@@ -267,8 +267,11 @@ public class CreateKeyFinalFragment extends Fragment {
 
         intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
 
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(getActivity(),
-                getString(R.string.progress_uploading), ProgressDialog.STYLE_HORIZONTAL) {
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
+                getActivity(),
+                getString(R.string.progress_uploading),
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFilesFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFilesFragment.java
@@ -38,8 +38,9 @@ import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.operations.results.DecryptVerifyResult;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
 import org.sufficientlysecure.keychain.service.KeychainIntentService.IOType;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
 import org.sufficientlysecure.keychain.ui.dialog.DeleteFileDialogFragment;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.FileHelper;
 import org.sufficientlysecure.keychain.util.Log;
@@ -197,8 +198,11 @@ public class DecryptFilesFragment extends DecryptFragment {
         intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
 
         // Message is received after decrypting is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(getActivity(),
-                getString(R.string.progress_decrypting), ProgressDialog.STYLE_HORIZONTAL) {
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
+                getActivity(),
+                getString(R.string.progress_decrypting),
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);
@@ -271,8 +275,11 @@ public class DecryptFilesFragment extends DecryptFragment {
         intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
 
         // Message is received after decrypting is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(getActivity(),
-                getString(R.string.progress_decrypting), ProgressDialog.STYLE_HORIZONTAL) {
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
+                getActivity(),
+                getString(R.string.progress_decrypting),
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptTextFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptTextFragment.java
@@ -37,7 +37,8 @@ import org.sufficientlysecure.keychain.compatibility.ClipboardReflection;
 import org.sufficientlysecure.keychain.operations.results.DecryptVerifyResult;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
 import org.sufficientlysecure.keychain.service.KeychainIntentService.IOType;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.ShareHelper;
@@ -167,8 +168,11 @@ public class DecryptTextFragment extends DecryptFragment {
         intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
 
         // Message is received after encrypting is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(getActivity(),
-                getString(R.string.progress_decrypting), ProgressDialog.STYLE_HORIZONTAL) {
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
+                getActivity(),
+                getString(R.string.progress_decrypting),
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EditKeyFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EditKeyFragment.java
@@ -50,7 +50,7 @@ import org.sufficientlysecure.keychain.provider.KeychainContract.UserPackets;
 import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.provider.ProviderHelper.NotFoundException;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
 import org.sufficientlysecure.keychain.service.PassphraseCacheService;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel.ChangeUnlockParcel;
@@ -59,12 +59,7 @@ import org.sufficientlysecure.keychain.ui.adapter.SubkeysAdapter;
 import org.sufficientlysecure.keychain.ui.adapter.SubkeysAddedAdapter;
 import org.sufficientlysecure.keychain.ui.adapter.UserIdsAdapter;
 import org.sufficientlysecure.keychain.ui.adapter.UserIdsAddedAdapter;
-import org.sufficientlysecure.keychain.ui.dialog.AddSubkeyDialogFragment;
-import org.sufficientlysecure.keychain.ui.dialog.AddUserIdDialogFragment;
-import org.sufficientlysecure.keychain.ui.dialog.EditSubkeyDialogFragment;
-import org.sufficientlysecure.keychain.ui.dialog.EditSubkeyExpiryDialogFragment;
-import org.sufficientlysecure.keychain.ui.dialog.EditUserIdDialogFragment;
-import org.sufficientlysecure.keychain.ui.dialog.SetPassphraseDialogFragment;
+import org.sufficientlysecure.keychain.ui.dialog.*;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Passphrase;
@@ -597,11 +592,12 @@ public class EditKeyFragment extends LoaderFragment implements
     private void saveInDatabase(Passphrase passphrase) {
         Log.d(Constants.TAG, "mSaveKeyringParcel:\n" + mSaveKeyringParcel.toString());
 
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
                 getActivity(),
                 getString(R.string.progress_saving),
                 ProgressDialog.STYLE_HORIZONTAL,
-                true) {
+                true,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptActivity.java
@@ -31,7 +31,8 @@ import org.sufficientlysecure.keychain.operations.results.PgpSignEncryptResult;
 import org.sufficientlysecure.keychain.operations.results.SignEncryptResult;
 import org.sufficientlysecure.keychain.pgp.SignEncryptParcel;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.util.Passphrase;
 
 import java.util.Date;
@@ -123,8 +124,11 @@ public abstract class EncryptActivity extends BaseActivity {
         intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
 
         // Message is received after encrypting is done in KeychainIntentService
-        KeychainIntentServiceHandler serviceHandler = new KeychainIntentServiceHandler(this,
-                getString(R.string.progress_encrypting), ProgressDialog.STYLE_HORIZONTAL) {
+        ServiceProgressHandler serviceHandler = new ServiceProgressHandler(
+                this,
+                getString(R.string.progress_encrypting),
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
@@ -35,8 +35,9 @@ import org.sufficientlysecure.keychain.keyimport.ImportKeysListEntry;
 import org.sufficientlysecure.keychain.keyimport.ParcelableKeyRing;
 import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
-import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.CloudImportService;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.Log;
@@ -294,12 +295,13 @@ public class ImportKeysActivity extends BaseActivity {
      * Import keys with mImportData
      */
     public void importKeys() {
-        // Message is received after importing is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(
+        // Message is received after importing is done in CloudImportService
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
                 this,
                 getString(R.string.progress_importing),
                 ProgressDialog.STYLE_HORIZONTAL,
-                true) {
+                true,
+                ProgressDialogFragment.ServiceType.CLOUD_IMPORT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);
@@ -342,9 +344,7 @@ public class ImportKeysActivity extends BaseActivity {
             Log.d(Constants.TAG, "importKeys started");
 
             // Send all information needed to service to import key in other thread
-            Intent intent = new Intent(this, KeychainIntentService.class);
-
-            intent.setAction(KeychainIntentService.ACTION_IMPORT_KEYRING);
+            Intent intent = new Intent(this, CloudImportService.class);
 
             // fill values for this action
             Bundle data = new Bundle();
@@ -362,11 +362,11 @@ public class ImportKeysActivity extends BaseActivity {
                         new ParcelableFileCache<>(this, "key_import.pcl");
                 cache.writeCache(selectedEntries);
 
-                intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
+                intent.putExtra(CloudImportService.EXTRA_DATA, data);
 
                 // Create a new Messenger for the communication back
                 Messenger messenger = new Messenger(saveHandler);
-                intent.putExtra(KeychainIntentService.EXTRA_MESSENGER, messenger);
+                intent.putExtra(CloudImportService.EXTRA_MESSENGER, messenger);
 
                 // show progress dialog
                 saveHandler.showProgressDialog(this);
@@ -382,14 +382,12 @@ public class ImportKeysActivity extends BaseActivity {
             ImportKeysListFragment.CloudLoaderState sls = (ImportKeysListFragment.CloudLoaderState) ls;
 
             // Send all information needed to service to query keys in other thread
-            Intent intent = new Intent(this, KeychainIntentService.class);
-
-            intent.setAction(KeychainIntentService.ACTION_IMPORT_KEYRING);
+            Intent intent = new Intent(this, CloudImportService.class);
 
             // fill values for this action
             Bundle data = new Bundle();
 
-            data.putString(KeychainIntentService.IMPORT_KEY_SERVER, sls.mCloudPrefs.keyserver);
+            data.putString(CloudImportService.IMPORT_KEY_SERVER, sls.mCloudPrefs.keyserver);
 
             // get selected key entries
             ArrayList<ParcelableKeyRing> keys = new ArrayList<>();
@@ -402,13 +400,13 @@ public class ImportKeysActivity extends BaseActivity {
                     );
                 }
             }
-            data.putParcelableArrayList(KeychainIntentService.IMPORT_KEY_LIST, keys);
+            data.putParcelableArrayList(CloudImportService.IMPORT_KEY_LIST, keys);
 
-            intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
+            intent.putExtra(CloudImportService.EXTRA_DATA, data);
 
             // Create a new Messenger for the communication back
             Messenger messenger = new Messenger(saveHandler);
-            intent.putExtra(KeychainIntentService.EXTRA_MESSENGER, messenger);
+            intent.putExtra(CloudImportService.EXTRA_MESSENGER, messenger);
 
             // show progress dialog
             saveHandler.showProgressDialog(this);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysProxyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysProxyActivity.java
@@ -42,7 +42,8 @@ import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.operations.results.SingletonResult;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.util.IntentIntegratorSupportV4;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Preferences;
@@ -213,11 +214,12 @@ public class ImportKeysProxyActivity extends FragmentActivity {
     private void startImportService (ArrayList<ParcelableKeyRing> keyRings) {
 
         // Message is received after importing is done in KeychainIntentService
-        KeychainIntentServiceHandler serviceHandler = new KeychainIntentServiceHandler(
+        ServiceProgressHandler serviceHandler = new ServiceProgressHandler(
                 this,
                 getString(R.string.progress_importing),
                 ProgressDialog.STYLE_HORIZONTAL,
-                true) {
+                true,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
@@ -20,7 +20,6 @@ package org.sufficientlysecure.keychain.ui;
 
 import android.animation.ObjectAnimator;
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -59,7 +58,6 @@ import com.getbase.floatingactionbutton.FloatingActionsMenu;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
-import org.sufficientlysecure.keychain.keyimport.ImportKeysListEntry;
 import org.sufficientlysecure.keychain.keyimport.ParcelableKeyRing;
 import org.sufficientlysecure.keychain.operations.results.ConsolidateResult;
 import org.sufficientlysecure.keychain.operations.results.DeleteResult;
@@ -70,9 +68,11 @@ import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.provider.KeychainDatabase;
 import org.sufficientlysecure.keychain.provider.ProviderHelper;
+import org.sufficientlysecure.keychain.service.CloudImportService;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
 import org.sufficientlysecure.keychain.ui.dialog.DeleteKeyDialogFragment;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.Highlighter;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils.State;
@@ -572,7 +572,7 @@ public class KeyListFragment extends LoaderFragment
     }
 
     private void updateAllKeys() {
-        Context context = this.getActivity();
+        Context context = getActivity();
 
         ProviderHelper providerHelper = new ProviderHelper(context);
 
@@ -591,11 +591,12 @@ public class KeyListFragment extends LoaderFragment
             keyList.add(keyEntry);
         }
 
-        KeychainIntentServiceHandler serviceHandler = new KeychainIntentServiceHandler(
+        ServiceProgressHandler serviceHandler = new ServiceProgressHandler(
                 getActivity(),
-                getString(R.string.progress_importing),
+                getString(R.string.progress_updating),
                 ProgressDialog.STYLE_HORIZONTAL,
-                true) {
+                true,
+                ProgressDialogFragment.ServiceType.CLOUD_IMPORT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);
@@ -613,15 +614,13 @@ public class KeyListFragment extends LoaderFragment
                         return;
                     }
 
-                    result.createNotify(KeyListFragment.this.getActivity()).show();
+                    result.createNotify(getActivity()).show();
                 }
             }
         };
 
         // Send all information needed to service to query keys in other thread
-        Intent intent = new Intent(getActivity(), KeychainIntentService.class);
-
-        intent.setAction(KeychainIntentService.ACTION_IMPORT_KEYRING);
+        Intent intent = new Intent(getActivity(), CloudImportService.class);
 
         // fill values for this action
         Bundle data = new Bundle();
@@ -631,16 +630,16 @@ public class KeyListFragment extends LoaderFragment
             Preferences prefs = Preferences.getPreferences(getActivity());
             Preferences.CloudSearchPrefs cloudPrefs =
                     new Preferences.CloudSearchPrefs(true, true, prefs.getPreferredKeyserver());
-            data.putString(KeychainIntentService.IMPORT_KEY_SERVER, cloudPrefs.keyserver);
+            data.putString(CloudImportService.IMPORT_KEY_SERVER, cloudPrefs.keyserver);
         }
 
-        data.putParcelableArrayList(KeychainIntentService.IMPORT_KEY_LIST, keyList);
+        data.putParcelableArrayList(CloudImportService.IMPORT_KEY_LIST, keyList);
 
-        intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
+        intent.putExtra(CloudImportService.EXTRA_DATA, data);
 
         // Create a new Messenger for the communication back
         Messenger messenger = new Messenger(serviceHandler);
-        intent.putExtra(KeychainIntentService.EXTRA_MESSENGER, messenger);
+        intent.putExtra(CloudImportService.EXTRA_MESSENGER, messenger);
 
         // show progress dialog
         serviceHandler.showProgressDialog(getActivity());
@@ -651,10 +650,11 @@ public class KeyListFragment extends LoaderFragment
 
     private void consolidate() {
         // Message is received after importing is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
                 getActivity(),
                 getString(R.string.progress_importing),
-                ProgressDialog.STYLE_HORIZONTAL) {
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
@@ -20,6 +20,7 @@ package org.sufficientlysecure.keychain.ui;
 
 import android.animation.ObjectAnimator;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -58,13 +59,17 @@ import com.getbase.floatingactionbutton.FloatingActionsMenu;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.keyimport.ImportKeysListEntry;
+import org.sufficientlysecure.keychain.keyimport.ParcelableKeyRing;
 import org.sufficientlysecure.keychain.operations.results.ConsolidateResult;
 import org.sufficientlysecure.keychain.operations.results.DeleteResult;
+import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.pgp.KeyRing;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.provider.KeychainDatabase;
+import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
 import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
 import org.sufficientlysecure.keychain.ui.dialog.DeleteKeyDialogFragment;
@@ -78,6 +83,7 @@ import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Preferences;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import se.emilsjolander.stickylistheaders.StickyListHeadersAdapter;
@@ -477,6 +483,10 @@ public class KeyListFragment extends LoaderFragment
                 mExportHelper.showExportKeysDialog(null, Constants.Path.APP_DIR_FILE, true);
                 return true;
 
+            case R.id.menu_key_list_update_all_keys:
+                updateAllKeys();
+                return true;
+
             case R.id.menu_key_list_debug_cons:
                 consolidate();
                 return true;
@@ -559,6 +569,84 @@ public class KeyListFragment extends LoaderFragment
     private void createKey() {
         Intent intent = new Intent(getActivity(), CreateKeyActivity.class);
         startActivityForResult(intent, 0);
+    }
+
+    private void updateAllKeys() {
+        Context context = this.getActivity();
+
+        ProviderHelper providerHelper = new ProviderHelper(context);
+
+        Cursor cursor = providerHelper.getContentResolver().query(
+                KeyRings.buildUnifiedKeyRingsUri(), new String[]{
+                        KeyRings.FINGERPRINT
+                }, null, null, null
+        );
+
+        ArrayList<ParcelableKeyRing> keyList = new ArrayList<>();
+
+        while (cursor.moveToNext()) {
+            byte[] blob = cursor.getBlob(0);//fingerprint column is 0
+            String fingerprint = KeyFormattingUtils.convertFingerprintToHex(blob);
+            ParcelableKeyRing keyEntry = new ParcelableKeyRing(fingerprint, null, null);
+            keyList.add(keyEntry);
+        }
+
+        KeychainIntentServiceHandler serviceHandler = new KeychainIntentServiceHandler(
+                getActivity(),
+                getString(R.string.progress_importing),
+                ProgressDialog.STYLE_HORIZONTAL,
+                true) {
+            public void handleMessage(Message message) {
+                // handle messages by standard KeychainIntentServiceHandler first
+                super.handleMessage(message);
+
+                if (message.arg1 == MessageStatus.OKAY.ordinal()) {
+                    // get returned data bundle
+                    Bundle returnData = message.getData();
+                    if (returnData == null) {
+                        return;
+                    }
+                    final ImportKeyResult result =
+                            returnData.getParcelable(OperationResult.EXTRA_RESULT);
+                    if (result == null) {
+                        Log.e(Constants.TAG, "result == null");
+                        return;
+                    }
+
+                    result.createNotify(KeyListFragment.this.getActivity()).show();
+                }
+            }
+        };
+
+        // Send all information needed to service to query keys in other thread
+        Intent intent = new Intent(getActivity(), KeychainIntentService.class);
+
+        intent.setAction(KeychainIntentService.ACTION_IMPORT_KEYRING);
+
+        // fill values for this action
+        Bundle data = new Bundle();
+
+        // search config
+        {
+            Preferences prefs = Preferences.getPreferences(getActivity());
+            Preferences.CloudSearchPrefs cloudPrefs =
+                    new Preferences.CloudSearchPrefs(true, true, prefs.getPreferredKeyserver());
+            data.putString(KeychainIntentService.IMPORT_KEY_SERVER, cloudPrefs.keyserver);
+        }
+
+        data.putParcelableArrayList(KeychainIntentService.IMPORT_KEY_LIST, keyList);
+
+        intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
+
+        // Create a new Messenger for the communication back
+        Messenger messenger = new Messenger(serviceHandler);
+        intent.putExtra(KeychainIntentService.EXTRA_MESSENGER, messenger);
+
+        // show progress dialog
+        serviceHandler.showProgressDialog(getActivity());
+
+        // start service with intent
+        getActivity().startService(intent);
     }
 
     private void consolidate() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SafeSlingerActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SafeSlingerActivity.java
@@ -39,7 +39,8 @@ import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.ParcelableFileCache;
@@ -123,11 +124,12 @@ public class SafeSlingerActivity extends BaseActivity {
             final FragmentActivity activity = SafeSlingerActivity.this;
 
             // Message is received after importing is done in KeychainIntentService
-            KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(
+            ServiceProgressHandler saveHandler = new ServiceProgressHandler(
                     activity,
                     getString(R.string.progress_importing),
                     ProgressDialog.STYLE_HORIZONTAL,
-                    true) {
+                    true,
+                    ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
                 public void handleMessage(Message message) {
                     // handle messages by standard KeychainIntentServiceHandler first
                     super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/UploadKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/UploadKeyActivity.java
@@ -36,7 +36,8 @@ import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Preferences;
 
@@ -107,8 +108,11 @@ public class UploadKeyActivity extends BaseActivity {
         intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
 
         // Message is received after uploading is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(this,
-                getString(R.string.progress_uploading), ProgressDialog.STYLE_HORIZONTAL) {
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(
+                this,
+                getString(R.string.progress_uploading),
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyActivity.java
@@ -63,8 +63,8 @@ import org.sufficientlysecure.keychain.pgp.exception.PgpKeyNotFoundException;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler.MessageStatus;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler.MessageStatus;
 import org.sufficientlysecure.keychain.service.PassphraseCacheService;
 import org.sufficientlysecure.keychain.ui.dialog.DeleteKeyDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.FormattingUtils;
@@ -387,7 +387,7 @@ public class ViewKeyActivity extends BaseActivity implements
 
     private void startCertifyIntent(Intent intent) {
         // Message is received after signing is done in KeychainIntentService
-        KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(this) {
+        ServiceProgressHandler saveHandler = new ServiceProgressHandler(this) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);
@@ -562,7 +562,7 @@ public class ViewKeyActivity extends BaseActivity implements
         entries.add(keyEntry);
 
         // Message is received after importing is done in KeychainIntentService
-        KeychainIntentServiceHandler serviceHandler = new KeychainIntentServiceHandler(this) {
+        ServiceProgressHandler serviceHandler = new ServiceProgressHandler(this) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
@@ -50,12 +50,12 @@ import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.util.Log;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -362,23 +362,26 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
 
         // Create a new Messenger for the communication back after proof work is done
         //
-        KeychainIntentServiceHandler handler = new KeychainIntentServiceHandler(getActivity(),
-                getString(R.string.progress_verifying_signature), ProgressDialog.STYLE_HORIZONTAL) {
+        ServiceProgressHandler handler = new ServiceProgressHandler(
+                getActivity(),
+                getString(R.string.progress_verifying_signature),
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);
 
                 if (message.arg1 == MessageStatus.OKAY.ordinal()) {
                     Bundle returnData = message.getData();
-                    String msg = returnData.getString(KeychainIntentServiceHandler.DATA_MESSAGE);
+                    String msg = returnData.getString(ServiceProgressHandler.DATA_MESSAGE);
                     SpannableStringBuilder ssb = new SpannableStringBuilder();
 
                     if ((msg != null) && msg.equals("OK")) {
 
                         //yay
-                        String proofUrl = returnData.getString(KeychainIntentServiceHandler.KEYBASE_PROOF_URL);
-                        String presenceUrl = returnData.getString(KeychainIntentServiceHandler.KEYBASE_PRESENCE_URL);
-                        String presenceLabel = returnData.getString(KeychainIntentServiceHandler.KEYBASE_PRESENCE_LABEL);
+                        String proofUrl = returnData.getString(ServiceProgressHandler.KEYBASE_PROOF_URL);
+                        String presenceUrl = returnData.getString(ServiceProgressHandler.KEYBASE_PRESENCE_URL);
+                        String presenceLabel = returnData.getString(ServiceProgressHandler.KEYBASE_PRESENCE_LABEL);
 
                         String proofLabel;
                         switch (proof.getType()) {
@@ -429,7 +432,7 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
                         ssb.append(" ").append(getString(R.string.keybase_contained_signature));
                     } else {
                         // verification failed!
-                        msg = returnData.getString(KeychainIntentServiceHandler.DATA_ERROR);
+                        msg = returnData.getString(ServiceProgressHandler.DATA_ERROR);
                         ssb.append(getString(R.string.keybase_proof_failure));
                         if (msg == null) {
                             msg = getString(R.string.keybase_unknown_proof_failure);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/DeleteKeyDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/DeleteKeyDialogFragment.java
@@ -37,7 +37,7 @@ import org.sufficientlysecure.keychain.pgp.KeyRing;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
 import org.sufficientlysecure.keychain.util.Log;
 
 import java.util.HashMap;
@@ -135,9 +135,12 @@ public class DeleteKeyDialogFragment extends DialogFragment {
                 intent.setAction(KeychainIntentService.ACTION_DELETE);
 
                 // Message is received after importing is done in KeychainIntentService
-                KeychainIntentServiceHandler saveHandler = new KeychainIntentServiceHandler(
-                        getActivity(), getString(R.string.progress_deleting),
-                        ProgressDialog.STYLE_HORIZONTAL, true) {
+                ServiceProgressHandler saveHandler = new ServiceProgressHandler(
+                        getActivity(),
+                        getString(R.string.progress_deleting),
+                        ProgressDialog.STYLE_HORIZONTAL,
+                        true,
+                        ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
                     @Override
                     public void handleMessage(Message message) {
                         super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ExportHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ExportHelper.java
@@ -19,9 +19,7 @@ package org.sufficientlysecure.keychain.util;
 
 import android.app.ProgressDialog;
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.Message;
 import android.os.Messenger;
 import android.support.v4.app.FragmentActivity;
@@ -29,11 +27,9 @@ import android.support.v4.app.FragmentActivity;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.operations.results.ExportResult;
-import org.sufficientlysecure.keychain.pgp.exception.PgpKeyNotFoundException;
-import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.service.KeychainIntentService;
-import org.sufficientlysecure.keychain.service.KeychainIntentServiceHandler;
-import org.sufficientlysecure.keychain.ui.dialog.DeleteKeyDialogFragment;
+import org.sufficientlysecure.keychain.service.ServiceProgressHandler;
+import org.sufficientlysecure.keychain.ui.dialog.ProgressDialogFragment;
 
 import java.io.File;
 
@@ -102,9 +98,10 @@ public class ExportHelper {
         intent.putExtra(KeychainIntentService.EXTRA_DATA, data);
 
         // Message is received after exporting is done in KeychainIntentService
-        KeychainIntentServiceHandler exportHandler = new KeychainIntentServiceHandler(mActivity,
+        ServiceProgressHandler exportHandler = new ServiceProgressHandler(mActivity,
                 mActivity.getString(R.string.progress_exporting),
-                ProgressDialog.STYLE_HORIZONTAL) {
+                ProgressDialog.STYLE_HORIZONTAL,
+                ProgressDialogFragment.ServiceType.KEYCHAIN_INTENT) {
             public void handleMessage(Message message) {
                 // handle messages by standard KeychainIntentServiceHandler first
                 super.handleMessage(message);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ParcelableFileCache.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ParcelableFileCache.java
@@ -83,10 +83,22 @@ public class ParcelableFileCache<E extends Parcelable> {
 
     }
 
+    /**
+     * Reads from cache file and deletes it afterward. Convenience function for readCache(boolean).
+     * @return an IteratorWithSize object containing entries read from the cache file
+     * @throws IOException
+     */
     public IteratorWithSize<E> readCache() throws IOException {
         return readCache(true);
     }
 
+    /**
+     * Reads entries from a cache file and returns an IteratorWithSize object containing the entries
+     * @param deleteAfterRead if true, the cache file will be deleted after being read
+     * @return an IteratorWithSize object containing entries read from the cache file
+     * @throws IOException if cache directory/parcel import file does not exist, or a read error
+     * occurs
+     */
     public IteratorWithSize<E> readCache(final boolean deleteAfterRead) throws IOException {
 
         File cacheDir = mContext.getCacheDir();

--- a/OpenKeychain/src/main/res/menu/key_list.xml
+++ b/OpenKeychain/src/main/res/menu/key_list.xml
@@ -20,6 +20,11 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_key_list_update_all_keys"
+        android:title="@string/menu_update_all_keys"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_key_list_debug_cons"
         android:title="Debug / Consolidate"
         android:visible="false"

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="menu_add_keys">"Add keys"</string>
     <string name="menu_search_cloud">"Search cloud"</string>
     <string name="menu_export_all_keys">"Export all keys"</string>
+    <string name="menu_update_all_keys">"Update all keys"</string>
     <string name="menu_advanced">"Show advanced info"</string>
     <string name="menu_certify_fingerprint">"Confirm via fingerprint comparison"</string>
     <string name="menu_export_log">"Export Log"</string>
@@ -316,6 +317,7 @@
     <string name="progress_cancelling">"cancelling…"</string>
     <string name="progress_saving">"saving…"</string>
     <string name="progress_importing">"importing…"</string>
+    <string name="progress_updating">"Updating keys…"</string>
     <string name="progress_exporting">"exporting…"</string>
     <string name="progress_uploading">"uploading…"</string>
     <string name="progress_building_key">"building key…"</string>


### PR DESCRIPTION
Added:
1. Support for multi-threaded key import when importing from the cloud.
2. An "Update all keys" option in the overflow menu of KeyListFragment.

This was just a quick patch I tried it to see how many threads we could run at a time while importing keys from the cloud. I've used a CachedThreadPool limited to 200 threads as of now, and there seemed to be no issues refreshing 174 keys.

I've introduced the multi-threading in KeychainIntentService currently - which I guess isn't a good idea since IntentServices are not really meant to spawn more threads, as the service dies as soon as it has no more work to do. The spawned threads talk back to the activity via the callbacks, but allowing the "Cancel" intent from the activity to reach the spawned threads required making the AtomicBoolean variable holding the "canceled" state static. This is because the worker thread belonging to the service dies as soon as it finishes spawning the key import threads, and only the static variable can be shared.

The only reason I tried it out in the IntentService was so that we could immediately observe the change on importing keys from the cloud (extremely fast: 173 keys in around 30 seconds).

Should I shift the entire multi-threaded key import to a separate thread/service or leave it here for now? Is there anything else I should be doing to get it right?