### PR TITLE
Fixed symmetric encryption crash

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptTextActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptTextActivity.java
@@ -136,7 +136,9 @@ public class EncryptTextActivity extends EncryptActivity implements EncryptActiv
 
     @Override
     public void setPassphrase(Passphrase passphrase) {
-        mPassphrase.removeFromMemory();
+        if (mPassphrase != null) {
+            mPassphrase.removeFromMemory();
+        }
         mPassphrase = passphrase;
     }
 


### PR DESCRIPTION
This is a fix for #1173.

During comparison of the two passphrase fields, the activity passphrase is set to null, if the two fields do not match. This causes an issue when entering the second character, at which point the `removeFromMemory()` method is called on the null passphrase. 

An empty passphrase would have been an elegant solution, but the input validation logic expects the passphrase to be null if the inputted passphrases do not match. So a simple null check in the setter will have to do.