### PR TITLE
-Fixed a situation where additional emails could be duplicated when crea...

### DIFF
--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -629,6 +629,7 @@
     <string name="create_key_edit">"Change key configuration"</string>
     <string name="create_key_add_email">"Add email address"</string>
     <string name="create_key_add_email_text">"Additional email addresses are also associated to this key and can be used for secure communication."</string>
+    <string name="create_key_email_already_exists_text">"Email has already been added"</string>
 
     <!-- View key -->
     <string name="view_key_revoked">"Revoked: Key must not be used anymore!"</string>


### PR DESCRIPTION
...ting a new key -If CreateKeyEmailFragment view is recreated, the array of additional emails won't be repopulated again if its not null, avoiding new reallocations. -if CreateKeyEmailFragment view is recreated, the email adapter wont be recreated if its not null, avoiding new reallocations.