### PR TITLE
Corrected import error message, changed style to WARN

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/ImportKeyResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/ImportKeyResult.java
@@ -162,7 +162,7 @@ public class ImportKeyResult extends OperationResult {
             if (isOkWithErrors()) {
                 // definitely switch to warning-style message in this case!
                 duration = 0;
-                style = Style.ERROR;
+                style = Style.WARN;
                 str += " " + activity.getResources().getQuantityString(
                         R.plurals.import_keys_with_errors, mBadKeys, mBadKeys);
             }
@@ -175,7 +175,10 @@ public class ImportKeyResult extends OperationResult {
                         ? R.string.import_error_nothing_cancelled
                         : R.string.import_error_nothing);
             } else {
-                str = activity.getResources().getQuantityString(R.plurals.import_error, mBadKeys);
+                str = activity.getResources().getQuantityString(
+                        R.plurals.import_error,
+                        mBadKeys,
+                        mBadKeys);
             }
         }
 


### PR DESCRIPTION
If an import operation for multiple keys fails for all, we get an incorrect "Import of %d keys failed!" message. Just had to add a missing parameter.
For reference:
Old:
![screenshot_2015-03-28-19-56-42](https://cloud.githubusercontent.com/assets/5712241/6881739/55cb68dc-d592-11e4-851b-f4111500fca0.png)

New:
![screenshot_2015-03-28-21-33-35](https://cloud.githubusercontent.com/assets/5712241/6881738/53c6ff2e-d592-11e4-85fc-ccee23b3b17d.png)

A comment recommended switching to the warning style in case some keys succeed but others fail. Changed that too.
