### PR TITLE
Immediate display of contact card, fixed contact picture display issue, hides card if no contact

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ContactHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ContactHelper.java
@@ -27,7 +27,6 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.ContactsContract;
 import android.util.Patterns;
 
@@ -405,8 +404,7 @@ public class ContactHelper {
         // openContactPhotoInputStream
         // http://stackoverflow.com/a/21214524/3000919
         // Uri lookupUri = ContactsContract.Contacts.getLookupUri(contentResolver, contactUri);
-        // also, we aren't storing the contact image for long term use. Hence it is okay to use
-        // contactUri.
+        // Also, we don't need a permanent shortcut to the contact since we load it afresh each time
 
         InputStream photoInputStream = ContactsContract.Contacts.openContactPhotoInputStream(
                 contentResolver,

--- a/OpenKeychain/src/main/res/layout/view_key_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/view_key_fragment.xml
@@ -46,6 +46,7 @@
             android:layout_gravity="center"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:visibility="gone"
             card_view:cardBackgroundColor="@android:color/white"
             card_view:cardElevation="2dp"
             card_view:cardUseCompatPadding="true"


### PR DESCRIPTION
Changes:
1. Shows linked contact card immediately on key verification.
2. Fixed issue with contact picture not being displayed on older devices (due to lookupUri) (tested on API level 15, http://stackoverflow.com/a/21214524/3000919).
3. Provides a fix for Issue https://github.com/open-keychain/open-keychain/issues/1176 (hide linked system contact card), which is contained to `ViewKeyFragment` and does not require changes to the enclosing activity.