### PR TITLE
Fix for NFC signing operations: move PIN verify inside sign/decrypt operation and set correct mode.

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseNfcActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseNfcActivity.java
@@ -301,28 +301,7 @@ public abstract class BaseNfcActivity extends BaseActivity {
      * @return a big integer representing the MPI for the given hash
      */
     public byte[] nfcCalculateSignature(byte[] hash, int hashAlgo) throws IOException {
-
-        if (mPin != null) {
-
-            byte[] pin = new String(mPin.getCharArray()).getBytes();
-            // SW1/2 0x9000 is the generic "ok" response, which we expect most of the time.
-            // See specification, page 51
-            String accepted = "9000";
-
-            // Command APDU for VERIFY command (page 32)
-            String login =
-            "00" // CLA
-            + "20" // INS
-            + "00" // P1
-            + "81" // P2 (PW1 with mode 81 for signing)
-            + String.format("%02x", pin.length) // Lc
-            + Hex.toHexString(pin);
-            if (!nfcCommunicate(login).equals(accepted)) { // login
-                handlePinError();
-                throw new IOException("Bad PIN!");
-            }
-
-        }
+        nfcVerifyPIN(0x81); // (Verify PW1 with mode 81 for signing)
 
         // dsi, including Lc
         String dsi;
@@ -416,28 +395,7 @@ public abstract class BaseNfcActivity extends BaseActivity {
      * @return the decoded session key
      */
     public byte[] nfcDecryptSessionKey(byte[] encryptedSessionKey) throws IOException {
-
-        if (mPin != null) {
-
-            byte[] pin = new String(mPin.getCharArray()).getBytes();
-            // SW1/2 0x9000 is the generic "ok" response, which we expect most of the time.
-            // See specification, page 51
-            String accepted = "9000";
-
-            // Command APDU for VERIFY command (page 32)
-            String login =
-            "00" // CLA
-            + "20" // INS
-            + "00" // P1
-            + "82" // P2 (PW1 with mode 82 for decryption)
-            + String.format("%02x", pin.length) // Lc
-            + Hex.toHexString(pin);
-            if (!nfcCommunicate(login).equals(accepted)) { // login
-                handlePinError();
-                throw new IOException("Bad PIN!");
-            }
-
-        }
+        nfcVerifyPIN(0x82); // (Verify PW1 with mode 82 for decryption)
 
         String firstApdu = "102a8086fe";
         String secondApdu = "002a808603";
@@ -460,6 +418,32 @@ public abstract class BaseNfcActivity extends BaseActivity {
         Log.d(Constants.TAG, "decryptedSessionKey: " + decryptedSessionKey);
 
         return Hex.decode(decryptedSessionKey);
+    }
+
+    /** Verifies the user's PW1 with the appropriate mode.
+     *
+     * @param mode This is 0x81 for signing, 0x82 for everything else
+     */
+    public void nfcVerifyPIN(int mode) throws IOException {
+        if (mPin != null) {
+            byte[] pin = new String(mPin.getCharArray()).getBytes();
+            // SW1/2 0x9000 is the generic "ok" response, which we expect most of the time.
+            // See specification, page 51
+            String accepted = "9000";
+
+            // Command APDU for VERIFY command (page 32)
+            String login =
+            "00" // CLA
+            + "20" // INS
+            + "00" // P1
+            + String.format("%02x", mode) // P2
+            + String.format("%02x", pin.length) // Lc
+            + Hex.toHexString(pin);
+            if (!nfcCommunicate(login).equals(accepted)) { // login
+                handlePinError();
+                throw new IOException("Bad PIN!");
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
According to the OpenPGP spec, PW1 must be submitted with mode 81 for a signing operation, and mode 82 for everything else. OpenKeychain currently verifies the PW1 with mode 82 all the time. OpenPGP-compliant cards will not issue a signature when the PW1 is submitted with mode 82. 

The reason this hasn't been broken is that the only widespread OpenPGP device with NFC, the Yubikey NEO, had a bug that allowed signatures to be generated without a verified PIN. Yubico has fixed this bug as of today, and issued [a security advisory](https://github.com/Yubico/ykneo-openpgp/blob/master/doc/SecurityAdvisory%202015-04-14.txt). New Yubikeys NEO will throw an error when signing is attempted after VERIFY PW1 with mode 82. 

This patch moves the PIN verification from the ```handleNdefDiscoveredIntent``` into a new method called ```nfcVerifyPIN```, which takes as a parameter the mode of operation. The new method is called from the sign and decrypt methods, so that the PIN can be submitted with the proper mode for the requested operation. If the PIN verification fails, an IOException is thrown, which is caught and passed to ```handleNfcError```. 

I've tested this on a Nexus 7, which is the only NFC-equipped Android device I have on hand, but I would welcome additional testing.