### PR TITLE
support for handling keyserver urls from browser, added documentation

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -624,6 +624,23 @@
                 <data android:pathPattern=".*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\..*\\.bin" />
             </intent-filter>
 
+            <!-- VIEW from keyserver urls opened in a browser -->
+            <intent-filter android:label="@string/intent_import_key">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="https"/>
+                <data android:scheme="http"/>
+                <!-- if we don't specify a host, pathPattern will be ignored-->
+                <data android:host="*"/>
+                <!-- convention for keyserver paths specified by internet draft
+                 draft-shaw-openpgp-hkp-00.txt
+                 (http://tools.ietf.org/html/draft-shaw-openpgp-hkp-00#section-3) -->
+                <data android:pathPattern="/pks/lookup.*"/>
+            </intent-filter>
+
             <!-- Keychain's own Actions -->
             <!-- IMPORT_KEY with files TODO: does this work? -->
             <intent-filter android:label="@string/intent_import_key">

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyYubiImportFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyYubiImportFragment.java
@@ -123,7 +123,8 @@ public class CreateKeyYubiImportFragment extends Fragment implements NfcListener
             });
         }
 
-        mListFragment = ImportKeysListFragment.newInstance(null, null, "0x" + mNfcFingerprint, true);
+        mListFragment = ImportKeysListFragment.newInstance(null, null,
+                "0x" + mNfcFingerprint, true, null);
 
         view.findViewById(R.id.button_search).setOnClickListener(new OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysCloudFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysCloudFragment.java
@@ -45,6 +45,7 @@ import java.util.List;
 public class ImportKeysCloudFragment extends Fragment {
     public static final String ARG_QUERY = "query";
     public static final String ARG_DISABLE_QUERY_EDIT = "disable_query_edit";
+    public static final String ARG_KEYSERVER = "keyserver";
 
     private ImportKeysActivity mImportActivity;
 
@@ -54,13 +55,20 @@ public class ImportKeysCloudFragment extends Fragment {
 
     /**
      * Creates new instance of this fragment
+     *
+     * @param query            query to search for
+     * @param disableQueryEdit if true, user cannot edit query
+     * @param keyserver        specified keyserver authority to use. If null, will use keyserver
+     *                         specified in user preferences
      */
-    public static ImportKeysCloudFragment newInstance(String query, boolean disableQueryEdit) {
+    public static ImportKeysCloudFragment newInstance(String query, boolean disableQueryEdit,
+                                                      String keyserver) {
         ImportKeysCloudFragment frag = new ImportKeysCloudFragment();
 
         Bundle args = new Bundle();
         args.putString(ARG_QUERY, query);
         args.putBoolean(ARG_DISABLE_QUERY_EDIT, disableQueryEdit);
+        args.putString(ARG_KEYSERVER, keyserver);
 
         frag.setArguments(args);
 
@@ -151,8 +159,17 @@ public class ImportKeysCloudFragment extends Fragment {
     }
 
     private void search(String query) {
-        Preferences prefs = Preferences.getPreferences(getActivity());
-        mImportActivity.loadCallback(new ImportKeysListFragment.CloudLoaderState(query, prefs.getCloudSearchPrefs()));
+        Preferences.CloudSearchPrefs cloudSearchPrefs;
+        String explicitKeyserver = getArguments().getString(ARG_KEYSERVER);
+        // no explicit keyserver passed
+        if (explicitKeyserver == null) {
+            cloudSearchPrefs = Preferences.getPreferences(getActivity()).getCloudSearchPrefs();
+        } else {
+            // assume we are also meant to search keybase.io
+            cloudSearchPrefs = new Preferences.CloudSearchPrefs(true, true, explicitKeyserver);
+        }
+        mImportActivity.loadCallback(
+                new ImportKeysListFragment.CloudLoaderState(query, cloudSearchPrefs));
         toggleKeyboard(false);
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysListFragment.java
@@ -58,6 +58,7 @@ public class ImportKeysListFragment extends ListFragment implements
     private static final String ARG_BYTES = "bytes";
     public static final String ARG_SERVER_QUERY = "query";
     public static final String ARG_NON_INTERACTIVE = "non_interactive";
+    public static final String ARG_KEYSERVER_URL = "keyserver_url";
 
     private Activity mActivity;
     private ImportKeysAdapter mAdapter;
@@ -78,7 +79,8 @@ public class ImportKeysListFragment extends ListFragment implements
         return mAdapter.getData();
     }
 
-    /** Returns an Iterator (with size) of the selected data items.
+    /**
+     * Returns an Iterator (with size) of the selected data items.
      * This iterator is sort of a tradeoff, it's slightly more complex than an
      * ArrayList would have been, but we save some memory by just returning
      * relevant elements on demand.
@@ -121,12 +123,36 @@ public class ImportKeysListFragment extends ListFragment implements
 
     }
 
-    public static ImportKeysListFragment newInstance(byte[] bytes, Uri dataUri, String serverQuery) {
-        return newInstance(bytes, dataUri, serverQuery, false);
+    /**
+     * Creates an interactive ImportKeyListFragment which reads keyrings from bytes, or file specified
+     * by dataUri, or searches a keyserver for serverQuery, if parameter is not null, in that order
+     *
+     * @param bytes       byte data containing list of keyrings to be imported
+     * @param dataUri     file from which keyrings are to be imported
+     * @param serverQuery query to search for on keyserver
+     * @param keyserver   if not null, will perform search on specified keyserver. Else, uses
+     *                    keyserver specified in user preferences
+     * @return fragment with arguments set based on passed parameters
+     */
+    public static ImportKeysListFragment newInstance(byte[] bytes, Uri dataUri, String serverQuery,
+                                                     String keyserver) {
+        return newInstance(bytes, dataUri, serverQuery, false, keyserver);
     }
 
-    public static ImportKeysListFragment newInstance(byte[] bytes, Uri dataUri,
-            String serverQuery, boolean nonInteractive) {
+    /**
+     * Visually consists of a list of keyrings with checkboxes to specify which are to be imported
+     * Can immediately load keyrings specified by any of its parameters
+     *
+     * @param bytes          byte data containing list of keyrings to be imported
+     * @param dataUri        file from which keyrings are to be imported
+     * @param serverQuery    query to search for on keyserver
+     * @param nonInteractive if true, users will not be able to check/uncheck items in the list
+     * @param keyserver      if set, will perform search on specified keyserver. If null, falls back
+     *                       to keyserver specified in user preferences
+     * @return fragment with arguments set based on passed parameters
+     */
+    public static ImportKeysListFragment newInstance(byte[] bytes, Uri dataUri, String serverQuery,
+                                                     boolean nonInteractive, String keyserver) {
         ImportKeysListFragment frag = new ImportKeysListFragment();
 
         Bundle args = new Bundle();
@@ -134,6 +160,7 @@ public class ImportKeysListFragment extends ListFragment implements
         args.putParcelable(ARG_DATA_URI, dataUri);
         args.putString(ARG_SERVER_QUERY, serverQuery);
         args.putBoolean(ARG_NON_INTERACTIVE, nonInteractive);
+        args.putString(ARG_KEYSERVER_URL, keyserver);
 
         frag.setArguments(args);
 
@@ -180,16 +207,23 @@ public class ImportKeysListFragment extends ListFragment implements
         setListAdapter(mAdapter);
 
         Bundle args = getArguments();
-        Uri dataUri = args.containsKey(ARG_DATA_URI) ? args.<Uri>getParcelable(ARG_DATA_URI) : null;
-        byte[] bytes = args.containsKey(ARG_BYTES) ? args.getByteArray(ARG_BYTES) : null;
-        String query = args.containsKey(ARG_SERVER_QUERY) ? args.getString(ARG_SERVER_QUERY) : null;
-        mNonInteractive = args.containsKey(ARG_NON_INTERACTIVE) ? args.getBoolean(ARG_NON_INTERACTIVE) : false;
+        Uri dataUri = args.getParcelable(ARG_DATA_URI);
+        byte[] bytes = args.getByteArray(ARG_BYTES);
+        String query = args.getString(ARG_SERVER_QUERY);
+        String keyserver = args.getString(ARG_KEYSERVER_URL);
+        mNonInteractive = args.getBoolean(ARG_NON_INTERACTIVE, false);
 
         if (dataUri != null || bytes != null) {
             mLoaderState = new BytesLoaderState(bytes, dataUri);
         } else if (query != null) {
-            Preferences prefs = Preferences.getPreferences(getActivity());
-            mLoaderState = new CloudLoaderState(query, prefs.getCloudSearchPrefs());
+            Preferences.CloudSearchPrefs cloudSearchPrefs;
+            if (keyserver != null) {
+                cloudSearchPrefs = Preferences.getPreferences(getActivity()).getCloudSearchPrefs();
+            } else {
+                cloudSearchPrefs = new Preferences.CloudSearchPrefs(true, true, keyserver);
+            }
+
+            mLoaderState = new CloudLoaderState(query, cloudSearchPrefs);
         }
 
         getListView().setOnTouchListener(new OnTouchListener() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysListLoader.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysListLoader.java
@@ -82,12 +82,12 @@ public class ImportKeysListLoader
 
     @Override
     protected void onStartLoading() {
-        forceLoad();
+        super.forceLoad();
     }
 
     @Override
     protected void onStopLoading() {
-        cancelLoad();
+        super.cancelLoad();
     }
 
     @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -193,6 +193,11 @@ public class Preferences {
         public final boolean searchKeybase;
         public final String keyserver;
 
+        /**
+         * @param searchKeyserver should passed keyserver be searched
+         * @param searchKeybase   should keybase.io be searched
+         * @param keyserver       the keyserver url authority to search on
+         */
         public CloudSearchPrefs(boolean searchKeyserver, boolean searchKeybase, String keyserver) {
             this.searchKeyserver = searchKeyserver;
             this.searchKeybase = searchKeybase;

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -404,6 +404,9 @@
     <string name="import_qr_code_button">"Scan QR Code"</string>
     <string name="import_qr_code_text">"Place your camera over the QR Code!"</string>
 
+    <!-- Import from URL -->
+    <string name="import_url_warn_no_search_parameter">"No search parameter found. You may still attempt manually searching the keyserver."</string>
+
     <!-- Generic result toast -->
     <string name="view_log">"Details"</string>
     <string name="with_warnings">", with warnings"</string>


### PR DESCRIPTION
Takes care of Issue https://github.com/open-keychain/open-keychain/issues/1199.

It's been written to handle all keyserver URLs based on the presence of /pks/lookup in the path, as specified in http://tools.ietf.org/html/draft-shaw-openpgp-hkp-00#section-3, not just https://hkps.pool.sks-keyservers.net or the ones the user has added on Openkeychain.

I've enabled searching through keybase.io by default when we handle a keyserver search from a URL.

A possible addition would be:
When the user clicks on a URL and it's a keyserver he hasn't registered on Openkeychain yet, we offer the option to add it to his list of keyservers.