### PR TITLE
Maintain client-side state for PIN verification operations

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseNfcActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseNfcActivity.java
@@ -57,6 +57,9 @@ public abstract class BaseNfcActivity extends BaseActivity {
     public static final int REQUEST_CODE_PASSPHRASE = 1;
 
     protected Passphrase mPin;
+    protected boolean mPw1ValidForMultipleSignatures;
+    protected boolean mPw1ValidatedForSignature;
+    protected boolean mPw1ValidatedForDecrypt; // Mode 82 does other things; consider renaming?
     private NfcAdapter mNfcAdapter;
     private IsoDep mIsoDep;
 
@@ -201,6 +204,11 @@ public abstract class BaseNfcActivity extends BaseActivity {
             throw new IOException("Initialization failed!");
         }
 
+        byte[] pwStatusBytes = nfcGetPwStatusBytes();
+        mPw1ValidForMultipleSignatures = (pwStatusBytes[0] == 1);
+        mPw1ValidatedForSignature = false;
+        mPw1ValidatedForDecrypt = false;
+
         onNfcPerform();
 
         mIsoDep.close();
@@ -278,6 +286,15 @@ public abstract class BaseNfcActivity extends BaseActivity {
         return fptlv.mV;
     }
 
+    /** Return the PW Status Bytes from the card. This is a simple DO; no TLV decoding needed.
+     *
+     * @return Seven bytes in fixed format, plus 0x9000 status word at the end.
+     */
+    public byte[] nfcGetPwStatusBytes() throws IOException {
+        String data = "00CA00C400";
+        return mIsoDep.transceive(Hex.decode(data));
+    }
+
     /** Return the fingerprint from application specific data stored on tag, or
      * null if it doesn't exist.
      *
@@ -316,7 +333,9 @@ public abstract class BaseNfcActivity extends BaseActivity {
      * @return a big integer representing the MPI for the given hash
      */
     public byte[] nfcCalculateSignature(byte[] hash, int hashAlgo) throws IOException {
-        nfcVerifyPIN(0x81); // (Verify PW1 with mode 81 for signing)
+        if (!mPw1ValidatedForSignature) {
+            nfcVerifyPIN(0x81); // (Verify PW1 with mode 81 for signing)
+        }
 
         // dsi, including Lc
         String dsi;
@@ -391,6 +410,10 @@ public abstract class BaseNfcActivity extends BaseActivity {
 
         Log.d(Constants.TAG, "final response:" + status);
 
+        if (!mPw1ValidForMultipleSignatures) {
+            mPw1ValidatedForSignature = false;
+        }
+
         if ( ! "9000".equals(status)) {
             throw new IOException("Bad NFC response code: " + status);
         }
@@ -410,7 +433,9 @@ public abstract class BaseNfcActivity extends BaseActivity {
      * @return the decoded session key
      */
     public byte[] nfcDecryptSessionKey(byte[] encryptedSessionKey) throws IOException {
-        nfcVerifyPIN(0x82); // (Verify PW1 with mode 82 for decryption)
+        if (!mPw1ValidatedForDecrypt) {
+            nfcVerifyPIN(0x82); // (Verify PW1 with mode 82 for decryption)
+        }
 
         String firstApdu = "102a8086fe";
         String secondApdu = "002a808603";
@@ -457,6 +482,12 @@ public abstract class BaseNfcActivity extends BaseActivity {
             if (!nfcCommunicate(login).equals(accepted)) { // login
                 handlePinError();
                 throw new IOException("Bad PIN!");
+            }
+
+            if (mode == 0x81) {
+                mPw1ValidatedForSignature = true;
+            } else if (mode == 0x82) {
+                mPw1ValidatedForDecrypt = true;
             }
         }
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseNfcActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseNfcActivity.java
@@ -200,7 +200,7 @@ public abstract class BaseNfcActivity extends BaseActivity {
                         + "06" // Lc (number of bytes)
                         + "D27600012401" // Data (6 bytes)
                         + "00"; // Le
-        if ( ! nfcCommunicate(opening).equals(accepted)) { // activate connection
+        if ( ! nfcCommunicate(opening).endsWith(accepted)) { // activate connection
             throw new IOException("Initialization failed!");
         }
 


### PR DESCRIPTION
This change adds three fields to BaseNfcActivity to track PIN verification. Two booleans track whether the PIN is verified for a given operation, and a third tracks whether the PIN must be resubmitted for every signature operation (page 32 of OpenPGP smart card spec). It also adds a method to query the PW status bytes for this information. 

This pull request also incorporates a separate commit with an unrelated fix when selecting the application. A successful SELECT FILE operation is indicated by the response ending with 9000, not being equal to 9000 (page 31 of OpenPGP smart card spec). The standard OpenPGP card includes file control information in the returned data field; this change is necessary to accommodate cards that implement this part of the spec. 