### PR TITLE
Raw "%s" showing up in "View Certificate Details"

### DIFF
--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -137,7 +137,7 @@
     <string name="label_file_compression">"File compression"</string>
     <string name="label_keyservers">"Keyservers"</string>
     <string name="label_key_id">"Key ID"</string>
-    <string name="label_creation">"Key created %s"</string>
+    <string name="label_creation">"Key created"</string>
     <string name="label_expiry">"Expiry"</string>
     <string name="label_usage">"Usage"</string>
     <string name="label_key_size">"Key Size"</string>


### PR DESCRIPTION
The actual string "%s" was showing up in the UI for "View Certificate Details"