### PR TITLE
updated robolectric to support new android support libs

### DIFF
--- a/OpenKeychain-Test/build.gradle
+++ b/OpenKeychain-Test/build.gradle
@@ -17,7 +17,8 @@ dependencies {
     testCompile 'junit:junit:4.11'
     testCompile 'com.google.android:android:4.1.1.4'
     testCompile('com.squareup:fest-android:1.0.8') { exclude module: 'support-v4' }
-    testCompile ('org.robolectric:robolectric:2.3') {
+    testCompile 'org.apache.maven:maven-ant-tasks:2.1.3'
+    testCompile ('org.robolectric:robolectric:2.4') {
         exclude module: 'classworlds'
         exclude module: 'maven-artifact'
         exclude module: 'maven-artifact-manager'


### PR DESCRIPTION
Fixes #1239 

Updated robolectric also requires explicit import of maven-ant-tasks, otherwise this error results:

    java.lang.NoClassDefFoundError: org/apache/maven/artifact/ant/DependenciesTask