### PR TITLE
Prevent NaN Progress Dialog on import with no selected keys

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
@@ -384,6 +384,13 @@ public class ImportKeysActivity extends BaseNfcActivity {
      */
     public void importKeys() {
         ImportKeysListFragment.LoaderState ls = mListFragment.getLoaderState();
+
+        if (mListFragment.getSelectedEntries().size() == 0) {
+            Notify.create(this, R.string.error_nothing_import_selected, Notify.Style.ERROR)
+                    .show((ViewGroup) findViewById(R.id.import_snackbar));
+            return;
+        }
+
         if (ls instanceof ImportKeysListFragment.BytesLoaderState) {
             Log.d(Constants.TAG, "importKeys started");
 
@@ -488,9 +495,6 @@ public class ImportKeysActivity extends BaseNfcActivity {
 
             // start service with intent
             startService(intent);
-        } else {
-            Notify.create(this, R.string.error_nothing_import, Notify.Style.ERROR)
-                    .show((ViewGroup) findViewById(R.id.import_snackbar));
         }
     }
 

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -281,6 +281,7 @@
     <string name="error_nfc_needed">"NFC must be enabled!"</string>
     <string name="error_beam_needed">"Beam must be enabled!"</string>
     <string name="error_nothing_import">"No keys found!"</string>
+    <string name="error_nothing_import_selected">"No keys selected for import!"</string>
     <string name="error_contacts_key_id_missing">"Retrieving the key ID from contacts failed!"</string>
     <string name="error_generic_report_bug">"A generic error occurred, please create a new bug report for OpenKeychain."</string>
 


### PR DESCRIPTION
Prevents a non-cancelable  progress dialog from appearing if the "Import selected keys" button is pressed after either a cloud search or import from file is performed, but no key is selected.