### PR TITLE
Prevent NullPointerException due to Activity death

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
@@ -263,7 +263,7 @@ public class ImportKeysActivity extends BaseNfcActivity {
         // However, if we're being restored from a previous state,
         // then we don't need to do anything and should return or else
         // we could end up with overlapping fragments.
-        if (savedInstanceState != null) {
+        if (mListFragment != null) {
             return;
         }
 
@@ -283,7 +283,7 @@ public class ImportKeysActivity extends BaseNfcActivity {
         // However, if we're being restored from a previous state,
         // then we don't need to do anything and should return or else
         // we could end up with overlapping fragments.
-        if (savedInstanceState != null) {
+        if (mTopFragment != null) {
             return;
         }
 
@@ -314,7 +314,7 @@ public class ImportKeysActivity extends BaseNfcActivity {
         // However, if we're being restored from a previous state,
         // then we don't need to do anything and should return or else
         // we could end up with overlapping fragments.
-        if (savedInstanceState != null) {
+        if (mTopFragment != null) {
             return;
         }
 


### PR DESCRIPTION
If the activity is killed, and then resumed, `savedInstanceState` will not be null, but the fragment reference will be, causing a `NullPointerException` at `mListFragment.loadNew` on search.