### PR TITLE
Fixed fingerprint mismatch on web download of keys

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/UncachedKeyRing.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/UncachedKeyRing.java
@@ -219,7 +219,7 @@ public class UncachedKeyRing {
         Iterator<PGPPublicKey> it = mRing.getPublicKeys();
         while (it.hasNext()) {
             if (KeyFormattingUtils.convertFingerprintToHex(
-                    it.next().getFingerprint()).equals(expectedFingerprint)) {
+                    it.next().getFingerprint()).equalsIgnoreCase(expectedFingerprint)) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/open-keychain/open-keychain/issues/1365. Key query had fingerprint in caps but we use lower case internally.