### PR TITLE
Add debug app name

### DIFF
--- a/OpenKeychain/src/debug/res/values/strings.xml
+++ b/OpenKeychain/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">"OpenKeychain (Debug)"</string>
+</resources>

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -23,6 +23,8 @@ import org.spongycastle.bcpg.HashAlgorithmTags;
 import org.spongycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.spongycastle.jce.provider.BouncyCastleProvider;
 
+import org.sufficientlysecure.keychain.BuildConfig;
+
 import java.io.File;
 
 public final class Constants {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
@@ -34,6 +34,7 @@ import android.widget.Toast;
 
 import org.spongycastle.jce.provider.BouncyCastleProvider;
 import org.sufficientlysecure.keychain.provider.TemporaryStorageProvider;
+import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.ConsolidateDialogActivity;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.PRNGFixes;

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/WorkaroundBuildConfig.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/WorkaroundBuildConfig.java
@@ -1,5 +1,7 @@
 package org.sufficientlysecure.keychain;
 
+import org.sufficientlysecure.keychain.BuildConfig;
+
 /**
  * Temporary workaround for https://github.com/robolectric/robolectric/issues/1747
  */


### PR DESCRIPTION
That way debug builds can be distinguished from the release version by name as well.

Also a minor refactoring, explicitly importing "R" an "BuildConfig" by FQN where that wasn't the case.