### PR TITLE
Fixe Keyserver Preference crash on empty list

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
@@ -45,6 +45,7 @@ import org.sufficientlysecure.keychain.ui.util.recyclerview.ItemTouchHelperViewH
 import org.sufficientlysecure.keychain.ui.util.recyclerview.ItemTouchHelperDragCallback;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.recyclerview.RecyclerItemClickListener;
+import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Preferences;
 
 import java.util.ArrayList;
@@ -83,7 +84,6 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
 
         String keyservers[] = getArguments().getStringArray(ARG_KEYSERVER_ARRAY);
         mKeyservers = new ArrayList<>(Arrays.asList(keyservers));
-        saveKeyserverList(); // in case user does not make any changes
 
         mAdapter = new KeyserverListAdapter(mKeyservers);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
@@ -45,7 +45,6 @@ import org.sufficientlysecure.keychain.ui.util.recyclerview.ItemTouchHelperViewH
 import org.sufficientlysecure.keychain.ui.util.recyclerview.ItemTouchHelperDragCallback;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.recyclerview.RecyclerItemClickListener;
-import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Preferences;
 
 import java.util.ArrayList;
@@ -146,7 +145,7 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
                         if (deleted) {
                             Notify.create(getActivity(),
                                     getActivity().getString(
-                                            R.string.keyserver_deleted, mKeyservers.get(position)),
+                                            R.string.keyserver_preference_deleted, mKeyservers.get(position)),
                                     Notify.Style.OK)
                                     .show();
                             deleteKeyserver(position);
@@ -222,6 +221,11 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
     }
 
     private void deleteKeyserver(int position) {
+        if (mKeyservers.size() == 1) {
+            Notify.create(getActivity(), R.string.keyserver_preference_cannot_delete_last,
+                    Notify.Style.ERROR).show();
+            return;
+        }
         mKeyservers.remove(position);
         // we use this
         mAdapter.notifyItemRemoved(position);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -138,6 +138,9 @@ public class Preferences {
     public String[] getKeyServers() {
         String rawData = mSharedPreferences.getString(Constants.Pref.KEY_SERVERS,
                 Constants.Defaults.KEY_SERVERS);
+        if (rawData.equals("")) {
+            return new String[0];
+        }
         Vector<String> servers = new Vector<>();
         String chunks[] = rawData.split(",");
         for (String c : chunks) {
@@ -150,7 +153,8 @@ public class Preferences {
     }
 
     public String getPreferredKeyserver() {
-        return getKeyServers()[0];
+        String[] keyservers = getKeyServers();
+        return keyservers.length == 0 ? null : keyservers[0];
     }
 
     public void setKeyServers(String[] value) {

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -685,7 +685,8 @@
     <string name="add_keyserver_without_verification">"Keyserver added without verification."</string>
     <string name="add_keyserver_invalid_url">"Invalid URL!"</string>
     <string name="add_keyserver_connection_failed">"Failed to connect to keyserver. Please check the URL and your internet connection."</string>
-    <string name="keyserver_deleted">"%s deleted"</string>
+    <string name="keyserver_preference_deleted">"%s deleted"</string>
+    <string name="keyserver_preference_cannot_delete_last">"Cannot delete last keyserver. At least one is required!"</string>
 
     <!-- Navigation Drawer -->
     <string name="nav_keys">"Keys"</string>


### PR DESCRIPTION
Fixes https://github.com/open-keychain/open-keychain/issues/1398.
I've made it accept already existing empty keyserver preferences (in case someone updating has 0 keyservers), but it won't let you delete if you have only 1 keyserver. Having 0 keyservers was unchecked in all places where `getPreferredKeyserver` was being used. Since we were shifting to "at least 1 keyserver", I've left them that way, is that okay?