### PR TITLE
Check upload response code and throw AddKeyException

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/HkpKeyserver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/HkpKeyserver.java
@@ -399,6 +399,10 @@ public class HkpKeyserver extends Keyserver {
             Log.d(Constants.TAG, "response code: " + response.code());
             Log.d(Constants.TAG, "answer: " + response.body().string());
 
+            if (response.code() != 200) {
+                throw new AddKeyException();
+            }
+
         } catch (IOException e) {
             Log.e(Constants.TAG, "IOException", e);
             throw new AddKeyException();


### PR DESCRIPTION
`HkpKeyserver` now verifies that the upload succeeded. Earlier it was failing uploads only if there was an `IOException`. Does this help with https://github.com/open-keychain/open-keychain/issues/1436?