### PR TITLE
ISSUE #1304: Change keybase strings 

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
@@ -269,8 +269,12 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
         private SpannableStringBuilder insertLinks(SpannableStringBuilder proofLinks,String proofType){
             SpannableStringBuilder ssb = new SpannableStringBuilder();
             ssb.append(proofType);
-            int i = proofType.indexOf("%s");
-            ssb.replace(i,i+2,proofLinks);
+            if(proofType.contains("%s")){
+                int i = proofType.indexOf("%s");
+                ssb.replace(i,i+2,proofLinks);
+            }
+            else ssb.append(proofLinks);
+
             return ssb;
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
@@ -249,8 +249,6 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
                     Proof[] proofsFor = proofs.get(proofType).toArray(x);
                     if (proofsFor.length > 0) {
                         SpannableStringBuilder ssb = new SpannableStringBuilder();
-                        ssb.append(getProofNarrative(proofType)).append(" ");
-
                         int i = 0;
                         while (i < proofsFor.length - 1) {
                             appendProofLinks(ssb, fingerprint, proofsFor[i]);
@@ -258,7 +256,7 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
                             i++;
                         }
                         appendProofLinks(ssb, fingerprint, proofsFor[i]);
-                        proofList.add(ssb);
+                        proofList.add(insertLinks(ssb,getProofNarrative(proofType)));
                     }
                 }
 
@@ -266,6 +264,14 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
             }
 
             return new ResultPage(getString(R.string.key_trust_results_prefix), proofList);
+        }
+
+        private SpannableStringBuilder insertLinks(SpannableStringBuilder proofLinks,String proofType){
+            SpannableStringBuilder ssb = new SpannableStringBuilder();
+            ssb.append(proofType);
+            int i = proofType.indexOf("%s");
+            ssb.replace(i,i+2,proofLinks);
+            return ssb;
         }
 
         private SpannableStringBuilder appendProofLinks(SpannableStringBuilder ssb, final String fingerprint, final Proof proof) throws KeybaseException {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyTrustFragment.java
@@ -256,7 +256,7 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
                             i++;
                         }
                         appendProofLinks(ssb, fingerprint, proofsFor[i]);
-                        proofList.add(insertLinks(ssb,getProofNarrative(proofType)));
+                        proofList.add(formatSpannableString(ssb, getProofNarrative(proofType)));
                     }
                 }
 
@@ -266,7 +266,10 @@ public class ViewKeyTrustFragment extends LoaderFragment implements
             return new ResultPage(getString(R.string.key_trust_results_prefix), proofList);
         }
 
-        private SpannableStringBuilder insertLinks(SpannableStringBuilder proofLinks,String proofType){
+        private SpannableStringBuilder formatSpannableString(SpannableStringBuilder proofLinks,String proofType){
+            //Formatting SpannableStringBuilder with String.format() causes the links to stop working.
+            //This method is to insert the links while reserving the links
+
             SpannableStringBuilder ssb = new SpannableStringBuilder();
             ssb.append(proofType);
             if(proofType.contains("%s")){

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -580,14 +580,14 @@
     <string name="key_trust_header_text">"Note: Keybase.io proofs are an experimental feature of OpenKeychain. We encourage you to scan QR Codes or exchange keys via NFC in addition to confirming them."</string>
 
     <!-- keybase proof stuff -->
-    <string name="keybase_narrative_twitter">"Posts to Twitter as"</string>
-    <string name="keybase_narrative_github">"Is known on GitHub as"</string>
-    <string name="keybase_narrative_dns">"Controls the domain name(s)"</string>
-    <string name="keybase_narrative_web_site">"Can post to the Web site(s)"</string>
-    <string name="keybase_narrative_reddit">"Posts to Reddit as"</string>
-    <string name="keybase_narrative_coinbase">"Is known on Coinbase as"</string>
-    <string name="keybase_narrative_hackernews">"Posts to Hacker News as"</string>
-    <string name="keybase_narrative_unknown">"Unknown proof type"</string>
+    <string name="keybase_narrative_twitter">"Posts to Twitter as %s"</string>
+    <string name="keybase_narrative_github">"Is known on GitHub as %s"</string>
+    <string name="keybase_narrative_dns">"Controls the domain name(s) %s"</string>
+    <string name="keybase_narrative_web_site">"Can post to the Web site(s) %s"</string>
+    <string name="keybase_narrative_reddit">"Posts to Reddit as %s"</string>
+    <string name="keybase_narrative_coinbase">"Is known on Coinbase as %s"</string>
+    <string name="keybase_narrative_hackernews">"Posts to Hacker News as %s"</string>
+    <string name="keybase_narrative_unknown">"Unknown proof type %s"</string>
     <string name="keybase_proof_failure">"Unfortunately this proof cannot be verified."</string>
     <string name="keybase_unknown_proof_failure">"Unrecognized problem with proof checker"</string>
     <string name="keybase_problem_fetching_evidence">"Problem with proof"</string>


### PR DESCRIPTION
-No longer appends the links to the keybase_narratives
-Now uses '%s' to insert the names in the keybase_narratives
-added '%s' to keybase_narrative_* in the string.xml file
-- NOTE:Have not modified for other languages