### PR TITLE
Fixed crash on api < 21 due to drawable using attrs

### DIFF
--- a/OpenKeychain/src/main/res/drawable/fab_label_background.xml
+++ b/OpenKeychain/src/main/res/drawable/fab_label_background.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="?attr/colorFabBackground"/>
+    <!-- using an attribute for color will crash on API <= 20. Refer to http://stackoverflow.com/a/13471695/3000919 -->
+    <solid android:color="#b2000000"/>
     <padding
         android:left="16dp"
         android:top="4dp"

--- a/OpenKeychain/src/main/res/drawable/section_header_dark.xml
+++ b/OpenKeychain/src/main/res/drawable/section_header_dark.xml
@@ -3,9 +3,9 @@
     android:shape="rectangle" >
 
     <size
-        android:height="1dp"
+        android:height="2dp"
         android:width="1000dp" />
 
-    <solid android:color="#808080" />
+    <solid android:color="#d0d0d0" />
 
 </shape>

--- a/OpenKeychain/src/main/res/drawable/section_header_light.xml
+++ b/OpenKeychain/src/main/res/drawable/section_header_light.xml
@@ -6,6 +6,6 @@
         android:height="2dp"
         android:width="1000dp" />
 
-    <solid android:color="?attr/colorHeaderText" />
+    <solid android:color="#212121" />
 
 </shape>

--- a/OpenKeychain/src/main/res/values/attrs.xml
+++ b/OpenKeychain/src/main/res/values/attrs.xml
@@ -3,19 +3,20 @@
     <declare-styleable name="CustomTheme">
         <attr name="colorFab" format="color" />
         <attr name="colorFabPressed" format="color" />
-        <attr name="colorFabBackground" format="color" />
+        <attr name="fabLabelBackgroundDrawable" format="reference" />
         <attr name="colorFabText" format="color" />
         <attr name="colorEmphasis" format="color" />
         <attr name="colorHeaderText" format="color" />
         <attr name="colorTertiaryText" format="color" />
         <attr name="colorButtonRow" format="color" />
         <attr name="colorLogBackground" format="color" />
-        <attr name="colorCardViewHeaderDivider" format="color" />
+        <attr name="cardViewHeaderDrawable" format="reference" />
         <attr name="colorText" format="color" />
         <attr name="colorBrightToolbar" format="color" />
         <attr name="colorCardViewBackground" format="color" />
         <attr name="colorTabText" format="color" />
         <attr name="colorTabTextSelected" format="color" />
         <attr name="colorTabIndicator" format="color" />
+        <attr name="sectionHeaderDrawable" format="reference" />
     </declare-styleable>
 </resources>

--- a/OpenKeychain/src/main/res/values/styles.xml
+++ b/OpenKeychain/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <style name="CardViewHeader">
-        <item name="android:drawableBottom">@drawable/cardview_header</item>
+        <item name="android:drawableBottom">?attr/cardViewHeaderDrawable</item>
         <item name="android:drawablePadding">16dp</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:paddingLeft">16dp</item>
@@ -12,7 +12,7 @@
     </style>
 
     <style name="SectionHeader">
-        <item name="android:drawableBottom">@drawable/section_header</item>
+        <item name="android:drawableBottom">?attr/sectionHeaderDrawable</item>
         <item name="android:drawablePadding">4dp</item>
         <item name="android:layout_marginTop">8dp</item>
         <item name="android:paddingLeft">8dp</item>
@@ -22,7 +22,7 @@
     </style>
 
     <style name="FabMenuStyle">
-        <item name="android:background">@drawable/fab_label_background</item>
+        <item name="android:background">?attr/fabLabelBackgroundDrawable</item>
         <item name="android:textColor">?attr/colorFabText</item>
     </style>
 

--- a/OpenKeychain/src/main/res/values/themes.xml
+++ b/OpenKeychain/src/main/res/values/themes.xml
@@ -9,8 +9,10 @@
 
         <item name="colorFab">#2196f3</item>
         <item name="colorFabPressed">#1976d2</item>
-        <item name="colorFabBackground">#b2000000</item>
         <item name="colorFabText">#fafafa</item>
+
+        <!-- using an attribute for color will crash on API <= 20. Different drawable xmls are necessary for each theme. Refer to http://stackoverflow.com/a/13471695/3000919 -->
+        <item name="fabLabelBackgroundDrawable">@drawable/fab_label_background</item>
 
         <item name="colorTabText">#70ffffff</item>
         <item name="colorTabTextSelected">#ffffff</item>
@@ -19,12 +21,15 @@
         <item name="colorEmphasis">#2196f3</item>
         <item name="colorButtonRow">#33cccccc</item>
         <item name="colorLogBackground">#cecbce</item>
-        <item name="colorCardViewHeaderDivider">#808080</item>
         <item name="colorCardViewBackground">#ffffff</item>
+        <!-- using an attribute for color will crash on API <= 20. Different drawable xmls are necessary for each theme. Refer to http://stackoverflow.com/a/13471695/3000919 -->
+        <item name="cardViewHeaderDrawable">@drawable/cardview_header</item>
 
         <item name="colorText">#000000</item>
         <item name="colorHeaderText">#212121</item>
         <item name="colorTertiaryText">#808080</item>
+        <!-- using an attribute for color will crash on API <= 20. Different drawable xmls are necessary for each theme. Refer to http://stackoverflow.com/a/13471695/3000919 -->
+        <item name="sectionHeaderDrawable">@drawable/section_header_light</item>
 
         <!-- remove actionbar and title, we use toolbar! -->
         <item name="windowNoTitle">true</item>
@@ -42,8 +47,10 @@
 
         <item name="colorFab">#2196f3</item>
         <item name="colorFabPressed">#1976d2</item>
-        <item name="colorFabBackground">#b2000000</item>
         <item name="colorFabText">#fafafa</item>
+
+        <!-- using an attribute for color will crash on API <= 20. Different drawable xmls are necessary for each theme. Refer to http://stackoverflow.com/a/13471695/3000919 -->
+        <item name="fabLabelBackgroundDrawable">@drawable/fab_label_background</item>
 
         <item name="colorTabText">#70ffffff</item>
         <item name="colorTabTextSelected">#ffffff</item>
@@ -52,12 +59,15 @@
         <item name="colorEmphasis">#2196f3</item>
         <item name="colorButtonRow">#33cccccc</item>
         <item name="colorLogBackground">#303030</item>
-        <item name="colorCardViewHeaderDivider">#808080</item>
         <item name="colorCardViewBackground">#505050</item>
+        <!-- using an attribute for color will crash on API <= 20. Different drawable xmls are necessary for each theme. Refer to http://stackoverflow.com/a/13471695/3000919 -->
+        <item name="cardViewHeaderDrawable">@drawable/cardview_header</item>
 
         <item name="colorText">#ffffff</item>
         <item name="colorHeaderText">#d0d0d0</item>
         <item name="colorTertiaryText">#808080</item>
+        <!-- using an attribute for color will crash on API <= 20. Different drawable xmls are necessary for each theme. Refer to http://stackoverflow.com/a/13471695/3000919 -->
+        <item name="sectionHeaderDrawable">@drawable/section_header_dark</item>
 
         <item name="material_drawer_selected_text">#268bd2</item>
 


### PR DESCRIPTION
Fixes https://github.com/open-keychain/open-keychain/issues/1470
According to http://stackoverflow.com/questions/8041537/how-to-reference-style-attributes-from-a-drawable/13471695#13471695, drawables can't refer to an attribute. The workaround implemented from there involves having a separate drawable xml for each theme. 
Changed all the drawables I could find that do this (as tracked down from a usage search of items in attrs.xml). Hope that covers everything.