### PR TITLE
Reworked KeyserverSyncAdapterService

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/ImportOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/ImportOperation.java
@@ -540,7 +540,9 @@ public class ImportOperation extends BaseOperation<ImportKeyringParcel> {
 
             // adding required information to mResultType
             // special case,no keys requested for import
-            if (mBadKeys == 0 && mNewKeys == 0 && mUpdatedKeys == 0) {
+            if (mBadKeys == 0 && mNewKeys == 0 && mUpdatedKeys == 0
+                    && (mResultType & ImportKeyResult.RESULT_CANCELLED)
+                    != ImportKeyResult.RESULT_CANCELLED) {
                 mResultType = ImportKeyResult.RESULT_FAIL_NOTHING;
             } else {
                 if (mNewKeys > 0) {


### PR DESCRIPTION
In `KeyserverSyncAdapterService`:
* Ignore null Intents and Intents with null actions to fix https://github.com/open-keychain/open-keychain/issues/1573.
* Introduced `START_REDELIVER_INTENT` to better handle service process being killed.
* Modified staggered Orbot update so that the first key is updated immediately. A large time difference between when Orbot is started and when the key is updated could result in starvation if the user turns Orbot off before even a single key could be updated (besides repeated Orbot starts and a lengthier update).

In `ImportOperation`:
* Corrected case where an early cancellation of multi-threaded import may be interpreted as `RESULT_FAIL_NOTHING`.
