### PR TITLE
Select time to remember password in dialog

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -467,6 +467,11 @@
             android:label="@string/title_key_server_preference"
             android:windowSoftInputMode="stateHidden" />
         <activity
+            android:name=".ui.SettingsCacheTTLActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden|keyboard"
+            android:label="@string/title_cache_ttl_preference"
+            android:windowSoftInputMode="stateHidden" />
+        <activity
             android:name=".ui.BackupActivity"
             android:configChanges="keyboardHidden|keyboard"
             android:label="@string/title_backup">

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -95,7 +95,8 @@ public final class Constants {
     }
 
     public static final class Pref {
-        public static final String PASSPHRASE_CACHE_TTL = "passphraseCacheTtl";
+        public static final String PASSPHRASE_CACHE_TTLS = "passphraseCacheTtls";
+        public static final String PASSPHRASE_CACHE_DEFAULT = "passphraseCacheDefault";
         public static final String PASSPHRASE_CACHE_SUBS = "passphraseCacheSubs";
         public static final String LANGUAGE = "language";
         public static final String KEY_SERVERS = "keyServers";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/EditKeyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/EditKeyOperation.java
@@ -171,27 +171,6 @@ public class EditKeyOperation extends BaseOperation<SaveKeyringParcel> {
             return new EditKeyResult(EditKeyResult.RESULT_ERROR, log, null);
         }
 
-        // There is a new passphrase - cache it
-        if (saveParcel.mNewUnlock != null && cryptoInput.mCachePassphrase) {
-            log.add(LogType.MSG_ED_CACHING_NEW, 1);
-
-            // NOTE: Don't cache empty passphrases! Important for MOVE_KEY_TO_CARD
-            if (saveParcel.mNewUnlock.mNewPassphrase != null
-                    && ( ! saveParcel.mNewUnlock.mNewPassphrase.isEmpty())) {
-                PassphraseCacheService.addCachedPassphrase(mContext,
-                        ring.getMasterKeyId(),
-                        ring.getMasterKeyId(),
-                        saveParcel.mNewUnlock.mNewPassphrase,
-                        ring.getPublicKey().getPrimaryUserIdWithFallback());
-            } else if (saveParcel.mNewUnlock.mNewPin != null) {
-                PassphraseCacheService.addCachedPassphrase(mContext,
-                        ring.getMasterKeyId(),
-                        ring.getMasterKeyId(),
-                        saveParcel.mNewUnlock.mNewPin,
-                        ring.getPublicKey().getPrimaryUserIdWithFallback());
-            }
-        }
-
         updateProgress(R.string.progress_done, 100, 100);
 
         // make sure new data is synced into contacts

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
@@ -93,7 +93,7 @@ public class PassphraseCacheService extends Service {
     public static final String EXTRA_MESSENGER = "messenger";
     public static final String EXTRA_USER_ID = "user_id";
 
-    private static final long DEFAULT_TTL = 15;
+    private static final int DEFAULT_TTL = 15;
 
     private static final int MSG_PASSPHRASE_CACHE_GET_OKAY = 1;
     private static final int MSG_PASSPHRASE_CACHE_GET_KEY_NOT_FOUND = 2;
@@ -121,7 +121,7 @@ public class PassphraseCacheService extends Service {
     public static void addCachedPassphrase(Context context, long masterKeyId, long subKeyId,
                                            Passphrase passphrase,
                                            String primaryUserId,
-                                           long timeToLiveSeconds) {
+                                           int timeToLiveSeconds) {
         Log.d(Constants.TAG, "PassphraseCacheService.addCachedPassphrase() for " + masterKeyId);
 
         Intent intent = new Intent(context, PassphraseCacheService.class);
@@ -237,8 +237,6 @@ public class PassphraseCacheService extends Service {
             if (cachedPassphrase == null) {
                 return null;
             }
-            addCachedPassphrase(this, Constants.key.symmetric, Constants.key.symmetric,
-                    cachedPassphrase.getPassphrase(), getString(R.string.passp_cache_notif_pwd), 180);
             return cachedPassphrase.getPassphrase();
         }
 
@@ -345,7 +343,7 @@ public class PassphraseCacheService extends Service {
         String action = intent.getAction();
         switch (action) {
             case ACTION_PASSPHRASE_CACHE_ADD: {
-                long ttl = intent.getLongExtra(EXTRA_TTL, DEFAULT_TTL);
+                long ttl = intent.getIntExtra(EXTRA_TTL, DEFAULT_TTL);
                 long masterKeyId = intent.getLongExtra(EXTRA_KEY_ID, -1);
                 long subKeyId = intent.getLongExtra(EXTRA_SUBKEY_ID, -1);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
@@ -238,8 +238,7 @@ public class PassphraseCacheService extends Service {
                 return null;
             }
             addCachedPassphrase(this, Constants.key.symmetric, Constants.key.symmetric,
-                    cachedPassphrase.getPassphrase(), getString(R.string.passp_cache_notif_pwd),
-                    Preferences.getPreferences(getBaseContext()).getPassphraseCacheTtl());
+                    cachedPassphrase.getPassphrase(), getString(R.string.passp_cache_notif_pwd), 180);
             return cachedPassphrase.getPassphrase();
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
@@ -120,13 +120,14 @@ public class PassphraseCacheService extends Service {
      */
     public static void addCachedPassphrase(Context context, long masterKeyId, long subKeyId,
                                            Passphrase passphrase,
-                                           String primaryUserId) {
+                                           String primaryUserId,
+                                           long timeToLiveSeconds) {
         Log.d(Constants.TAG, "PassphraseCacheService.addCachedPassphrase() for " + masterKeyId);
 
         Intent intent = new Intent(context, PassphraseCacheService.class);
         intent.setAction(ACTION_PASSPHRASE_CACHE_ADD);
 
-        intent.putExtra(EXTRA_TTL, Preferences.getPreferences(context).getPassphraseCacheTtl());
+        intent.putExtra(EXTRA_TTL, timeToLiveSeconds);
         intent.putExtra(EXTRA_PASSPHRASE, passphrase);
         intent.putExtra(EXTRA_KEY_ID, masterKeyId);
         intent.putExtra(EXTRA_SUBKEY_ID, subKeyId);
@@ -237,7 +238,8 @@ public class PassphraseCacheService extends Service {
                 return null;
             }
             addCachedPassphrase(this, Constants.key.symmetric, Constants.key.symmetric,
-                    cachedPassphrase.getPassphrase(), getString(R.string.passp_cache_notif_pwd));
+                    cachedPassphrase.getPassphrase(), getString(R.string.passp_cache_notif_pwd),
+                    Preferences.getPreferences(getBaseContext()).getPassphraseCacheTtl());
             return cachedPassphrase.getPassphrase();
         }
 
@@ -285,9 +287,6 @@ public class PassphraseCacheService extends Service {
 
         }
 
-        // set it again to reset the cache life cycle
-        Log.d(Constants.TAG, "PassphraseCacheService: Cache passphrase again when getting it!");
-        addCachedPassphrase(this, masterKeyId, subKeyId, cachedPassphrase.getPassphrase(), cachedPassphrase.getPrimaryUserID());
         return cachedPassphrase.getPassphrase();
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/input/RequiredInputParcel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/input/RequiredInputParcel.java
@@ -28,6 +28,8 @@ public class RequiredInputParcel implements Parcelable {
     private Long mMasterKeyId;
     private Long mSubKeyId;
 
+    public boolean mSkipCaching = false;
+
     private RequiredInputParcel(RequiredInputType type, byte[][] inputData,
             int[] signAlgos, Date signatureTime, Long masterKeyId, Long subKeyId) {
         mType = type;
@@ -66,6 +68,7 @@ public class RequiredInputParcel implements Parcelable {
         mSignatureTime = source.readInt() != 0 ? new Date(source.readLong()) : null;
         mMasterKeyId = source.readInt() != 0 ? source.readLong() : null;
         mSubKeyId = source.readInt() != 0 ? source.readLong() : null;
+        mSkipCaching = source.readInt() != 0;
 
     }
 
@@ -171,6 +174,7 @@ public class RequiredInputParcel implements Parcelable {
         } else {
             dest.writeInt(0);
         }
+        dest.writeInt(mSkipCaching ? 1 : 0);
 
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupRestoreFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupRestoreFragment.java
@@ -36,6 +36,7 @@ import android.view.ViewGroup;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.pgp.CanonicalizedSecretKey.SecretKeyType;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
+import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.FileHelper;
 
@@ -157,7 +158,10 @@ public class BackupRestoreFragment extends Fragment {
 
         Intent intent = new Intent(activity, PassphraseDialogActivity.class);
         long masterKeyId = mIdsForRepeatAskPassphrase.get(mIndex++);
-        intent.putExtra(PassphraseDialogActivity.EXTRA_SUBKEY_ID, masterKeyId);
+        RequiredInputParcel requiredInput =
+                RequiredInputParcel.createRequiredDecryptPassphrase(masterKeyId, masterKeyId);
+        requiredInput.mSkipCaching = true;
+        intent.putExtra(PassphraseDialogActivity.EXTRA_REQUIRED_INPUT, requiredInput);
         startActivityForResult(intent, REQUEST_REPEAT_PASSPHRASE);
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -63,6 +63,7 @@ import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
 import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
 import org.sufficientlysecure.keychain.ui.dialog.CustomAlertDialogBuilder;
 import org.sufficientlysecure.keychain.ui.util.ThemeChanger;
+import org.sufficientlysecure.keychain.ui.widget.CacheTTLSpinner;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Passphrase;
 import org.sufficientlysecure.keychain.util.Preferences;
@@ -200,6 +201,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
 
         private Intent mServiceIntent;
         private ViewAnimator mLayout;
+        private CacheTTLSpinner mTimeToLiveSpinner;
 
         @NonNull
         @Override
@@ -240,6 +242,8 @@ public class PassphraseDialogActivity extends FragmentActivity {
 
             mPassphraseText = (TextView) mLayout.findViewById(R.id.passphrase_text);
             mPassphraseEditText = (EditText) mLayout.findViewById(R.id.passphrase_passphrase);
+
+            mTimeToLiveSpinner = (CacheTTLSpinner) mLayout.findViewById(R.id.ttl_spinner);
 
             alert.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
 
@@ -415,12 +419,14 @@ public class PassphraseDialogActivity extends FragmentActivity {
                     CryptoInputParcel cryptoInputParcel =
                             ((PassphraseDialogActivity) getActivity()).mCryptoInputParcel;
 
+                    final long timeToLiveSeconds = mTimeToLiveSpinner.getSelectedTimeToLive();
+
                     // Early breakout if we are dealing with a symmetric key
                     if (mSecretRing == null) {
                         if (cryptoInputParcel.mCachePassphrase) {
                             PassphraseCacheService.addCachedPassphrase(getActivity(),
                                     Constants.key.symmetric, Constants.key.symmetric, passphrase,
-                                    getString(R.string.passp_cache_notif_pwd));
+                                    getString(R.string.passp_cache_notif_pwd), timeToLiveSeconds);
                         }
 
                         finishCaching(passphrase);
@@ -484,7 +490,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
                                 try {
                                     PassphraseCacheService.addCachedPassphrase(getActivity(),
                                             mSecretRing.getMasterKeyId(), mSubKeyId, passphrase,
-                                            mSecretRing.getPrimaryUserIdWithFallback());
+                                            mSecretRing.getPrimaryUserIdWithFallback(), timeToLiveSeconds);
                                 } catch (PgpKeyNotFoundException e) {
                                     Log.e(Constants.TAG, "adding of a passphrase failed", e);
                                 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -44,6 +44,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.widget.ViewAnimator;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
@@ -191,7 +192,6 @@ public class PassphraseDialogActivity extends FragmentActivity {
     public static class PassphraseDialogFragment extends DialogFragment implements TextView.OnEditorActionListener {
         private EditText mPassphraseEditText;
         private TextView mPassphraseText;
-        private View mInput, mProgress;
         private EditText[] mBackupCodeEditText;
 
         private CanonicalizedSecretKeyRing mSecretRing = null;
@@ -199,6 +199,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
         private long mSubKeyId;
 
         private Intent mServiceIntent;
+        private ViewAnimator mLayout;
 
         @NonNull
         @Override
@@ -234,13 +235,11 @@ public class PassphraseDialogActivity extends FragmentActivity {
             }
 
             LayoutInflater inflater = LayoutInflater.from(theme);
-            View view = inflater.inflate(R.layout.passphrase_dialog, null);
-            alert.setView(view);
+            mLayout = (ViewAnimator) inflater.inflate(R.layout.passphrase_dialog, null);
+            alert.setView(mLayout);
 
-            mPassphraseText = (TextView) view.findViewById(R.id.passphrase_text);
-            mPassphraseEditText = (EditText) view.findViewById(R.id.passphrase_passphrase);
-            mInput = view.findViewById(R.id.input);
-            mProgress = view.findViewById(R.id.progress);
+            mPassphraseText = (TextView) mLayout.findViewById(R.id.passphrase_text);
+            mPassphraseEditText = (EditText) mLayout.findViewById(R.id.passphrase_passphrase);
 
             alert.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
 
@@ -428,8 +427,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
                         return;
                     }
 
-                    mInput.setVisibility(View.INVISIBLE);
-                    mProgress.setVisibility(View.VISIBLE);
+                    mLayout.setDisplayedChild(1);
                     positive.setEnabled(false);
 
                     new AsyncTask<Void, Void, Boolean>() {
@@ -469,8 +467,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
                             if (!result) {
                                 mPassphraseEditText.setText("");
                                 mPassphraseEditText.setError(getString(R.string.wrong_passphrase));
-                                mInput.setVisibility(View.VISIBLE);
-                                mProgress.setVisibility(View.INVISIBLE);
+                                mLayout.setDisplayedChild(0);
                                 positive.setEnabled(true);
                                 return;
                             }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -419,7 +419,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
                     CryptoInputParcel cryptoInputParcel =
                             ((PassphraseDialogActivity) getActivity()).mCryptoInputParcel;
 
-                    final long timeToLiveSeconds = mTimeToLiveSpinner.getSelectedTimeToLive();
+                    final int timeToLiveSeconds = mTimeToLiveSpinner.getSelectedTimeToLive();
 
                     // Early breakout if we are dealing with a symmetric key
                     if (mSecretRing == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -61,6 +61,7 @@ import org.sufficientlysecure.keychain.remote.CryptoInputParcelCacheService;
 import org.sufficientlysecure.keychain.service.PassphraseCacheService;
 import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
 import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
+import org.sufficientlysecure.keychain.service.input.RequiredInputParcel.RequiredInputType;
 import org.sufficientlysecure.keychain.ui.dialog.CustomAlertDialogBuilder;
 import org.sufficientlysecure.keychain.ui.util.ThemeChanger;
 import org.sufficientlysecure.keychain.ui.widget.CacheTTLSpinner;
@@ -79,14 +80,10 @@ public class PassphraseDialogActivity extends FragmentActivity {
     public static final String RESULT_CRYPTO_INPUT = "result_data";
 
     public static final String EXTRA_REQUIRED_INPUT = "required_input";
-    public static final String EXTRA_SUBKEY_ID = "secret_key_id";
     public static final String EXTRA_CRYPTO_INPUT = "crypto_input";
 
     // special extra for OpenPgpService
     public static final String EXTRA_SERVICE_INTENT = "data";
-    private long mSubKeyId;
-
-    private CryptoInputParcel mCryptoInputParcel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -101,62 +98,37 @@ public class PassphraseDialogActivity extends FragmentActivity {
             );
         }
 
-        mCryptoInputParcel = getIntent().getParcelableExtra(EXTRA_CRYPTO_INPUT);
-
-        if (mCryptoInputParcel == null) {
-            // not all usages of PassphraseActivity are from CryptoInputOperation
-            // NOTE: This CryptoInputParcel cannot be used for signing operations without setting
-            // signature time
-            mCryptoInputParcel = new CryptoInputParcel();
+        CryptoInputParcel cryptoInputParcel = getIntent().getParcelableExtra(EXTRA_CRYPTO_INPUT);
+        if (cryptoInputParcel == null) {
+            cryptoInputParcel = new CryptoInputParcel();
+            getIntent().putExtra(EXTRA_CRYPTO_INPUT, cryptoInputParcel);
         }
 
         // this activity itself has no content view (see manifest)
+        RequiredInputParcel requiredInput = getIntent().getParcelableExtra(EXTRA_REQUIRED_INPUT);
+        if (requiredInput.mType != RequiredInputType.PASSPHRASE) {
+            return;
+        }
 
-        if (getIntent().hasExtra(EXTRA_SUBKEY_ID)) {
-            mSubKeyId = getIntent().getLongExtra(EXTRA_SUBKEY_ID, 0);
-        } else {
-            RequiredInputParcel requiredInput = getIntent().getParcelableExtra(EXTRA_REQUIRED_INPUT);
-            switch (requiredInput.mType) {
-                case PASSPHRASE_SYMMETRIC: {
-                    mSubKeyId = Constants.key.symmetric;
-                    break;
-                }
-                case BACKUP_CODE: {
-                    mSubKeyId = Constants.key.backup_code;
-                    break;
-                }
-                case PASSPHRASE: {
-
-                    // handle empty passphrases by directly returning an empty crypto input parcel
-                    try {
-                        CanonicalizedSecretKeyRing pubRing =
-                                new ProviderHelper(this).getCanonicalizedSecretKeyRing(
-                                        requiredInput.getMasterKeyId());
-                        // use empty passphrase for empty passphrase
-                        if (pubRing.getSecretKey(requiredInput.getSubKeyId()).getSecretKeyType() ==
-                                SecretKeyType.PASSPHRASE_EMPTY) {
-                            // also return passphrase back to activity
-                            Intent returnIntent = new Intent();
-                            mCryptoInputParcel.mPassphrase = new Passphrase("");
-                            returnIntent.putExtra(RESULT_CRYPTO_INPUT, mCryptoInputParcel);
-                            setResult(RESULT_OK, returnIntent);
-                            finish();
-                            return;
-                        }
-                    } catch (NotFoundException e) {
-                        Log.e(Constants.TAG, "Key not found?!", e);
-                        setResult(RESULT_CANCELED);
-                        finish();
-                        return;
-                    }
-
-                    mSubKeyId = requiredInput.getSubKeyId();
-                    break;
-                }
-                default: {
-                    throw new AssertionError("Unsupported required input type for PassphraseDialogActivity!");
-                }
+        // handle empty passphrases by directly returning an empty crypto input parcel
+        try {
+            CanonicalizedSecretKeyRing pubRing =
+                    new ProviderHelper(this).getCanonicalizedSecretKeyRing(
+                            requiredInput.getMasterKeyId());
+            // use empty passphrase for empty passphrase
+            if (pubRing.getSecretKey(requiredInput.getSubKeyId()).getSecretKeyType() ==
+                    SecretKeyType.PASSPHRASE_EMPTY) {
+                // also return passphrase back to activity
+                Intent returnIntent = new Intent();
+                cryptoInputParcel.mPassphrase = new Passphrase("");
+                returnIntent.putExtra(RESULT_CRYPTO_INPUT, cryptoInputParcel);
+                setResult(RESULT_OK, returnIntent);
+                finish();
             }
+        } catch (NotFoundException e) {
+            Log.e(Constants.TAG, "Key not found?!", e);
+            setResult(RESULT_CANCELED);
+            finish();
         }
 
     }
@@ -169,14 +141,8 @@ public class PassphraseDialogActivity extends FragmentActivity {
          * encryption. Based on mSecretKeyId it asks for a passphrase to open a private key or it asks
          * for a symmetric passphrase
          */
-
-        Intent serviceIntent = getIntent().getParcelableExtra(EXTRA_SERVICE_INTENT);
-
         PassphraseDialogFragment frag = new PassphraseDialogFragment();
-        Bundle args = new Bundle();
-        args.putLong(EXTRA_SUBKEY_ID, mSubKeyId);
-        args.putParcelable(EXTRA_SERVICE_INTENT, serviceIntent);
-        frag.setArguments(args);
+        frag.setArguments(getIntent().getExtras());
         frag.show(getSupportFragmentManager(), "passphraseDialog");
     }
 
@@ -197,9 +163,8 @@ public class PassphraseDialogActivity extends FragmentActivity {
 
         private CanonicalizedSecretKeyRing mSecretRing = null;
         private boolean mIsCancelled = false;
-        private long mSubKeyId;
+        private RequiredInputParcel mRequiredInput;
 
-        private Intent mServiceIntent;
         private ViewAnimator mLayout;
         private CacheTTLSpinner mTimeToLiveSpinner;
 
@@ -210,15 +175,14 @@ public class PassphraseDialogActivity extends FragmentActivity {
 
             ContextThemeWrapper theme = ThemeChanger.getDialogThemeWrapper(activity);
 
-            mSubKeyId = getArguments().getLong(EXTRA_SUBKEY_ID);
-            mServiceIntent = getArguments().getParcelable(EXTRA_SERVICE_INTENT);
+            mRequiredInput = getArguments().getParcelable(EXTRA_REQUIRED_INPUT);
 
             CustomAlertDialogBuilder alert = new CustomAlertDialogBuilder(theme);
 
             // No title, see http://www.google.com/design/spec/components/dialogs.html#dialogs-alerts
             //alert.setTitle()
 
-            if (mSubKeyId == Constants.key.backup_code) {
+            if (mRequiredInput.mType == RequiredInputType.BACKUP_CODE) {
                 LayoutInflater inflater = LayoutInflater.from(theme);
                 View view = inflater.inflate(R.layout.passphrase_dialog_backup_code, null);
                 alert.setView(view);
@@ -236,12 +200,17 @@ public class PassphraseDialogActivity extends FragmentActivity {
                 return dialog;
             }
 
+            long subKeyId = mRequiredInput.getSubKeyId();
+
             LayoutInflater inflater = LayoutInflater.from(theme);
             mLayout = (ViewAnimator) inflater.inflate(R.layout.passphrase_dialog, null);
             alert.setView(mLayout);
 
             mPassphraseText = (TextView) mLayout.findViewById(R.id.passphrase_text);
             mPassphraseEditText = (EditText) mLayout.findViewById(R.id.passphrase_passphrase);
+
+            View vTimeToLiveLayout = mLayout.findViewById(R.id.remember_layout);
+            vTimeToLiveLayout.setVisibility(mRequiredInput.mSkipCaching ? View.GONE : View.VISIBLE);
 
             mTimeToLiveSpinner = (CacheTTLSpinner) mLayout.findViewById(R.id.ttl_spinner);
 
@@ -258,14 +227,14 @@ public class PassphraseDialogActivity extends FragmentActivity {
 
             String message;
             String hint;
-            if (mSubKeyId == Constants.key.symmetric || mSubKeyId == Constants.key.none) {
+            if (mRequiredInput.mType == RequiredInputType.PASSPHRASE_SYMMETRIC) {
                 message = getString(R.string.passphrase_for_symmetric_encryption);
                 hint = getString(R.string.label_passphrase);
             } else {
                 try {
                     ProviderHelper helper = new ProviderHelper(activity);
                     mSecretRing = helper.getCanonicalizedSecretKeyRing(
-                            KeychainContract.KeyRings.buildUnifiedKeyRingsFindBySubkeyUri(mSubKeyId));
+                            KeychainContract.KeyRings.buildUnifiedKeyRingsFindBySubkeyUri(subKeyId));
                     // yes the inner try/catch block is necessary, otherwise the final variable
                     // above can't be statically verified to have been set in all cases because
                     // the catch clause doesn't return.
@@ -281,7 +250,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
                         userId = null;
                     }
 
-                    keyType = mSecretRing.getSecretKey(mSubKeyId).getSecretKeyType();
+                    keyType = mSecretRing.getSecretKey(subKeyId).getSecretKeyType();
                     switch (keyType) {
                         case PASSPHRASE:
                             message = getString(R.string.passphrase_for, userId);
@@ -304,7 +273,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
 
                 } catch (ProviderHelper.NotFoundException e) {
                     alert.setTitle(R.string.title_key_not_found);
-                    alert.setMessage(getString(R.string.key_not_found, mSubKeyId));
+                    alert.setMessage(getString(R.string.key_not_found, mRequiredInput.getSubKeyId()));
                     alert.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int which) {
                             dismiss();
@@ -400,7 +369,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
                 public void onClick(View v) {
 
                     final Passphrase passphrase;
-                    if (mSubKeyId == Constants.key.backup_code) {
+                    if (mRequiredInput.mType == RequiredInputType.BACKUP_CODE) {
                         StringBuilder backupCodeInput = new StringBuilder(26);
                         for (EditText editText : mBackupCodeEditText) {
                             if (editText.getText().length() < 6) {
@@ -416,14 +385,11 @@ public class PassphraseDialogActivity extends FragmentActivity {
                         passphrase = new Passphrase(mPassphraseEditText);
                     }
 
-                    CryptoInputParcel cryptoInputParcel =
-                            ((PassphraseDialogActivity) getActivity()).mCryptoInputParcel;
-
                     final int timeToLiveSeconds = mTimeToLiveSpinner.getSelectedTimeToLive();
 
                     // Early breakout if we are dealing with a symmetric key
                     if (mSecretRing == null) {
-                        if (cryptoInputParcel.mCachePassphrase) {
+                        if ( ! mRequiredInput.mSkipCaching) {
                             PassphraseCacheService.addCachedPassphrase(getActivity(),
                                     Constants.key.symmetric, Constants.key.symmetric, passphrase,
                                     getString(R.string.passp_cache_notif_pwd), timeToLiveSeconds);
@@ -447,7 +413,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
                                     // never mind
                                 }
                                 // make sure this unlocks
-                                return mSecretRing.getSecretKey(mSubKeyId).unlock(passphrase);
+                                return mSecretRing.getSecretKey(mRequiredInput.getSubKeyId()).unlock(passphrase);
                             } catch (PgpGeneralException e) {
                                 Toast.makeText(getActivity(), R.string.error_could_not_extract_private_key,
                                         Toast.LENGTH_SHORT).show();
@@ -481,21 +447,18 @@ public class PassphraseDialogActivity extends FragmentActivity {
                             // cache the new passphrase as specified in CryptoInputParcel
                             Log.d(Constants.TAG, "Everything okay!");
 
-                            CryptoInputParcel cryptoInputParcel
-                                    = ((PassphraseDialogActivity) getActivity()).mCryptoInputParcel;
-
-                            if (cryptoInputParcel.mCachePassphrase) {
+                            if (mRequiredInput.mSkipCaching) {
+                                Log.d(Constants.TAG, "Not caching entered passphrase!");
+                            } else {
                                 Log.d(Constants.TAG, "Caching entered passphrase");
 
                                 try {
                                     PassphraseCacheService.addCachedPassphrase(getActivity(),
-                                            mSecretRing.getMasterKeyId(), mSubKeyId, passphrase,
+                                            mSecretRing.getMasterKeyId(), mRequiredInput.getSubKeyId(), passphrase,
                                             mSecretRing.getPrimaryUserIdWithFallback(), timeToLiveSeconds);
                                 } catch (PgpKeyNotFoundException e) {
                                     Log.e(Constants.TAG, "adding of a passphrase failed", e);
                                 }
-                            } else {
-                                Log.d(Constants.TAG, "Not caching entered passphrase!");
                             }
 
                             finishCaching(passphrase);
@@ -511,13 +474,14 @@ public class PassphraseDialogActivity extends FragmentActivity {
                 return;
             }
 
-            CryptoInputParcel inputParcel =
-                    ((PassphraseDialogActivity) getActivity()).mCryptoInputParcel;
+            CryptoInputParcel inputParcel = getArguments().getParcelable(EXTRA_CRYPTO_INPUT);
+            // noinspection ConstantConditions, we handle the non-null case in PassphraseDialogActivity.onCreate()
             inputParcel.mPassphrase = passphrase;
-            if (mServiceIntent != null) {
-                CryptoInputParcelCacheService.addCryptoInputParcel(getActivity(), mServiceIntent,
-                        inputParcel);
-                getActivity().setResult(RESULT_OK, mServiceIntent);
+
+            Intent serviceIntent = getArguments().getParcelable(EXTRA_SERVICE_INTENT);
+            if (serviceIntent != null) {
+                CryptoInputParcelCacheService.addCryptoInputParcel(getActivity(), serviceIntent, inputParcel);
+                getActivity().setResult(RESULT_OK, serviceIntent);
             } else {
                 // also return passphrase back to activity
                 Intent returnIntent = new Intent();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -18,6 +18,9 @@
 
 package org.sufficientlysecure.keychain.ui;
 
+
+import java.util.List;
+
 import android.Manifest;
 import android.accounts.Account;
 import android.accounts.AccountManager;
@@ -29,6 +32,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
@@ -49,12 +53,9 @@ import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.compatibility.AppCompatPreferenceActivity;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.ThemeChanger;
-import org.sufficientlysecure.keychain.ui.widget.IntegerListPreference;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Preferences;
 import org.sufficientlysecure.keychain.util.orbot.OrbotHelper;
-
-import java.util.List;
 
 public class SettingsActivity extends AppCompatPreferenceActivity {
 
@@ -103,6 +104,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         Toolbar toolbar = (Toolbar) toolbarContainer.findViewById(R.id.toolbar);
 
         toolbar.setTitle(R.string.title_preferences);
+        // noinspection deprecation, TODO use alternative in API level 21
         toolbar.setNavigationIcon(getResources().getDrawable(R.drawable.ic_arrow_back_white_24dp));
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
@@ -195,23 +197,19 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             // Load the preferences from an XML resource
             addPreferencesFromResource(R.xml.passphrase_preferences);
 
-            initializePassphraseCacheTtl(
-                    (IntegerListPreference) findPreference(Constants.Pref.PASSPHRASE_CACHE_TTL));
-        }
-
-        private static void initializePassphraseCacheTtl(
-                final IntegerListPreference passphraseCacheTtl) {
-            passphraseCacheTtl.setValue("" + sPreferences.getPassphraseCacheTtl());
-            passphraseCacheTtl.setSummary(passphraseCacheTtl.getEntry());
-            passphraseCacheTtl
-                    .setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                        public boolean onPreferenceChange(Preference preference, Object newValue) {
-                            passphraseCacheTtl.setValue(newValue.toString());
-                            passphraseCacheTtl.setSummary(passphraseCacheTtl.getEntry());
-                            sPreferences.setPassphraseCacheTtl(Integer.parseInt(newValue.toString()));
+            findPreference(Constants.Pref.PASSPHRASE_CACHE_TTLS)
+                    .setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                        public boolean onPreferenceClick(Preference preference) {
+                            Intent intent = new Intent(getActivity(), SettingsCacheTTLActivity.class);
+                            intent.putExtra(SettingsCacheTTLActivity.EXTRA_TTL_PREF,
+                                    sPreferences.getPassphraseCacheTtl());
+                            startActivity(intent);
                             return false;
                         }
                     });
+
+            initializePassphraseCacheSubs(
+                    (CheckBoxPreference) findPreference(Constants.Pref.PASSPHRASE_CACHE_SUBS));
         }
     }
 
@@ -579,5 +577,16 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 || SyncPrefsFragment.class.getName().equals(fragmentName)
                 || ExperimentalPrefsFragment.class.getName().equals(fragmentName)
                 || super.isValidFragment(fragmentName);
+    }
+
+    private static void initializePassphraseCacheSubs(final CheckBoxPreference mPassphraseCacheSubs) {
+        mPassphraseCacheSubs.setChecked(sPreferences.getPassphraseCacheSubs());
+        mPassphraseCacheSubs.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                mPassphraseCacheSubs.setChecked((Boolean) newValue);
+                sPreferences.setPassphraseCacheSubs((Boolean) newValue);
+                return false;
+            }
+        });
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsCacheTTLActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsCacheTTLActivity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 Vincent Breitmoser <v.breitmoser@my.amazin.horse>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.ui;
+
+import java.util.ArrayList;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnClickListener;
+
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.ui.base.BaseActivity;
+import org.sufficientlysecure.keychain.util.Preferences.CacheTTLPrefs;
+
+
+public class SettingsCacheTTLActivity extends BaseActivity {
+
+    public static final String EXTRA_TTL_PREF = "ttl_pref";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        CacheTTLPrefs ttlPrefs = (CacheTTLPrefs) intent.getSerializableExtra(EXTRA_TTL_PREF);
+        loadFragment(savedInstanceState, ttlPrefs);
+
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void initLayout() {
+        setContentView(R.layout.settings_cache_ttl);
+    }
+
+    private void loadFragment(Bundle savedInstanceState, CacheTTLPrefs ttlPrefs) {
+        // However, if we're being restored from a previous state,
+        // then we don't need to do anything and should return or else
+        // we could end up with overlapping fragments.
+        if (savedInstanceState != null) {
+            return;
+        }
+
+        SettingsCacheTTLFragment fragment = SettingsCacheTTLFragment.newInstance(ttlPrefs);
+
+        // Add the fragment to the 'fragment_container' FrameLayout
+        // NOTE: We use commitAllowingStateLoss() to prevent weird crashes!
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.settings_cache_ttl_fragment, fragment)
+                .commitAllowingStateLoss();
+        // do it immediately!
+        getSupportFragmentManager().executePendingTransactions();
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsCacheTTLFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsCacheTTLFragment.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2015 Vincent Breitmoser <v.breitmoser@my.amazin.horse>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.ui;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.RadioButton;
+import android.widget.TextView;
+
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.ui.util.Notify;
+import org.sufficientlysecure.keychain.ui.util.Notify.Style;
+import org.sufficientlysecure.keychain.ui.util.recyclerview.DividerItemDecoration;
+import org.sufficientlysecure.keychain.util.Preferences.CacheTTLPrefs;
+
+
+public class SettingsCacheTTLFragment extends Fragment {
+
+    public static final String ARG_TTL_PREFS = "ttl_prefs";
+
+    private CacheTTLListAdapter mAdapter;
+
+    public static SettingsCacheTTLFragment newInstance(CacheTTLPrefs ttlPrefs) {
+        Bundle args = new Bundle();
+        args.putSerializable(ARG_TTL_PREFS, ttlPrefs);
+
+        SettingsCacheTTLFragment fragment = new SettingsCacheTTLFragment();
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle
+            savedInstanceState) {
+
+        return inflater.inflate(R.layout.settings_cache_ttl_fragment, null);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        CacheTTLPrefs prefs = (CacheTTLPrefs) getArguments().getSerializable(ARG_TTL_PREFS);
+
+        mAdapter = new CacheTTLListAdapter(prefs);
+
+        RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.cache_ttl_recycler_view);
+        recyclerView.setHasFixedSize(true);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+        recyclerView.setAdapter(mAdapter);
+        recyclerView.addItemDecoration(new DividerItemDecoration(getActivity(), DividerItemDecoration.VERTICAL_LIST));
+
+
+    }
+
+    private void saveKeyserverList() {
+        // Preferences.getPreferences(getActivity()).setKeyServers(servers);
+    }
+
+    public class CacheTTLListAdapter extends RecyclerView.Adapter<CacheTTLListAdapter.ViewHolder> {
+
+        private final ArrayList<Boolean> mPositionIsChecked;
+        private int mDefaultPosition;
+
+        public CacheTTLListAdapter(CacheTTLPrefs prefs) {
+            this.mPositionIsChecked = new ArrayList<>();
+            for (int ttlTime : CacheTTLPrefs.CACHE_TTLS) {
+                mPositionIsChecked.add(prefs.ttlTimes.contains(ttlTime));
+                if (ttlTime == prefs.defaultTtl) {
+                    mDefaultPosition = mPositionIsChecked.size() -1;
+                }
+            }
+
+        }
+
+        @Override
+        public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View view = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.settings_cache_ttl_item, parent, false);
+            return new ViewHolder(view);
+        }
+
+        @Override
+        public void onBindViewHolder(final ViewHolder holder, int position) {
+            holder.bind(position);
+        }
+
+        @Override
+        public int getItemCount() {
+            return mPositionIsChecked.size();
+        }
+
+        public class ViewHolder extends RecyclerView.ViewHolder {
+
+            CheckBox mChecked;
+            TextView mTitle;
+            RadioButton mIsDefault;
+
+            public ViewHolder(View itemView) {
+                super(itemView);
+                mChecked = (CheckBox) itemView.findViewById(R.id.ttl_selected);
+                mTitle = (TextView) itemView.findViewById(R.id.ttl_title);
+                mIsDefault = (RadioButton) itemView.findViewById(R.id.ttl_default);
+
+                itemView.setOnClickListener(new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        mChecked.performClick();
+                    }
+                });
+            }
+
+            public void bind(final int position) {
+
+                int ttl = CacheTTLPrefs.CACHE_TTLS.get(position);
+                boolean isChecked = mPositionIsChecked.get(position);
+                boolean isDefault = position == mDefaultPosition;
+
+                mTitle.setText(CacheTTLPrefs.CACHE_TTL_NAMES.get(ttl));
+                mChecked.setChecked(isChecked);
+                mIsDefault.setEnabled(isChecked);
+                mIsDefault.setChecked(isDefault);
+
+                mChecked.setOnClickListener(new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        setTtlChecked(position);
+                    }
+                });
+
+                mIsDefault.setOnClickListener(!isChecked ? null : new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        setDefault(position);
+                    }
+                });
+
+            }
+
+            private void setTtlChecked(int position) {
+                boolean isChecked = mPositionIsChecked.get(position);
+                int checkedItems = countCheckedItems();
+
+                boolean isLastChecked = isChecked && checkedItems == 1;
+                boolean isOneTooMany = !isChecked && checkedItems >= 3;
+                if (isLastChecked) {
+                    Notify.create(getActivity(), R.string.settings_cache_ttl_at_least_one, Style.ERROR).show();
+                } else if (isOneTooMany) {
+                    Notify.create(getActivity(), R.string.settings_cache_ttl_max_three, Style.ERROR).show();
+                } else {
+                    mPositionIsChecked.set(position, !isChecked);
+                    repositionDefault();
+                }
+                notifyItemChanged(position);
+            }
+
+            private void repositionDefault() {
+                boolean defaultPositionIsChecked = mPositionIsChecked.get(mDefaultPosition);
+                if (defaultPositionIsChecked) {
+                    return;
+                }
+
+                // prefer moving default up
+                int i = mDefaultPosition;
+                while (--i >= 0) {
+                    if (mPositionIsChecked.get(i)) {
+                        setDefault(i);
+                        return;
+                    }
+                }
+
+                // if that didn't work, move it down
+                i = mDefaultPosition;
+                while (++i < mPositionIsChecked.size()) {
+                    if (mPositionIsChecked.get(i)) {
+                        setDefault(i);
+                        return;
+                    }
+                }
+
+                // we should never get here - if we do, leave default as is (there is a sanity check in the
+                // set preference method, so no biggie)
+
+            }
+
+            private void setDefault(int position) {
+                int previousDefaultPosition = mDefaultPosition;
+                mDefaultPosition = position;
+                notifyItemChanged(previousDefaultPosition);
+                notifyItemChanged(mDefaultPosition);
+            }
+
+            private int countCheckedItems() {
+                int result = 0;
+                for (boolean isChecked : mPositionIsChecked) {
+                    if (isChecked) {
+                        result += 1;
+                    }
+                }
+                return result;
+            }
+
+        }
+
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyActivity.java
@@ -82,6 +82,7 @@ import org.sufficientlysecure.keychain.provider.ProviderHelper;
 import org.sufficientlysecure.keychain.provider.ProviderHelper.NotFoundException;
 import org.sufficientlysecure.keychain.service.ImportKeyringParcel;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
+import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
 import org.sufficientlysecure.keychain.ui.ViewKeyFragment.PostponeType;
 import org.sufficientlysecure.keychain.ui.base.BaseNfcActivity;
 import org.sufficientlysecure.keychain.ui.base.CryptoOperationHelper;
@@ -531,7 +532,10 @@ public class ViewKeyActivity extends BaseNfcActivity implements
 
         if (keyHasPassphrase()) {
             Intent intent = new Intent(this, PassphraseDialogActivity.class);
-            intent.putExtra(PassphraseDialogActivity.EXTRA_SUBKEY_ID, mMasterKeyId);
+            RequiredInputParcel requiredInput =
+                    RequiredInputParcel.createRequiredDecryptPassphrase(mMasterKeyId, mMasterKeyId);
+            requiredInput.mSkipCaching = true;
+            intent.putExtra(PassphraseDialogActivity.EXTRA_REQUIRED_INPUT, requiredInput);
             startActivityForResult(intent, requestCode);
         } else {
             startBackupActivity();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
@@ -19,61 +19,56 @@ package org.sufficientlysecure.keychain.ui.widget;
 
 
 import android.content.Context;
-import android.content.res.Resources.Theme;
 import android.database.Cursor;
 import android.database.MatrixCursor;
-import android.os.Bundle;
-import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
 import android.support.v4.widget.SimpleCursorAdapter;
 import android.support.v7.widget.AppCompatSpinner;
 import android.util.AttributeSet;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
-import android.widget.SpinnerAdapter;
-import android.widget.TextView;
 
-import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
-import org.sufficientlysecure.keychain.provider.KeychainContract;
-import org.sufficientlysecure.keychain.ui.adapter.KeyAdapter;
-import org.sufficientlysecure.keychain.ui.adapter.KeyAdapter.KeyItem;
+import org.sufficientlysecure.keychain.util.Preferences;
+import org.sufficientlysecure.keychain.util.Preferences.CacheTTLPrefs;
 
 
 public class CacheTTLSpinner extends AppCompatSpinner {
 
     public CacheTTLSpinner(Context context, AttributeSet attrs) {
         super(context, attrs);
-        initView();
+        initView(context);
     }
 
     public CacheTTLSpinner(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        initView();
+        initView(context);
     }
 
-    private void initView() {
+    private void initView(Context context) {
+
+        CacheTTLPrefs prefs = Preferences.getPreferences(context).getPassphraseCacheTtl();
         MatrixCursor  cursor = new MatrixCursor(new String[] { "_id", "TTL", "description" }, 5);
-        cursor.addRow(new Object[] { 0, 60*5, getContext().getString(R.string.cache_ttl_five_minutes) });
-        cursor.addRow(new Object[] { 1, 60*60, getContext().getString(R.string.cache_ttl_one_hour) });
-        cursor.addRow(new Object[] { 2, 60*60*3, getContext().getString(R.string.cache_ttl_three_hours) });
-        cursor.addRow(new Object[] { 3, 60*60*24, getContext().getString(R.string.cache_ttl_one_day) });
-        cursor.addRow(new Object[] { 4, 60*60*24*3, getContext().getString(R.string.cache_ttl_three_days) });
+        int i = 0, defaultPosition = 0;
+        for (int ttl : CacheTTLPrefs.CACHE_TTLS) {
+            if ( ! prefs.ttlTimes.contains(ttl)) {
+                continue;
+            }
+            if (ttl == prefs.defaultTtl) {
+                defaultPosition = i;
+            }
+            cursor.addRow(new Object[] { i++, ttl, getContext().getString(CacheTTLPrefs.CACHE_TTL_NAMES.get(ttl)) });
+        }
 
         setAdapter(new SimpleCursorAdapter(getContext(), R.layout.simple_item, cursor,
                 new String[] { "description" },
                 new int[] { R.id.simple_item_text },
                 0));
+
+        setSelection(defaultPosition);
     }
 
-    public long getSelectedTimeToLive() {
+    public int getSelectedTimeToLive() {
         int selectedItemPosition = getSelectedItemPosition();
         Object item = getAdapter().getItem(selectedItemPosition);
-        return ((Cursor) item).getLong(1);
+        return ((Cursor) item).getInt(1);
     }
 
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
@@ -58,11 +58,11 @@ public class CacheTTLSpinner extends AppCompatSpinner {
 
     private void initView() {
         MatrixCursor  cursor = new MatrixCursor(new String[] { "_id", "TTL", "description" }, 5);
-        cursor.addRow(new Object[] { 0, 60*5, "Five Minutes" });
-        cursor.addRow(new Object[] { 1, 60*60, "One Hour" });
-        cursor.addRow(new Object[] { 2, 60*60*3, "Three Hours" });
-        cursor.addRow(new Object[] { 3, 60*60*24, "One Day" });
-        cursor.addRow(new Object[] { 4, 60*60*24*3, "Three Days" });
+        cursor.addRow(new Object[] { 0, 60*5, getContext().getString(R.string.cache_ttl_five_minutes) });
+        cursor.addRow(new Object[] { 1, 60*60, getContext().getString(R.string.cache_ttl_one_hour) });
+        cursor.addRow(new Object[] { 2, 60*60*3, getContext().getString(R.string.cache_ttl_three_hours) });
+        cursor.addRow(new Object[] { 3, 60*60*24, getContext().getString(R.string.cache_ttl_one_day) });
+        cursor.addRow(new Object[] { 4, 60*60*24*3, getContext().getString(R.string.cache_ttl_three_days) });
 
         setAdapter(new SimpleCursorAdapter(getContext(), R.layout.simple_item, cursor,
                 new String[] { "description" },

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
@@ -73,7 +73,7 @@ public class CacheTTLSpinner extends AppCompatSpinner {
     public long getSelectedTimeToLive() {
         int selectedItemPosition = getSelectedItemPosition();
         Object item = getAdapter().getItem(selectedItemPosition);
-        return ((Cursor) item).getLong(0);
+        return ((Cursor) item).getLong(1);
     }
 
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 Vincent Breitmoser <v.breitmoser@my.amazin.horse>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.ui.widget;
+
+
+import android.content.Context;
+import android.content.res.Resources.Theme;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.support.v4.widget.SimpleCursorAdapter;
+import android.support.v7.widget.AppCompatSpinner;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.BaseAdapter;
+import android.widget.SpinnerAdapter;
+import android.widget.TextView;
+
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.provider.KeychainContract;
+import org.sufficientlysecure.keychain.ui.adapter.KeyAdapter;
+import org.sufficientlysecure.keychain.ui.adapter.KeyAdapter.KeyItem;
+
+
+public class CacheTTLSpinner extends AppCompatSpinner {
+
+    public CacheTTLSpinner(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initView();
+    }
+
+    public CacheTTLSpinner(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        initView();
+    }
+
+    private void initView() {
+        MatrixCursor  cursor = new MatrixCursor(new String[] { "_id", "TTL", "description" }, 5);
+        cursor.addRow(new Object[] { 0, 60*5, "Five Minutes" });
+        cursor.addRow(new Object[] { 1, 60*60, "One Hour" });
+        cursor.addRow(new Object[] { 2, 60*60*3, "Three Hours" });
+        cursor.addRow(new Object[] { 3, 60*60*24, "One Day" });
+        cursor.addRow(new Object[] { 4, 60*60*24*3, "Three Days" });
+
+        setAdapter(new SimpleCursorAdapter(getContext(), R.layout.simple_item, cursor,
+                new String[] { "description" },
+                new int[] { R.id.simple_item_text },
+                0));
+    }
+
+    public long getSelectedTimeToLive() {
+        int selectedItemPosition = getSelectedItemPosition();
+        Object item = getAdapter().getItem(selectedItemPosition);
+        return ((Cursor) item).getLong(0);
+    }
+
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CacheTTLSpinner.java
@@ -46,23 +46,16 @@ public class CacheTTLSpinner extends AppCompatSpinner {
 
         CacheTTLPrefs prefs = Preferences.getPreferences(context).getPassphraseCacheTtl();
         MatrixCursor  cursor = new MatrixCursor(new String[] { "_id", "TTL", "description" }, 5);
-        int i = 0, defaultPosition = 0;
+        int i = 0;
         for (int ttl : CacheTTLPrefs.CACHE_TTLS) {
             if ( ! prefs.ttlTimes.contains(ttl)) {
                 continue;
-            }
-            if (ttl == prefs.defaultTtl) {
-                defaultPosition = i;
             }
             cursor.addRow(new Object[] { i++, ttl, getContext().getString(CacheTTLPrefs.CACHE_TTL_NAMES.get(ttl)) });
         }
 
         setAdapter(new SimpleCursorAdapter(getContext(), R.layout.simple_item, cursor,
-                new String[] { "description" },
-                new int[] { R.id.simple_item_text },
-                0));
-
-        setSelection(defaultPosition);
+                new String[] { "description" }, new int[] { R.id.simple_item_text }, 0));
     }
 
     public int getSelectedTimeToLive() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Parcel;
@@ -47,6 +48,7 @@ import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
 /**
  * Singleton Implementation of a Preference Helper
  */
+@SuppressLint("CommitPrefEdits")
 public class Preferences {
     private static Preferences sPreferences;
     private SharedPreferences mSharedPreferences;
@@ -135,7 +137,7 @@ public class Preferences {
     public String[] getKeyServers() {
         String rawData = mSharedPreferences.getString(Constants.Pref.KEY_SERVERS,
                 Constants.Defaults.KEY_SERVERS);
-        if (rawData.equals("")) {
+        if ("".equals(rawData)) {
             return new String[0];
         }
         Vector<String> servers = new Vector<>();
@@ -457,15 +459,19 @@ public class Preferences {
                         if (server == null) {
                             continue;
                         }
-                        if (server.equals("pool.sks-keyservers.net")) {
-                            // use HKPS!
-                            it.set("hkps://hkps.pool.sks-keyservers.net");
-                        } else if (server.equals("pgp.mit.edu")) {
-                            // use HKPS!
-                            it.set("hkps://pgp.mit.edu");
-                        } else if (server.equals("subkeys.pgp.net")) {
-                            // remove, because often down and no HKPS!
-                            it.remove();
+                        switch (server) {
+                            case "pool.sks-keyservers.net":
+                                // use HKPS!
+                                it.set("hkps://hkps.pool.sks-keyservers.net");
+                                break;
+                            case "pgp.mit.edu":
+                                // use HKPS!
+                                it.set("hkps://pgp.mit.edu");
+                                break;
+                            case "subkeys.pgp.net":
+                                // remove, because often down and no HKPS!
+                                it.remove();
+                                break;
                         }
 
                     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -321,6 +321,7 @@ public class Preferences {
         public static final ArrayList<Integer> CACHE_TTLS;
         static {
             HashMap<Integer,Integer> cacheTtlNames = new HashMap<>();
+            cacheTtlNames.put(0, R.string.cache_ttl_lock_screen);
             cacheTtlNames.put(60 * 5, R.string.cache_ttl_five_minutes);
             cacheTtlNames.put(60 * 60, R.string.cache_ttl_one_hour);
             cacheTtlNames.put(60 * 60 * 3, R.string.cache_ttl_three_hours);
@@ -353,10 +354,11 @@ public class Preferences {
 
         public static CacheTTLPrefs getDefault() {
             ArrayList<String> ttlStrings = new ArrayList<>();
+            ttlStrings.add(Integer.toString(0));
             ttlStrings.add(Integer.toString(60 * 5));
             ttlStrings.add(Integer.toString(60 * 60));
             ttlStrings.add(Integer.toString(60 * 60 * 24));
-            return new CacheTTLPrefs(ttlStrings, 60 * 5);
+            return new CacheTTLPrefs(ttlStrings, 0);
         }
 
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -307,14 +307,12 @@ public class Preferences {
         if (pref == null) {
             return CacheTTLPrefs.getDefault();
         }
-        int def = mSharedPreferences.getInt(Pref.PASSPHRASE_CACHE_DEFAULT, 300);
-        return new CacheTTLPrefs(pref, def);
+        return new CacheTTLPrefs(pref);
     }
 
     public void setPassphraseCacheTtl(CacheTTLPrefs prefs) {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         editor.putStringSet(Constants.Pref.PASSPHRASE_CACHE_TTLS, prefs.getStringSet());
-        editor.putInt(Pref.PASSPHRASE_CACHE_DEFAULT, prefs.defaultTtl);
         editor.commit();
     }
 
@@ -336,10 +334,8 @@ public class Preferences {
         }
 
         public HashSet<Integer> ttlTimes;
-        public int defaultTtl;
 
-        public CacheTTLPrefs(Collection<String> ttlStrings, int defaultTtl) {
-            this.defaultTtl = defaultTtl;
+        public CacheTTLPrefs(Collection<String> ttlStrings) {
             ttlTimes = new HashSet<>();
             for (String ttlString : ttlStrings) {
                 ttlTimes.add(Integer.parseInt(ttlString));
@@ -356,11 +352,10 @@ public class Preferences {
 
         public static CacheTTLPrefs getDefault() {
             ArrayList<String> ttlStrings = new ArrayList<>();
-            ttlStrings.add(Integer.toString(0));
             ttlStrings.add(Integer.toString(60 * 5));
             ttlStrings.add(Integer.toString(60 * 60));
             ttlStrings.add(Integer.toString(60 * 60 * 24));
-            return new CacheTTLPrefs(ttlStrings, 0);
+            return new CacheTTLPrefs(ttlStrings);
         }
 
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -98,21 +98,6 @@ public class Preferences {
         editor.commit();
     }
 
-    public CacheTTLPrefs getPassphraseCacheTtl() {
-        Set<String> pref = mSharedPreferences.getStringSet(Constants.Pref.PASSPHRASE_CACHE_TTLS, null);
-        if (pref == null) {
-            return CacheTTLPrefs.getDefault();
-        }
-        int def = mSharedPreferences.getInt(Pref.PASSPHRASE_CACHE_DEFAULT, 0);
-        return new CacheTTLPrefs(pref, def);
-    }
-
-    public void setPassphraseCacheTtl(int value) {
-        SharedPreferences.Editor editor = mSharedPreferences.edit();
-        editor.putInt(Constants.Pref.PASSPHRASE_CACHE_TTLS, value);
-        editor.commit();
-    }
-
     public boolean getPassphraseCacheSubs() {
         return mSharedPreferences.getBoolean(Pref.PASSPHRASE_CACHE_SUBS, false);
     }
@@ -315,6 +300,22 @@ public class Preferences {
 
     }
 
+    public CacheTTLPrefs getPassphraseCacheTtl() {
+        Set<String> pref = mSharedPreferences.getStringSet(Constants.Pref.PASSPHRASE_CACHE_TTLS, null);
+        if (pref == null) {
+            return CacheTTLPrefs.getDefault();
+        }
+        int def = mSharedPreferences.getInt(Pref.PASSPHRASE_CACHE_DEFAULT, 300);
+        return new CacheTTLPrefs(pref, def);
+    }
+
+    public void setPassphraseCacheTtl(CacheTTLPrefs prefs) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putStringSet(Constants.Pref.PASSPHRASE_CACHE_TTLS, prefs.getStringSet());
+        editor.putInt(Pref.PASSPHRASE_CACHE_DEFAULT, prefs.defaultTtl);
+        editor.commit();
+    }
+
     public static class CacheTTLPrefs implements Serializable {
         public static final Map<Integer,Integer> CACHE_TTL_NAMES;
         public static final ArrayList<Integer> CACHE_TTLS;
@@ -331,7 +332,6 @@ public class Preferences {
             Collections.sort(CACHE_TTLS);
         }
 
-
         public HashSet<Integer> ttlTimes;
         public int defaultTtl;
 
@@ -341,6 +341,14 @@ public class Preferences {
             for (String ttlString : ttlStrings) {
                 ttlTimes.add(Integer.parseInt(ttlString));
             }
+        }
+
+        public HashSet<String> getStringSet() {
+            HashSet<String> ttlTimeStrings = new HashSet<>();
+            for (Integer ttlTime : ttlTimes) {
+                ttlTimeStrings.add(Integer.toString(ttlTime));
+            }
+            return ttlTimeStrings;
         }
 
         public static CacheTTLPrefs getDefault() {

--- a/OpenKeychain/src/main/res/layout/encrypt_asymmetric_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/encrypt_asymmetric_fragment.xml
@@ -91,6 +91,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@color/md_black_1000"
                 android:text="@string/label_asymmetric_from"
                 android:paddingRight="8dp"/>
 

--- a/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
@@ -44,7 +44,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Remember for "
+                android:text="@string/remember"
                 android:textAppearance="@android:style/TextAppearance.Medium" />
 
             <org.sufficientlysecure.keychain.ui.widget.CacheTTLSpinner

--- a/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
@@ -39,7 +39,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:gravity="center_vertical"
-            android:layout_margin="6dp">
+            android:layout_margin="8dp">
 
             <TextView
                 android:layout_width="wrap_content"

--- a/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
@@ -4,6 +4,7 @@
     xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
     android:paddingTop="16dp"
     android:paddingBottom="16dp"
     android:paddingLeft="24dp"
@@ -32,6 +33,27 @@
             android:hint="@string/label_passphrase"
             android:ems="10"
             android:layout_gravity="center_horizontal" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center_vertical"
+            android:layout_margin="6dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Remember for "
+                android:textAppearance="@android:style/TextAppearance.Medium" />
+
+            <org.sufficientlysecure.keychain.ui.widget.CacheTTLSpinner
+                android:id="@+id/ttl_spinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+            </org.sufficientlysecure.keychain.ui.widget.CacheTTLSpinner>
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<org.sufficientlysecure.keychain.ui.widget.ToolableViewAnimator
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingTop="16dp"
     android:paddingBottom="16dp"
     android:paddingLeft="24dp"
     android:paddingRight="24dp"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    custom:initialView="0">
 
     <LinearLayout
-        android:id="@+id/input"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
@@ -34,7 +36,6 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/progress"
         android:layout_centerInParent="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -57,4 +58,4 @@
 
     </LinearLayout>
 
-</RelativeLayout>
+</org.sufficientlysecure.keychain.ui.widget.ToolableViewAnimator>

--- a/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
@@ -6,7 +6,6 @@
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
     android:paddingTop="16dp"
-    android:paddingBottom="16dp"
     android:paddingLeft="24dp"
     android:paddingRight="24dp"
     android:orientation="vertical"
@@ -41,10 +40,12 @@
             android:gravity="center_vertical"
             android:layout_margin="8dp">
 
+            <!-- paddingBottom for spinner alignment -->
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/remember"
+                android:paddingBottom="1dp"
                 android:textAppearance="@android:style/TextAppearance.Medium" />
 
             <org.sufficientlysecure.keychain.ui.widget.CacheTTLSpinner

--- a/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/passphrase_dialog.xml
@@ -38,7 +38,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:gravity="center_vertical"
-            android:layout_margin="8dp">
+            android:layout_margin="8dp"
+            android:id="@+id/remember_layout">
 
             <!-- paddingBottom for spinner alignment -->
             <TextView

--- a/OpenKeychain/src/main/res/layout/settings_cache_ttl.xml
+++ b/OpenKeychain/src/main/res/layout/settings_cache_ttl.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/toolbar_include"
+        layout="@layout/toolbar_standalone" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:text="@string/settings_cache_select_three"/>
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:text="@string/setting_cache_select_default"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="12dp"
+            android:src="@drawable/ic_expand_more_black_24dp"
+            />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="12dp"
+            android:src="@drawable/ic_expand_more_black_24dp"
+            />
+
+    </LinearLayout>
+
+    <View style="@style/Divider"/>
+
+    <FrameLayout
+        android:id="@+id/settings_cache_ttl_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical" />
+
+</LinearLayout>

--- a/OpenKeychain/src/main/res/layout/settings_cache_ttl.xml
+++ b/OpenKeychain/src/main/res/layout/settings_cache_ttl.xml
@@ -20,44 +20,6 @@
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:text="@string/settings_cache_select_three"/>
 
-        <Space
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:text="@string/setting_cache_select_default"/>
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="12dp"
-            android:src="@drawable/ic_expand_more_black_24dp"
-            />
-
-        <Space
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1" />
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="12dp"
-            android:src="@drawable/ic_expand_more_black_24dp"
-            />
-
     </LinearLayout>
 
     <View style="@style/Divider"/>

--- a/OpenKeychain/src/main/res/layout/settings_cache_ttl_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/settings_cache_ttl_fragment.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<android.support.v7.widget.RecyclerView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/cache_ttl_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />

--- a/OpenKeychain/src/main/res/layout/settings_cache_ttl_item.xml
+++ b/OpenKeychain/src/main/res/layout/settings_cache_ttl_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:background="?selectableItemBackground">
+
+    <CheckBox
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/ttl_selected"
+        android:layout_margin="8dp"
+        />
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:id="@+id/ttl_title"
+        android:layout_weight="1"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textStyle="bold"
+        tools:text="One Hour"
+        />
+
+    <RadioButton
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/ttl_default"
+        android:padding="4dp"
+        />
+
+</LinearLayout>

--- a/OpenKeychain/src/main/res/layout/settings_cache_ttl_item.xml
+++ b/OpenKeychain/src/main/res/layout/settings_cache_ttl_item.xml
@@ -26,11 +26,4 @@
         tools:text="One Hour"
         />
 
-    <RadioButton
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/ttl_default"
-        android:padding="4dp"
-        />
-
 </LinearLayout>

--- a/OpenKeychain/src/main/res/layout/simple_item.xml
+++ b/OpenKeychain/src/main/res/layout/simple_item.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/simple_item_text"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        tools:text="itemtext" />
+</LinearLayout>

--- a/OpenKeychain/src/main/res/layout/simple_item.xml
+++ b/OpenKeychain/src/main/res/layout/simple_item.xml
@@ -5,12 +5,13 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center">
+    android:gravity="center_vertical">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/simple_item_text"
         android:textAppearance="@android:style/TextAppearance.Medium"
+        android:padding="8dp"
         tools:text="itemtext" />
 </LinearLayout>

--- a/OpenKeychain/src/main/res/values/arrays.xml
+++ b/OpenKeychain/src/main/res/values/arrays.xml
@@ -1,34 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string-array name="passphrase_cache_ttl_entries" translatable="false">
-        <item>@string/choice_15secs</item>
-        <item>@string/choice_1min</item>
-        <item>@string/choice_3mins</item>
-        <item>@string/choice_5mins</item>
-        <item>@string/choice_10mins</item>
-        <item>@string/choice_20mins</item>
-        <item>@string/choice_40mins</item>
-        <item>@string/choice_1hour</item>
-        <item>@string/choice_2hours</item>
-        <item>@string/choice_4hours</item>
-        <item>@string/choice_8hours</item>
-        <item>@string/choice_forever</item>
-    </string-array>
-    <string-array name="passphrase_cache_ttl_values" translatable="false">
-        <item>15</item>
-        <item>60</item>
-        <item>180</item>
-        <item>300</item>
-        <item>600</item>
-        <item>1200</item>
-        <item>2400</item>
-        <item>3600</item>
-        <item>7200</item>
-        <item>14400</item>
-        <item>28800</item>
-        <item>-1</item>
-    </string-array>
     <string-array name="pref_proxy_type_entries" translatable="false">
         <item>@string/pref_proxy_type_choice_http</item>
         <item>@string/pref_proxy_type_choice_socks</item>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="title_preferences">"Settings"</string>
     <string name="title_api_registered_apps">"Apps"</string>
     <string name="title_key_server_preference">"OpenPGP keyservers"</string>
+    <string name="title_cache_ttl_preference">"Customize 'Remember' Choices"</string>
     <string name="title_change_passphrase">"Change Password"</string>
     <string name="title_share_fingerprint_with">"Share fingerprint with…"</string>
     <string name="title_share_key">"Share key with…"</string>
@@ -157,7 +158,7 @@
     <string name="label_encryption_algorithm">"Encryption algorithm"</string>
     <string name="label_hash_algorithm">"Hash algorithm"</string>
     <string name="label_symmetric">"Encrypt with password"</string>
-    <string name="label_passphrase_cache_ttl">"Remember time"</string>
+    <string name="label_passphrase_cache_ttl">"Customize 'Remember' Choices"</string>
     <string name="label_passphrase_cache_subs">"Remember passwords by subkey"</string>
     <string name="label_message_compression">"Text compression"</string>
     <string name="label_file_compression">"File compression"</string>
@@ -1709,5 +1710,14 @@
     <string name="title_edit_identities">"Edit Identities"</string>
     <string name="title_edit_subkeys">"Edit Subkeys"</string>
     <string name="btn_search_for_query">"Search for\n'%s'"</string>
+    <string name="cache_ttl_five_minutes">"Five Minutes"</string>
+    <string name="cache_ttl_one_hour">"One Hour"</string>
+    <string name="cache_ttl_three_hours">"Three Hours"</string>
+    <string name="cache_ttl_one_day">"One Day"</string>
+    <string name="cache_ttl_three_days">"Three Days"</string>
+    <string name="settings_cache_select_three">"Pick up to three"</string>
+    <string name="setting_cache_select_default">"and one default"</string>
+    <string name="settings_cache_ttl_at_least_one">"At least one item must be selected!"</string>
+    <string name="settings_cache_ttl_max_three">"Can\'t select more than three items!"</string>
 
 </resources>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1716,8 +1716,7 @@
     <string name="cache_ttl_three_hours">"for Three Hours"</string>
     <string name="cache_ttl_one_day">"for One Day"</string>
     <string name="cache_ttl_three_days">"for Three Days"</string>
-    <string name="settings_cache_select_three">"Pick up to three"</string>
-    <string name="setting_cache_select_default">"and one default"</string>
+    <string name="settings_cache_select_three">"Pick up to three."</string>
     <string name="settings_cache_ttl_at_least_one">"At least one item must be selected!"</string>
     <string name="settings_cache_ttl_max_three">"Can\'t select more than three items!"</string>
     <string name="remember">"Remember"</string>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1710,14 +1710,16 @@
     <string name="title_edit_identities">"Edit Identities"</string>
     <string name="title_edit_subkeys">"Edit Subkeys"</string>
     <string name="btn_search_for_query">"Search for\n'%s'"</string>
-    <string name="cache_ttl_five_minutes">"Five Minutes"</string>
-    <string name="cache_ttl_one_hour">"One Hour"</string>
-    <string name="cache_ttl_three_hours">"Three Hours"</string>
-    <string name="cache_ttl_one_day">"One Day"</string>
-    <string name="cache_ttl_three_days">"Three Days"</string>
+    <string name="cache_ttl_lock_screen">"until Screen Off"</string>
+    <string name="cache_ttl_five_minutes">"for Five Minutes"</string>
+    <string name="cache_ttl_one_hour">"for One Hour"</string>
+    <string name="cache_ttl_three_hours">"for Three Hours"</string>
+    <string name="cache_ttl_one_day">"for One Day"</string>
+    <string name="cache_ttl_three_days">"for Three Days"</string>
     <string name="settings_cache_select_three">"Pick up to three"</string>
     <string name="setting_cache_select_default">"and one default"</string>
     <string name="settings_cache_ttl_at_least_one">"At least one item must be selected!"</string>
     <string name="settings_cache_ttl_max_three">"Can\'t select more than three items!"</string>
+    <string name="remember">"Remember"</string>
 
 </resources>

--- a/OpenKeychain/src/main/res/xml/passphrase_preferences.xml
+++ b/OpenKeychain/src/main/res/xml/passphrase_preferences.xml
@@ -1,8 +1,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <org.sufficientlysecure.keychain.ui.widget.IntegerListPreference
-        android:entries="@array/passphrase_cache_ttl_entries"
-        android:entryValues="@array/passphrase_cache_ttl_values"
-        android:key="passphraseCacheTtl"
+    <PreferenceScreen
+        android:key="passphraseCacheTtls"
         android:persistent="false"
         android:title="@string/label_passphrase_cache_ttl" />
     <CheckBoxPreference


### PR DESCRIPTION
Using different caching times at different times is quite the valid use case. If I know I'll be doing a lot of keysigning or mail reading in the next hour or so, for example, it should be in the few hours range. Otherwise, couple minutes is fine. But it really varies.

Another advantage is that it raises awareness that passwords are cached. Users are sometimes confused why they aren't asked their password on a second operation, if they havn't noticed the cache notification before.