### PR TITLE
Use Nordpol for BaseNfcActivity

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -64,6 +64,10 @@ dependencies {
     compile 'org.thoughtcrime.ssl.pinning:AndroidPinning:1.0.0'
     compile 'com.cocosw:bottomsheet:1.2.0@aar'
 
+    // Nordpol
+    compile 'com.fidesmo:nordpol-android:0.1.10@aar'
+    compile 'com.fidesmo:nordpol-core:0.1.10'
+
     // libs as submodules
     compile project(':extern:openpgp-api-lib:openpgp-api')
     compile project(':extern:openkeychain-api-lib:openkeychain-intents')

--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -65,8 +65,8 @@ dependencies {
     compile 'com.cocosw:bottomsheet:1.2.0@aar'
 
     // Nordpol
-    compile 'com.fidesmo:nordpol-android:0.1.10@aar'
-    compile 'com.fidesmo:nordpol-core:0.1.10'
+    compile 'com.fidesmo:nordpol-android:0.1.15@aar'
+    compile 'com.fidesmo:nordpol-core:0.1.15'
 
     // libs as submodules
     compile project(':extern:openpgp-api-lib:openpgp-api')
@@ -121,6 +121,8 @@ dependencyVerification {
 //            'OpenKeychain.extern:minidns:51e34ebab23ebd6bdd4cc681024040e5cfd2d713a51a4b209e4fbeaa73e5fe57',
             'com.android.support:support-annotations:f347a35b9748a4103b39a6714a77e2100f488d623fd6268e259c177b200e9d82',
             'com.squareup.okio:okio:114bdc1f47338a68bcbc95abf2f5cdc72beeec91812f2fcd7b521c1937876266',
+            'com.fidesmo:nordpol-core:fe09e65379f2c7300b669ef7df2bfbde47729dac19edacc26b5ddb44b94ff67d',
+            'com.fidesmo:nordpol-android:012f93c2c78bd5e3b35af3e8a6676c4fac56755abee252dcfdbb8b35df19e3dd'
     ]
 }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyActivity.java
@@ -77,7 +77,7 @@ public class CreateKeyActivity extends BaseSecurityTokenNfcActivity {
         // NOTE: ACTION_NDEF_DISCOVERED and not ACTION_TAG_DISCOVERED like in BaseNfcActivity
         if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(getIntent().getAction())) {
 
-            handleIntentInBackground(getIntent());
+            mTagDispatcher.interceptIntent(getIntent());
 
             setTitle(R.string.title_manage_my_keys);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseSecurityTokenNfcActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseSecurityTokenNfcActivity.java
@@ -191,7 +191,7 @@ public abstract class BaseSecurityTokenNfcActivity extends BaseActivity implemen
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mTagDispatcher = TagDispatcher.get(this, this, false);
+        mTagDispatcher = TagDispatcher.get(this, this, false, false);
 
         // Check whether we're recreating a previously destroyed instance
         if (savedInstanceState != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'http://releases.marmeladburk.fidesmo.com'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'http://releases.marmeladburk.fidesmo.com'
-        }
     }
 }
 


### PR DESCRIPTION
[Nordpol](https://github.com/fidesmo/nordpol) is a library that tries to consolidate the two different ways Android interacts with NFC as well as well as provide good default values for apps that require real ISO APDU communication with the tag. On top of this provides some work arounds for some of the NFC bugs out there. It tries to do so while being a drop in replacement for the IsoTag class.

I have tried to minimize the changes to the existing code. The following have been altered:
- Replace handling of intents with Nordpol tag dispatcher
- Update CreateKeyActivity to pass it's intent to the tag dispatcher
  when invoked by the system (onCreate)
- Add Fidesmo marmeladburk repository
- Add dependency on nordpol-android and nordpol-core