### PR TITLE
Fixed Keyserver and Contact Sync turning itself on

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
@@ -155,22 +155,10 @@ public class ContactSyncAdapterService extends Service {
     }
 
     public static void enableContactsSync(Context context) {
-        try {
-            AccountManager manager = AccountManager.get(context);
-            Account[] accounts = manager.getAccountsByType(Constants.ACCOUNT_TYPE);
+        AccountManager manager = AccountManager.get(context);
+        Account account = manager.getAccountsByType(Constants.ACCOUNT_TYPE)[0];
 
-            Account account = new Account(Constants.ACCOUNT_NAME, Constants.ACCOUNT_TYPE);
-            if (accounts.length == 0) {
-                if (!manager.addAccountExplicitly(account, null, null)) {
-                    Log.d(Constants.TAG, "account already exists, the account is null, or another error occured");
-                }
-            }
-
-            ContentResolver.setIsSyncable(account, ContactsContract.AUTHORITY, 1);
-            ContentResolver.setSyncAutomatically(account, ContactsContract.AUTHORITY, true);
-        } catch (SecurityException e) {
-            Log.e(Constants.TAG, "SecurityException when adding the account", e);
-            Toast.makeText(context, R.string.reinstall_openkeychain, Toast.LENGTH_LONG).show();
-        }
+        ContentResolver.setIsSyncable(account, ContactsContract.AUTHORITY, 1);
+        ContentResolver.setSyncAutomatically(account, ContactsContract.AUTHORITY, true);
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -476,6 +476,8 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 
         private boolean checkContactsPermission(String authority) {
             if (!ContactsContract.AUTHORITY.equals(authority)) {
+                // provides convenience of not using separate checks for keyserver and contact sync
+                // in initializeSyncCheckBox
                 return true;
             }
 


### PR DESCRIPTION
Fixes https://github.com/open-keychain/open-keychain/issues/1622. Looks like at some point keyserver sync and contact linking was enabled whenever the app started.
Also cancels a postponed/staggered sync if it was scheduled, but was disabled in preferences before it could trigger.