### PR TITLE
allow "panic button" apps to clear all passphrases

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -782,6 +782,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.ExitActivity"
+            android:theme="@android:style/Theme.NoDisplay" />
 
         <!-- Internal services/content providers (not exported) -->
         <service

--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -772,6 +772,17 @@
             android:name=".ui.HelpActivity"
             android:label="@string/title_help" />
 
+        <activity
+            android:name=".ui.PanicResponderActivity"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="info.guardianproject.panic.action.TRIGGER" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <!-- Internal services/content providers (not exported) -->
         <service
             android:name=".service.PassphraseCacheService"

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ExitActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ExitActivity.java
@@ -23,27 +23,30 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 
-import org.sufficientlysecure.keychain.service.PassphraseCacheService;
-
-public class PanicResponderActivity extends Activity {
-
-    public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+public class ExitActivity extends Activity {
 
     @SuppressLint("NewApi")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        Intent intent = getIntent();
-        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
-            PassphraseCacheService.clearCachedPassphrases(this);
-            ExitActivity.exitAndRemoveFromRecentApps(this);
-        }
-
         if (Build.VERSION.SDK_INT >= 21) {
             finishAndRemoveTask();
         } else {
             finish();
         }
+
+        System.exit(0);
+    }
+
+    public static void exitAndRemoveFromRecentApps(Activity activity) {
+        Intent intent = new Intent(activity, ExitActivity.class);
+
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+                | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                | Intent.FLAG_ACTIVITY_CLEAR_TASK
+                | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+        activity.startActivity(intent);
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PanicResponderActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PanicResponderActivity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015-2016 Hans-Christoph Steiner <hans@eds.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.ui;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+import org.sufficientlysecure.keychain.service.PassphraseCacheService;
+
+public class PanicResponderActivity extends Activity {
+
+    public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+    @SuppressLint("NewApi")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+            PassphraseCacheService.clearCachedPassphrases(this);
+        }
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+    }
+}


### PR DESCRIPTION
We've been developing "panic button" features in our apps for years, and now we are working to make a more flexible and open ecosystem of apps that can both trigger other apps, or respond to triggers. Since OpenKeychain already caches passphrases and includes a "clear" feature, it is a natural panic responder app. This setup allows for easy configuration of a single trigger action which can then trigger multiple apps.

The first commit adds support for receiving the panic trigger. The second commit wipes OpenKeychain from the Recent Apps when it is responding to a panic trigger.

I made a video to demonstrate the user experience, this pull request offers the same user experience as the demonstration with Orweb:
https://www.youtube.com/watch?v=mS1gstS6YS8

The first panic button app that sends this kind of trigger is called Ripple, and it is available here:
* https://github.com/guardianproject/ripple
* https://play.google.com/store/apps/details?id=info.guardianproject.ripple
* https://guardianproject.info/fdroid

I've added support to this app, and it'll be included in the next release:
* https://panicbutton.io/
* https://play.google.com/store/apps/details?id=org.iilab.pb

This pull request just implements the most basic panic response.  I could see OpenKeychain offering more options, like disguising itself, deleting all files (especially if the user has an off-device backup), etc.  That would require adding a "panic setup" Activity like [Zom](https://zom.im) has for the user to opt-in.  Read all about that here:
https://guardianproject.info/2016/01/12/panickit-making-your-whole-phone-respond-to-a-panic-button/