### PR TITLE
Handle not installed PGP applet

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/FidesmoInstallDialog.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/FidesmoInstallDialog.java
@@ -1,0 +1,59 @@
+package org.sufficientlysecure.keychain.ui.dialog;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+import org.sufficientlysecure.keychain.R;
+
+public class FidesmoInstallDialog extends DialogFragment {
+
+    // URLs for Google Play app and to install apps via browser
+    private final static String PLAY_STORE_URI = "market://details?id=";
+    private final static String PLAY_STORE_VIA_BROWSER_URI = "http://play.google.com/store/apps/details?id=";
+
+    // Fidesmo constants
+    private static final String FIDESMO_APP_PACKAGE = "com.fidesmo.sec.android";
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        CustomAlertDialogBuilder mCustomAlertDialogBuilder = new CustomAlertDialogBuilder(getActivity());
+        mCustomAlertDialogBuilder.setTitle(getString(R.string.prompt_fidesmo_app_install_title));
+        mCustomAlertDialogBuilder.setMessage(getString(R.string.prompt_fidesmo_app_install_message));
+        mCustomAlertDialogBuilder.setPositiveButton(
+                getString(R.string.prompt_fidesmo_app_install_button_positive),
+                new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dismiss();
+                startPlayStoreFidesmoAppActivity();
+            }
+        });
+        mCustomAlertDialogBuilder.setNegativeButton(
+                getString(R.string.prompt_fidesmo_app_install_button_negative),
+                new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dismiss();
+            }
+        });
+
+        return mCustomAlertDialogBuilder.show();
+    }
+
+    private void startPlayStoreFidesmoAppActivity() {
+        try {
+            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_URI +
+                    FIDESMO_APP_PACKAGE)));
+        } catch (android.content.ActivityNotFoundException exception) {
+            // if the Google Play app is not installed, call the browser
+            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_VIA_BROWSER_URI +
+                    FIDESMO_APP_PACKAGE)));
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/FidesmoPgpInstallDialog.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/FidesmoPgpInstallDialog.java
@@ -1,0 +1,63 @@
+package org.sufficientlysecure.keychain.ui.dialog;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.util.Log;
+
+public class FidesmoPgpInstallDialog extends DialogFragment {
+
+    // Fidesmo constants
+    private static final String FIDESMO_SERVICE_DELIVERY_CARD_ACTION = "com.fidesmo.sec.DELIVER_SERVICE";
+    private static final String FIDESMO_SERVICE_URI = "https://api.fidesmo.com/service/";
+    private static final String FIDESMO_PGP_APPLICATION_ID = "0cdc651e";
+    private static final String FIDESMO_PGP_SERVICE_ID = "OKC-install";
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        CustomAlertDialogBuilder mCustomAlertDialogBuilder = new CustomAlertDialogBuilder(getActivity());
+        mCustomAlertDialogBuilder.setTitle(getString(R.string.prompt_fidesmo_pgp_install_title));
+        mCustomAlertDialogBuilder.setMessage(getString(R.string.prompt_fidesmo_pgp_install_message));
+        mCustomAlertDialogBuilder.setPositiveButton(
+                getString(R.string.prompt_fidesmo_pgp_install_button_positive),
+                new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dismiss();
+                startFidesmoPgpAppletActivity();
+            }
+        });
+        mCustomAlertDialogBuilder.setNegativeButton(
+                getString(R.string.prompt_fidesmo_pgp_install_button_negative),
+                new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dismiss();
+            }
+        });
+
+        return mCustomAlertDialogBuilder.show();
+    }
+
+    private void startFidesmoPgpAppletActivity() {
+        try {
+            // Call the Fidesmo app with the PGP applet as parameter to
+            // send the user straight to it
+            final String mPgpInstallServiceUrl = FIDESMO_SERVICE_URI + FIDESMO_PGP_APPLICATION_ID
+                    + "/" + FIDESMO_PGP_SERVICE_ID;
+            Intent mPgpServiceIntent = new Intent(FIDESMO_SERVICE_DELIVERY_CARD_ACTION,
+                    Uri.parse(mPgpInstallServiceUrl));
+            startActivity(mPgpServiceIntent);
+        } catch (IllegalArgumentException e) {
+            Log.e(Constants.TAG, "Error when parsing URI");
+        }
+    }
+}

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1720,5 +1720,14 @@
     <string name="settings_cache_ttl_at_least_one">"At least one item must be selected!"</string>
     <string name="settings_cache_ttl_max_three">"Can\'t select more than three items!"</string>
     <string name="remember">"Remember"</string>
+    <string name="security_token_error_pgp_app_not_installed">"No PGP app was found on the security token"</string>
+    <string name="prompt_fidesmo_pgp_install_title">"Install PGP?"</string>
+    <string name="prompt_fidesmo_pgp_install_message">"There was no PGP app available on your Fidesmo device."</string>
+    <string name="prompt_fidesmo_pgp_install_button_positive">"Install"</string>
+    <string name="prompt_fidesmo_pgp_install_button_negative">"Cancel"</string>
+    <string name="prompt_fidesmo_app_install_title">"Install Fidesmo?"</string>
+    <string name="prompt_fidesmo_app_install_message">"To install PGP you need the Fidesmo Android app."</string>
+    <string name="prompt_fidesmo_app_install_button_positive">"Install"</string>
+    <string name="prompt_fidesmo_app_install_button_negative">"Cancel"</string>
 
 </resources>


### PR DESCRIPTION
Handles the case of a PGP applet not being available on a (possibly) compatible Security Token.
If the Security Token is a Fidesmo device it prompts the user to install the applet through the Fidesmo app. If the Fidesmo app is not installed the user is prompted about that. 