### PR TITLE
Deletes linked OpenKeychain contacts if sync is disabled

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
@@ -118,8 +118,8 @@ public class KeychainApplication extends Application {
     }
 
     /**
-     * @return the OpenKeychain contact/sync account if it exists or was successfully created, null
-     * otherwise
+     * @return the OpenKeychain contact/keyserver sync account if it exists or was successfully
+     * created, null otherwise
      */
     public static @Nullable Account createAccountIfNecessary(Context context) {
         try {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -51,6 +51,8 @@ import android.widget.LinearLayout;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.compatibility.AppCompatPreferenceActivity;
+import org.sufficientlysecure.keychain.service.ContactSyncAdapterService;
+import org.sufficientlysecure.keychain.ui.base.BaseActivity;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.ThemeChanger;
 import org.sufficientlysecure.keychain.util.Log;
@@ -79,6 +81,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        BaseActivity.onResumeChecks(this);
 
         if (mThemeChanger.changeTheme()) {
             Intent intent = getIntent();
@@ -463,6 +466,8 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                     } else {
                         // disable syncs
                         ContentResolver.setSyncAutomatically(account, authority, false);
+                        // immediately delete any linked contacts
+                        ContactSyncAdapterService.deleteIfSyncDisabled(getActivity());
                         // cancel any ongoing/pending syncs
                         ContentResolver.cancelSync(account, authority);
                         setSummary(syncCheckBox, authority, false);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseActivity.java
@@ -18,6 +18,7 @@
 package org.sufficientlysecure.keychain.ui.base;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
@@ -30,6 +31,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.service.ContactSyncAdapterService;
 import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
 import org.sufficientlysecure.keychain.ui.util.ThemeChanger;
 
@@ -52,7 +54,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        KeyserverSyncAdapterService.cancelUpdates(this);
+        onResumeChecks(this);
 
         if (mThemeChanger.changeTheme()) {
             Intent intent = getIntent();
@@ -61,6 +63,12 @@ public abstract class BaseActivity extends AppCompatActivity {
             startActivity(intent);
             overridePendingTransition(0, 0);
         }
+    }
+
+    public static void onResumeChecks(Context context) {
+        KeyserverSyncAdapterService.cancelUpdates(context);
+        // in case user has disabled sync from settings
+        ContactSyncAdapterService.deleteIfSyncDisabled(context);
     }
 
     protected void initLayout() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ContactHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/ContactHelper.java
@@ -465,7 +465,7 @@ public class ContactHelper {
      */
     public void writeKeysToContacts() {
         if (Constants.DEBUG_SYNC_REMOVE_CONTACTS) {
-            debugDeleteRawContacts();
+            deleteAllContacts();
         }
 
         writeKeysToMainProfileContact();
@@ -671,7 +671,7 @@ public class ContactHelper {
      *
      * @return number of rows deleted
      */
-    private int debugDeleteRawContacts() {
+    public int deleteAllContacts() {
         // CALLER_IS_SYNCADAPTER allows us to actually wipe the RawContact from the device, otherwise
         // would be just flagged for deletion
         Uri deleteUri = ContactsContract.RawContacts.CONTENT_URI.buildUpon().


### PR DESCRIPTION
Fixes https://github.com/open-keychain/open-keychain/issues/1712. Deletes linked contacts in both situations:
* __When the user disables contact linking in the app__ - Linked contacts are immediately deleted.
* __When the user disables contact linking in permissions__ - Linked contacts are deleted the next time any of our activities are resumed. (Wasn't able to find a way to be notified of a change in sync settings except with a <a href="http://developer.android.com/reference/android/content/ContentResolver.html#addStatusChangeListener(int, android.content.SyncStatusObserver)">`SyncStatusObserver`</a> whose implementation seems to require having an always running service).