### PR TITLE
Always check read permission

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysListFragment.java
@@ -330,8 +330,15 @@ public class ImportKeysListFragment extends ListFragment implements
     }
 
     public void loadNew(LoaderState loaderState) {
-
         mLoaderState = loaderState;
+
+        if (mLoaderState instanceof BytesLoaderState) {
+            BytesLoaderState ls = (BytesLoaderState) mLoaderState;
+
+            if ( ! checkAndRequestReadPermission(ls.mDataUri)) {
+                return;
+            }
+        }
 
         restartLoaders();
     }


### PR DESCRIPTION
This solve a wrong "File not found" when the user try to import a key when the app was not granted read permission previously. (Using Android 6.0)
Allow the user to grant read permission even in this case.

This is a quick fix.
Probably the code here need a bit of refactoring. 
If you agree i will try to restructure it a bit in the future.