### PR TITLE
issue/1625 (Xiaomi save dialog) quickfix

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/FileHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/FileHelper.java
@@ -79,6 +79,8 @@ import org.sufficientlysecure.keychain.R;
  */
 public class FileHelper {
 
+    private static final String defaultSavePath="/sdcard/OpenKeychain/";
+
     private static Boolean hasOpenDocumentIntent;
 
     @TargetApi(VERSION_CODES.KITKAT)
@@ -95,7 +97,23 @@ public class FileHelper {
         // Note: This is not documented, but works: Show the Internal Storage menu item in the drawer!
         intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
         intent.putExtra(Intent.EXTRA_TITLE, suggestedName);
-        fragment.startActivityForResult(intent, requestCode);
+
+        try {
+            fragment.startActivityForResult(intent, requestCode);
+        } catch (ActivityNotFoundException e) {
+            // On a device that does not support save file dialog.
+            //Will be using a default save location.
+            String savePath=defaultSavePath+suggestedName;
+
+            // Note: Faking an intent return,do not want to mess rest of code for rare occurrence.
+            Intent fakeIntent = new Intent();
+            fakeIntent.setData(Uri.parse("file://" + savePath));
+            fragment.onActivityResult(0x00007007, -1, fakeIntent);
+
+            Toast.makeText(fragment.getActivity(), R.string.saving_file_to_default,
+                    Toast.LENGTH_SHORT).show();
+        }
+
     }
 
     public static void openDocument(Fragment fragment, Uri last, String mimeType, boolean multiple, int requestCode) {

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -301,6 +301,7 @@
     <!-- sentences -->
     <string name="wrong_passphrase">"Wrong password."</string>
     <string name="no_filemanager_installed">"No compatible file manager installed."</string>
+    <string name="saving_file_to_default">"Saving file to OpenKeychain folder."</string>
     <string name="passphrases_do_not_match">"The passwords didn't match."</string>
     <string name="passphrase_must_not_be_empty">"Please enter a password."</string>
     <string name="passphrase_for_symmetric_encryption">"Enter password"</string>


### PR DESCRIPTION
This is a quick fix for xiaomi phones.[Issue](https://github.com/open-keychain/open-keychain/issues/1625)
Currently works on my Redmi Note 2 prime.

I didn't want to mess FileHelper/EncryptFilesFragment structure for such a rare exception so i decided to fake the ACTION_CREATE_DOCUMENT activity when it fails.
Didn't include Activity.class and EncryptFilesFragment on FileHelper and use the static code integers for the same reason.

I would be more than happy to create a cleaner solution if needed but i will have to change the rest of the filesystem code a lot. 