### PR TITLE
Fix wrong behavior of third-party apps while opening files after decryption

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/InputDataOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/InputDataOperation.java
@@ -119,8 +119,9 @@ public class InputDataOperation extends BaseOperation<InputDataParcel> {
 
             // inform the storage provider about the mime type for this uri
             if (decryptResult.getDecryptionMetadata() != null) {
-                TemporaryFileProvider.setMimeType(mContext, currentInputUri,
-                        decryptResult.getDecryptionMetadata().getMimeType());
+                OpenPgpMetadata meta = decryptResult.getDecryptionMetadata();
+                TemporaryFileProvider.setName(mContext, currentInputUri, meta.getFilename());
+                TemporaryFileProvider.setMimeType(mContext, currentInputUri, meta.getMimeType());
             }
 
         } else {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/TemporaryFileProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/TemporaryFileProvider.java
@@ -99,6 +99,12 @@ public class TemporaryFileProvider extends ContentProvider {
         return context.getContentResolver().insert(CONTENT_URI, contentValues);
     }
 
+    public static int setName(Context context, Uri uri, String name) {
+        ContentValues values = new ContentValues();
+        values.put(TemporaryFileColumns.COLUMN_NAME, name);
+        return context.getContentResolver().update(uri, values, null, null);
+    }
+
     public static int setMimeType(Context context, Uri uri, String mimetype) {
         ContentValues values = new ContentValues();
         values.put(TemporaryFileColumns.COLUMN_TYPE, mimetype);
@@ -283,8 +289,11 @@ public class TemporaryFileProvider extends ContentProvider {
 
     @Override
     public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
-        if (values.size() != 1 || !values.containsKey(TemporaryFileColumns.COLUMN_TYPE)) {
-            throw new UnsupportedOperationException("Update supported only for type field!");
+        if (values.size() != 1) {
+            throw new UnsupportedOperationException("Update supported only for one field at a time!");
+        }
+        if (!values.containsKey(TemporaryFileColumns.COLUMN_NAME) && !values.containsKey(TemporaryFileColumns.COLUMN_TYPE)) {
+            throw new UnsupportedOperationException("Update supported only for name and type field!");
         }
         if (selection != null || selectionArgs != null) {
             throw new UnsupportedOperationException("Update supported only for plain uri!");


### PR DESCRIPTION
Some behave strangely when opening files after decryption because they have no name. 
(Ex: Adobe Reader crashes)

Fix it by setting the correct name after decryption.