### PR TITLE
sync only when unmetered internet is available? #1670

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -5,11 +5,6 @@
     android:installLocation="auto">
 
     <!--
-        General remarks
-        ===============
-        - Last APG 1 version was 10900 (1.0.9 beta 00)
-        - Keychain starting with versionCode 20000!
-
         Association of file types to Keychain
         =====================================
         General remarks about file ending conventions:

--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
     android:installLocation="auto">
 
     <!--
+        General remarks
+        ===============
+        - Last APG 1 version was 10900 (1.0.9 beta 00)
+        - Keychain starting with versionCode 20000!
+
         Association of file types to Keychain
         =====================================
         General remarks about file ending conventions:
@@ -76,6 +81,8 @@
 
     <!-- other group (for free) -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
@@ -89,6 +96,18 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.Keychain.Light">
+        <!-- broadcast receiver for Wi-Fi Connection -->
+        <receiver
+            android:name=".receiver.NetworkReceiver"
+            android:enabled="true"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.net.wifi.WIFI_STATE_CHANGE"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.net.wifi.STATE_CHANGE"/>
+            </intent-filter>
+        </receiver>
         <!-- singleTop for NFC dispatch, see SecurityTokenOperationActivity -->
         <activity
             android:name=".ui.MainActivity"

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -118,6 +118,9 @@ public final class Constants {
         // keyserver sync settings
         public static final String SYNC_CONTACTS = "syncContacts";
         public static final String SYNC_KEYSERVER = "syncKeyserver";
+        public static final String SYNC_WIFI = "syncWifi";
+        public static final String ENABLE_WIFI_SYNC_ONLY = "enableWifiSyncOnly";
+        public static final String ENABLE_ALLOW_SYNC = "enableAllowSync";
         // other settings
         public static final String EXPERIMENTAL_ENABLE_WORD_CONFIRM = "experimentalEnableWordConfirm";
         public static final String EXPERIMENTAL_ENABLE_LINKED_IDENTITIES = "experimentalEnableLinkedIdentities";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
@@ -1,0 +1,54 @@
+package org.sufficientlysecure.keychain.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
+import org.sufficientlysecure.keychain.util.Preferences;
+
+public class NetworkReceiver extends BroadcastReceiver {
+
+    Context context;
+    public NetworkReceiver(){}
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        this.context = context;
+
+        KeyserverSyncAdapterService KSAS = new KeyserverSyncAdapterService(context);
+        ConnectivityManager conn = (ConnectivityManager)
+                context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = conn.getActiveNetworkInfo();
+
+        if (networkInfo != null && networkInfo.getType() == ConnectivityManager.TYPE_WIFI) {
+
+            // broadcaster receiver disabled
+            setWifiReceiverComponent(false, context);
+        }
+    }
+
+    public void setWifiReceiverComponent(Boolean isEnabled, Context context){
+
+        PackageManager pm = context.getPackageManager();
+        ComponentName compName = new ComponentName(context,
+                NetworkReceiver.class);
+
+        if(isEnabled) {
+            Preferences.getPreferences(context).setAllowSync(false);
+            pm.setComponentEnabledSetting(compName,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
+        }
+        else {
+            pm.setComponentEnabledSetting(compName,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+
+            if(!Preferences.getPreferences(context).getAllowSync())
+            KeyserverSyncAdapterService.enableKeyserverSync(context);
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -18,7 +18,6 @@
 
 package org.sufficientlysecure.keychain.ui;
 
-
 import java.util.List;
 
 import android.Manifest;
@@ -405,7 +404,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     }
 
     /**
-     * This fragment shows the keyserver/contacts sync preferences
+     * This fragment shows the keyserver/wifi-only-sync/contacts sync preferences
      */
     public static class SyncPrefsFragment extends PresetPreferenceFragment {
 
@@ -436,6 +435,18 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                     account,
                     ContactsContract.AUTHORITY
             );
+
+            SwitchPreference pref = (SwitchPreference) findPreference(Constants.Pref.SYNC_WIFI);
+            pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    Preferences prefs = Preferences.getPreferences(getContext());
+                    prefs.setWifiOnlySync((Boolean) newValue);
+
+                    return true;
+                }
+            });
         }
 
         private void initializeSyncCheckBox(final SwitchPreference syncCheckBox,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -19,19 +19,6 @@
 package org.sufficientlysecure.keychain.util;
 
 
-import java.io.Serializable;
-import java.net.Proxy;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -44,6 +31,19 @@ import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.Constants.Pref;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
+
+import java.io.Serializable;
+import java.net.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
 
 /**
  * Singleton Implementation of a Preference Helper
@@ -422,6 +422,28 @@ public class Preferences {
                 return new CloudSearchPrefs[size];
             }
         };
+    }
+
+    // sync preferences
+
+    public void setWifiOnlySync(Boolean sync){
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, sync);
+        editor.commit();
+    }
+
+    public boolean getWifiOnlySync() {
+        return mSharedPreferences.getBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, false);
+    }
+
+    public void setAllowSync(Boolean sync){
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(Pref.ENABLE_ALLOW_SYNC, sync);
+        editor.commit();
+    }
+
+    public boolean getAllowSync() {
+        return mSharedPreferences.getBoolean(Pref.ENABLE_ALLOW_SYNC, true);
     }
 
     // experimental prefs

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1734,6 +1734,7 @@
     <string name="help_donation_paypal_item">OpenKeychain Donation</string>
     <string-array name="help_donation_google_catalog_values">
         <item>1 EUR</item>
+        <item>2 EUR</item>
         <item>3 EUR</item>
         <item>5 EUR</item>
         <item>10 EUR</item>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="label_sync_settings_keyserver_title">"Automatic key updates"</string>
     <string name="label_sync_settings_keyserver_summary_on">"Every three days, keys are updated from the preferred keyserver"</string>
     <string name="label_sync_settings_keyserver_summary_off">"Keys are not automatically updated"</string>
+    <string name="label_sync_settings_wifi_title">"Sync only on Wi-Fi"</string>
     <string name="label_sync_settings_contacts_title">"Link keys to contacts"</string>
     <string name="label_sync_settings_contacts_summary_on">"Link keys to contacts based on names and email addresses. This happens completely offline on your device."</string>
     <string name="label_sync_settings_contacts_summary_off">"New keys will not be linked to contacts"</string>
@@ -1733,7 +1734,6 @@
     <string name="help_donation_paypal_item">OpenKeychain Donation</string>
     <string-array name="help_donation_google_catalog_values">
         <item>1 EUR</item>
-        <item>2 EUR</item>
         <item>3 EUR</item>
         <item>5 EUR</item>
         <item>10 EUR</item>

--- a/OpenKeychain/src/main/res/xml/sync_preferences.xml
+++ b/OpenKeychain/src/main/res/xml/sync_preferences.xml
@@ -4,6 +4,9 @@
         android:persistent="false"
         android:title="@string/label_sync_settings_keyserver_title"/>
     <SwitchPreference
+        android:key="syncWifi"
+        android:title="@string/label_sync_settings_wifi_title"/>
+    <SwitchPreference
         android:key="syncContacts"
         android:persistent="false"
         android:title="@string/label_sync_settings_contacts_title" />


### PR DESCRIPTION
Created a Sync Only on Wi-Fi switch in Settings. When On, a receiver is
created when the sync is pending and Wi-Fi is disconnected. This
listens for any Wi-Fi state change broadcasts. Once connected the
receiver is disabled.

Reference : #1670 