### PR TITLE
sync only when unmetered internet is available? #1670

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -76,6 +76,8 @@
 
     <!-- other group (for free) -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
@@ -89,6 +91,18 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.Keychain.Light">
+        <!-- broadcast receiver for Wi-Fi Connection -->
+        <receiver
+            android:name=".receiver.NetworkReceiver"
+            android:enabled="true"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.net.wifi.WIFI_STATE_CHANGE"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.net.wifi.STATE_CHANGE"/>
+            </intent-filter>
+        </receiver>
         <!-- singleTop for NFC dispatch, see SecurityTokenOperationActivity -->
         <activity
             android:name=".ui.MainActivity"

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -118,6 +118,9 @@ public final class Constants {
         // keyserver sync settings
         public static final String SYNC_CONTACTS = "syncContacts";
         public static final String SYNC_KEYSERVER = "syncKeyserver";
+        public static final String SYNC_WIFI = "syncWifi";
+        public static final String ENABLE_WIFI_SYNC_ONLY = "enableWifiSyncOnly";
+        public static final String ENABLE_ALLOW_SYNC = "enableAllowSync";
         // other settings
         public static final String EXPERIMENTAL_ENABLE_WORD_CONFIRM = "experimentalEnableWordConfirm";
         public static final String EXPERIMENTAL_ENABLE_LINKED_IDENTITIES = "experimentalEnableLinkedIdentities";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
@@ -1,0 +1,54 @@
+package org.sufficientlysecure.keychain.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
+import org.sufficientlysecure.keychain.util.Preferences;
+
+public class NetworkReceiver extends BroadcastReceiver {
+
+    Context context;
+    public NetworkReceiver(){}
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        this.context = context;
+
+        KeyserverSyncAdapterService KSAS = new KeyserverSyncAdapterService(context);
+        ConnectivityManager conn = (ConnectivityManager)
+                context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = conn.getActiveNetworkInfo();
+
+        if (networkInfo != null && networkInfo.getType() == ConnectivityManager.TYPE_WIFI) {
+
+            // broadcaster receiver disabled
+            setWifiReceiverComponent(false, context);
+        }
+    }
+
+    public void setWifiReceiverComponent(Boolean isEnabled, Context context){
+
+        PackageManager pm = context.getPackageManager();
+        ComponentName compName = new ComponentName(context,
+                NetworkReceiver.class);
+
+        if(isEnabled) {
+            Preferences.getPreferences(context).setAllowSync(false);
+            pm.setComponentEnabledSetting(compName,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
+        }
+        else {
+            pm.setComponentEnabledSetting(compName,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+
+            if(!Preferences.getPreferences(context).getAllowSync())
+            KeyserverSyncAdapterService.enableKeyserverSync(context);
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
@@ -144,9 +144,10 @@ public class ContactSyncAdapterService extends Service {
 
     public static void requestContactsSync() {
         // if user has disabled automatic sync, do nothing
-        if (!ContentResolver.getSyncAutomatically(
-                new Account(Constants.ACCOUNT_NAME, Constants.ACCOUNT_TYPE),
-                ContactsContract.AUTHORITY)) {
+        boolean isSyncEnabled = ContentResolver.getSyncAutomatically(new Account
+                        (Constants.ACCOUNT_NAME, Constants.ACCOUNT_TYPE), ContactsContract.AUTHORITY);
+
+        if (!isSyncEnabled) {
             return;
         }
         

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -16,6 +16,8 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -35,6 +37,7 @@ import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.ProviderHelper;
+import org.sufficientlysecure.keychain.receiver.NetworkReceiver;
 import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
 import org.sufficientlysecure.keychain.ui.OrbotRequiredDialogActivity;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
@@ -74,6 +77,14 @@ public class KeyserverSyncAdapterService extends Service {
     private static final String ACTION_CANCEL = "cancel";
 
     private AtomicBoolean mCancelled = new AtomicBoolean(false);
+    Context context;
+
+    //zero argument constructor
+    public KeyserverSyncAdapterService(){}
+
+    public KeyserverSyncAdapterService(Context context){
+        this.context=context;
+    }
 
     @Override
     public int onStartCommand(final Intent intent, int flags, final int startId) {
@@ -178,6 +189,25 @@ public class KeyserverSyncAdapterService extends Service {
                                   ContentProviderClient provider, SyncResult syncResult) {
             Log.d(Constants.TAG, "Performing a keyserver sync!");
 
+            Preferences prefs = Preferences.getPreferences(getContext());
+
+            // for a wifi-ONLY sync
+            if(prefs.getWifiOnlySync()){
+
+                ConnectivityManager connMgr = (ConnectivityManager)
+                        getSystemService(Context.CONNECTIVITY_SERVICE);
+                @SuppressWarnings("deprecation") // our min is API 15, deprecated only in 23
+                        NetworkInfo networkInfo = connMgr.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+                boolean isWifiConn = networkInfo.isConnected();
+
+                // if Wi-Fi connection doesn't exist then receiver is enabled
+                if(!isWifiConn){
+                    new NetworkReceiver().setWifiReceiverComponent(true, getContext());
+                    postponeSync();
+                    return;
+                }
+            }
+            Log.d(Constants.TAG, "Performing a keyserver sync!");
             PowerManager pm = (PowerManager) KeyserverSyncAdapterService.this
                     .getSystemService(Context.POWER_SERVICE);
             @SuppressWarnings("deprecation") // our min is API 15, deprecated only in 20
@@ -510,6 +540,7 @@ public class KeyserverSyncAdapterService extends Service {
     }
 
     public static void enableKeyserverSync(Context context) {
+        Preferences.getPreferences(context).setAllowSync(true);
         Account account = KeychainApplication.createAccountIfNecessary(context);
 
         if (account == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptModeAsymmetricFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptModeAsymmetricFragment.java
@@ -17,6 +17,8 @@
 
 package org.sufficientlysecure.keychain.ui;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -50,6 +52,7 @@ public class EncryptModeAsymmetricFragment extends EncryptModeFragment {
 
     private KeySpinner mSignKeySpinner;
     private EncryptKeyCompletionView mEncryptKeyView;
+    private String mQuery;
 
     public static final String ARG_SINGATURE_KEY_ID = "signature_key_id";
     public static final String ARG_ENCRYPTION_KEY_IDS = "encryption_key_ids";
@@ -109,6 +112,25 @@ public class EncryptModeAsymmetricFragment extends EncryptModeFragment {
                 if (vEncryptionIcon.getDisplayedChild() != child) {
                     vEncryptionIcon.setDisplayedChild(child);
                 }
+            }
+        });
+
+        // link to search
+        View searchButton = view.findViewById(R.id.cloud_import_server_search);
+        searchButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Activity activity = getActivity();
+                if (activity == null) {
+                    return;
+                }
+
+                mQuery = mEncryptKeyView.getText().toString();
+
+                Intent searchIntent = new Intent(activity, ImportKeysActivity.class);
+                searchIntent.putExtra(ImportKeysActivity.EXTRA_QUERY, mQuery);
+                searchIntent.setAction(ImportKeysActivity.ACTION_IMPORT_KEY_FROM_KEYSERVER);
+                startActivity(searchIntent);
             }
         });
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -405,7 +405,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     }
 
     /**
-     * This fragment shows the keyserver/contacts sync preferences
+     * This fragment shows the keyserver/wifi-only-sync/contacts sync preferences
      */
     public static class SyncPrefsFragment extends PresetPreferenceFragment {
 
@@ -436,6 +436,18 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                     account,
                     ContactsContract.AUTHORITY
             );
+
+            SwitchPreference pref = (SwitchPreference) findPreference(Constants.Pref.SYNC_WIFI);
+            pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    Preferences prefs = Preferences.getPreferences(getContext());
+                    prefs.setWifiOnlySync((Boolean) newValue);
+
+                    return true;
+                }
+            });
         }
 
         private void initializeSyncCheckBox(final SwitchPreference syncCheckBox,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -426,9 +426,9 @@ public class Preferences {
 
     // sync preferences
 
-    public void setWifiOnlySync(Boolean sync){
+    public void setWifiOnlySync(Boolean isSyncEnabled){
         SharedPreferences.Editor editor = mSharedPreferences.edit();
-        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, sync);
+        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, isSyncEnabled;
         editor.commit();
     }
 
@@ -436,9 +436,9 @@ public class Preferences {
         return mSharedPreferences.getBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, false);
     }
 
-    public void setAllowSync(Boolean sync){
+    public void setAllowSync(Boolean isSyncEnabled){
         SharedPreferences.Editor editor = mSharedPreferences.edit();
-        editor.putBoolean(Pref.ENABLE_ALLOW_SYNC, sync);
+        editor.putBoolean(Pref.ENABLE_ALLOW_SYNC, isSyncEnabled);
         editor.commit();
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -424,6 +424,28 @@ public class Preferences {
         };
     }
 
+    // sync preferences
+
+    public void setWifiOnlySync(Boolean sync){
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, sync);
+        editor.commit();
+    }
+
+    public boolean getWifiOnlySync() {
+        return mSharedPreferences.getBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, false);
+    }
+
+    public void setAllowSync(Boolean sync){
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(Pref.ENABLE_ALLOW_SYNC, sync);
+        editor.commit();
+    }
+
+    public boolean getAllowSync() {
+        return mSharedPreferences.getBoolean(Pref.ENABLE_ALLOW_SYNC, true);
+    }
+
     // experimental prefs
 
     public boolean getExperimentalEnableWordConfirm() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -428,7 +428,7 @@ public class Preferences {
 
     public void setWifiOnlySync(Boolean isSyncEnabled){
         SharedPreferences.Editor editor = mSharedPreferences.edit();
-        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, isSyncEnabled;
+        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, isSyncEnabled);
         editor.commit();
     }
 

--- a/OpenKeychain/src/main/res/layout/encrypt_asymmetric_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/encrypt_asymmetric_fragment.xml
@@ -44,8 +44,18 @@
             android:minHeight="56dip"
             android:paddingLeft="8dp"
             android:paddingRight="8dp"
+            android:layout_weight="1"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical" />
+
+        <ImageButton
+            android:id="@+id/cloud_import_server_search"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:padding="8dp"
+            android:src="@drawable/ic_search_grey_24dp"
+            android:layout_gravity="center_vertical"
+            android:background="?android:selectableItemBackground" />
 
     </LinearLayout>
 

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="label_sync_settings_keyserver_title">"Automatic key updates"</string>
     <string name="label_sync_settings_keyserver_summary_on">"Every three days, keys are updated from the preferred keyserver"</string>
     <string name="label_sync_settings_keyserver_summary_off">"Keys are not automatically updated"</string>
+    <string name="label_sync_settings_wifi_title">"Sync only on Wi-Fi"</string>
     <string name="label_sync_settings_contacts_title">"Link keys to contacts"</string>
     <string name="label_sync_settings_contacts_summary_on">"Link keys to contacts based on names and email addresses. This happens completely offline on your device."</string>
     <string name="label_sync_settings_contacts_summary_off">"New keys will not be linked to contacts"</string>

--- a/OpenKeychain/src/main/res/xml/sync_preferences.xml
+++ b/OpenKeychain/src/main/res/xml/sync_preferences.xml
@@ -4,6 +4,9 @@
         android:persistent="false"
         android:title="@string/label_sync_settings_keyserver_title"/>
     <SwitchPreference
+        android:key="syncWifi"
+        android:title="@string/label_sync_settings_wifi_title"/>
+    <SwitchPreference
         android:key="syncContacts"
         android:persistent="false"
         android:title="@string/label_sync_settings_contacts_title" />


### PR DESCRIPTION
Created a Sync Only on Wi-Fi switch in Settings. When On, a receiver is
created when the sync is pending and Wi-Fi is disconnected. This
listens for any Wi-Fi state change broadcasts. Once connected the
receiver is disabled.

Reference: https://github.com/open-keychain/open-keychain/issues/1670

Minor change from previous pull request (Contact Synchronisation
Notification Contact Synchronisation Notification #1743)