### PR TITLE
WIP: Improve EncryptFilesFragment

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -3,6 +3,11 @@ apply plugin: 'witness'
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 
+repositories {
+    mavenCentral()
+    maven { url 'http://guardian.github.com/maven/repo-releases' }
+}
+
 dependencies {
     // NOTE: Always use fixed version codes not dynamic ones, e.g. 0.7.3 instead of 0.7.+, see README for more information
     // NOTE: libraries are pinned to a specific build, see below
@@ -61,6 +66,8 @@ dependencies {
     compile 'org.apache.james:apache-mime4j-dom:0.7.2'
     compile 'org.thoughtcrime.ssl.pinning:AndroidPinning:1.0.0'
     compile 'com.cocosw:bottomsheet:1.3.0@aar'
+    compile 'net.rdrei.android.dirchooser:library:3.2@aar'
+    compile 'com.gu:option:1.3'
 
     // Material Drawer
     compile 'com.mikepenz:materialdrawer:4.6.3@aar'

--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -88,7 +88,8 @@
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Keychain.Light">
+        android:theme="@style/Theme.Keychain.Light"
+        tools:replace="android:theme">
         <!-- singleTop for NFC dispatch, see SecurityTokenOperationActivity -->
         <activity
             android:name=".ui.MainActivity"
@@ -861,6 +862,9 @@
             android:name=".remote.ui.RemoteImportKeysActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|keyboard"
             android:label="@string/title_import_keys" />
+        <activity
+            android:name="net.rdrei.android.dirchooser.DirectoryChooserActivity"
+            android:theme="@style/Theme.AppCompat.Light" />
 
         <!-- DEPRECATED service,
              using this service may lead to truncated data being returned to the caller -->

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/EncryptFilesAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/EncryptFilesAdapter.java
@@ -1,0 +1,164 @@
+package org.sufficientlysecure.keychain.ui.adapter;
+
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.ui.EncryptFilesFragment;
+import org.sufficientlysecure.keychain.ui.EncryptFilesFragment.ViewModel;
+import org.sufficientlysecure.keychain.util.FileHelper;
+
+import java.util.ArrayList;
+
+public class EncryptFilesAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private ArrayList<ViewModel> mDataset;
+    private FilesListListener mFileListListener;
+    private View.OnClickListener mItemOnClickListener;
+    private View.OnClickListener mFooterOnClickListener;
+    private static final int TYPE_FOOTER = 0;
+    private static final int TYPE_ITEM = 1;
+
+
+    public interface FilesListListener {
+        boolean useArmor();
+
+        boolean encryptFilenames();
+    }
+
+    // Provide a reference to the views for each data item
+    // Complex data items may need more than one view per item, and
+    // you provide access to all the views for a data item in a view holder
+    class ViewHolder extends RecyclerView.ViewHolder {
+        public TextView filename;
+        public TextView filenameOut;
+        public TextView fileSize;
+        public View removeButton;
+        public View view;
+        public ImageView thumbnail;
+
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+            filename = (TextView) itemView.findViewById(R.id.filename);
+            filenameOut = (TextView) itemView.findViewById(R.id.filename_out);
+            fileSize = (TextView) itemView.findViewById(R.id.filesize);
+            removeButton = itemView.findViewById(R.id.action_remove_file_from_list);
+            view = itemView;
+            thumbnail = (ImageView) itemView.findViewById(R.id.thumbnail);
+        }
+    }
+
+    class FooterHolder extends RecyclerView.ViewHolder {
+        public Button mAddButton;
+
+        public FooterHolder(View itemView) {
+            super(itemView);
+            mAddButton = (Button) itemView.findViewById(R.id.file_list_entry_add);
+        }
+    }
+
+    // Provide a suitable constructor (depends on the kind of dataset)
+    public EncryptFilesAdapter(ArrayList<ViewModel> dataset,
+                               FilesListListener fileListListener,
+                               View.OnClickListener onItemlickListener,
+                               View.OnClickListener onFooterClickListener) {
+        mDataset = dataset;
+        mFileListListener = fileListListener;
+        mItemOnClickListener = onItemlickListener;
+        mFooterOnClickListener = onFooterClickListener;
+    }
+
+    // Create new views (invoked by the layout manager)
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        if (viewType == TYPE_FOOTER) {
+            View v = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.file_list_entry_add, parent, false);
+            return new FooterHolder(v);
+        } else {
+            //inflate your layout and pass it to view holder
+            View v = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.file_list_entry, parent, false);
+            return new ViewHolder(v);
+        }
+    }
+
+    // Replace the contents of a view (invoked by the layout manager)
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, final int position) {
+        if (holder instanceof FooterHolder) {
+            FooterHolder thisHolder = (FooterHolder) holder;
+            thisHolder.mAddButton.setOnClickListener(mFooterOnClickListener);
+        } else if (holder instanceof ViewHolder) {
+            ViewHolder thisHolder = (ViewHolder) holder;
+            thisHolder.view.setTag(position);
+            thisHolder.view.setOnClickListener(mItemOnClickListener);
+
+            // - get element from your dataset at this position
+            // - replace the contents of the view with that element
+            final EncryptFilesFragment.ViewModel model = mDataset.get(position);
+
+            thisHolder.filename.setText(model.filename);
+            String ext = mFileListListener.useArmor()
+                    ? Constants.FILE_EXTENSION_ASC : Constants.FILE_EXTENSION_PGP_MAIN;
+            if (mFileListListener.encryptFilenames() && model.defaultFilenameOut) {
+                thisHolder.filenameOut.setText((position + 1) + ext);
+            } else {
+                thisHolder.filenameOut.setText(model.filenameOut + ext);
+            }
+
+            if (model.fileSize == -1) {
+                thisHolder.fileSize.setText("");
+            } else {
+                thisHolder.fileSize.setText(FileHelper.readableFileSize(model.fileSize));
+            }
+
+            thisHolder.removeButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    remove(model);
+                }
+            });
+            if (model.thumbnail != null) {
+                thisHolder.thumbnail.setImageBitmap(model.thumbnail);
+            } else {
+                thisHolder.thumbnail.setImageResource(R.drawable.ic_doc_generic_am);
+            }
+        }
+    }
+
+    // Return the size of your dataset (invoked by the layout manager)
+    @Override
+    public int getItemCount() {
+        // one extra for the footer!
+        return mDataset.size() + 1;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        if (isPositionFooter(position)) {
+            return TYPE_FOOTER;
+        } else {
+            return TYPE_ITEM;
+        }
+    }
+
+    private boolean isPositionFooter(int position) {
+        return position == mDataset.size();
+    }
+
+    public void remove(ViewModel model) {
+        int position = mDataset.indexOf(model);
+        mDataset.remove(position);
+        notifyItemRemoved(position);
+    }
+
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EncryptFilesOptionsDialog.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EncryptFilesOptionsDialog.java
@@ -1,0 +1,89 @@
+package org.sufficientlysecure.keychain.ui.dialog;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+
+import org.sufficientlysecure.keychain.R;
+
+import java.io.Serializable;
+
+public class EncryptFilesOptionsDialog extends DialogFragment {
+
+    private static final String ARG_FILE_OPTIONS = "file_options";
+
+
+    public interface FileOptionsDialogListener {
+        boolean onFileOptionsUpdated(FileOptions options);
+    }
+
+    public static class FileOptions implements Serializable {
+        public String realFilename;
+        public String curFilename;
+
+        public FileOptions(String realFilename, String curFilename) {
+            this.realFilename = realFilename;
+            this.curFilename = curFilename;
+        }
+    }
+
+    private FileOptionsDialogListener listener;
+
+    public static EncryptFilesOptionsDialog newInstance(FileOptions options) {
+        EncryptFilesOptionsDialog fragment = new EncryptFilesOptionsDialog();
+
+        Bundle args = new Bundle();
+        args.putSerializable(ARG_FILE_OPTIONS, options);
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        final LayoutInflater inflater = getActivity().getLayoutInflater();
+        final View view = inflater.inflate(R.layout.encrypt_files_options_dialog, null);
+
+        Bundle args = getArguments();
+        final FileOptions options = (FileOptions) args.getSerializable(ARG_FILE_OPTIONS);
+
+        final EditText curFilename = (EditText) view.findViewById(R.id.filename_out);
+
+        builder.setTitle(options.realFilename);
+        builder.setView(view)
+                .setPositiveButton(R.string.btn_save, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        options.curFilename = curFilename.getText().toString();
+
+                        InputMethodManager imm = (InputMethodManager)
+                                getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+                        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+
+                        if (listener.onFileOptionsUpdated(options))
+                            EncryptFilesOptionsDialog.this.getDialog().cancel();
+                    }
+                })
+                .setNegativeButton(R.string.btn_do_not_save, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        EncryptFilesOptionsDialog.this.getDialog().cancel();
+                    }
+                });
+
+        return builder.create();
+    }
+
+    public void setListener(FileOptionsDialogListener listener) {
+        this.listener = listener;
+    }
+
+}

--- a/OpenKeychain/src/main/res/layout/encrypt_files_options_dialog.xml
+++ b/OpenKeychain/src/main/res/layout/encrypt_files_options_dialog.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingEnd="24dp"
+    android:paddingStart="24dp"
+    android:paddingTop="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:text="@string/label_output_filename" />
+
+    <EditText
+        android:id="@+id/filename_out"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:singleLine="true" />
+</LinearLayout>

--- a/OpenKeychain/src/main/res/layout/file_list_entry.xml
+++ b/OpenKeychain/src/main/res/layout/file_list_entry.xml
@@ -1,58 +1,133 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="48dip"
-    android:background="@drawable/attachment_bg_holo">
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:layout_marginTop="8dp">
 
-    <ImageView
-        android:id="@+id/thumbnail"
-        android:layout_alignParentLeft="true"
-        android:layout_centerVertical="true"
-        android:scaleType="center"
-        android:layout_width="48dip"
-        android:layout_height="48dip" />
-
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="wrap_content"
+    <RelativeLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@+id/thumbnail"
-        android:layout_centerVertical="true">
+        android:paddingBottom="16dp"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="16dp">
 
-        <TextView
-            android:id="@+id/filename"
-            android:layout_marginLeft="8dip"
-            android:layout_marginRight="32dip"
-            android:maxLines="1"
+        <ImageView
+            android:id="@+id/thumbnail"
+            android:layout_width="48dip"
+            android:layout_height="48dip"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true"
+            android:scaleType="center" />
+
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="?android:attr/textColorSecondary"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:ellipsize="end" />
+            android:layout_centerVertical="true"
+            android:layout_marginLeft="16dip"
+            android:layout_toLeftOf="@+id/action_remove_file_from_list"
+            android:layout_toRightOf="@+id/thumbnail"
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/filesize"
-            android:layout_marginLeft="8dip"
-            android:layout_marginRight="32dip"
-            android:maxLines="1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="?android:attr/textColorTertiary"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:textSize="12sp"
-            android:ellipsize="end" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
-    </LinearLayout>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:text="@string/label_input"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorTertiary"
+                    android:textSize="12sp"
+                    android:textStyle="bold" />
 
-    <ImageButton
-        android:id="@+id/action_remove_file_from_list"
-        android:layout_width="48dip"
-        android:layout_height="48dip"
-        android:layout_alignParentRight="true"
-        android:paddingRight="16dip"
-        android:paddingLeft="16dip"
-        android:src="@drawable/ic_close_grey_24dp"
-        android:clickable="true"
-        android:layout_centerVertical="true"
-        android:background="?android:selectableItemBackground" />
-</RelativeLayout>
+                <TextView
+                    android:id="@+id/filename"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="8dip"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:text="@string/label_output"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorTertiary"
+                    android:textSize="12sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/filename_out"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="8dip"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:text="@string/label_size"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorTertiary"
+                    android:textSize="12sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/filesize"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="8dip"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <ImageButton
+            android:id="@+id/action_remove_file_from_list"
+            android:layout_width="48dip"
+            android:layout_height="48dip"
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"
+            android:background="?android:selectableItemBackground"
+            android:clickable="true"
+            android:paddingLeft="16dip"
+            android:paddingRight="16dip"
+            android:src="@drawable/ic_close_grey_24dp" />
+    </RelativeLayout>
+</android.support.v7.widget.CardView>

--- a/OpenKeychain/src/main/res/layout/file_list_entry_add.xml
+++ b/OpenKeychain/src/main/res/layout/file_list_entry_add.xml
@@ -1,24 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="16dp"
-    android:orientation="horizontal"
-    android:singleLine="true">
+    android:layout_gravity="center"
+    android:layout_marginTop="8dp">
 
-    <Button
-        android:id="@+id/file_list_entry_add"
-        android:paddingLeft="8dp"
-        android:paddingRight="8dp"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:layout_width="match_parent"
+    <RelativeLayout
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:minHeight="?android:attr/listPreferredItemHeight"
-        android:layout_gravity="center"
-        android:text="@string/btn_add_files"
-        style="?android:attr/borderlessButtonStyle"
-        android:drawableLeft="@drawable/ic_folder_grey_24dp"
-        android:drawablePadding="16dp"
-        android:gravity="left|center_vertical" />
+        android:paddingBottom="16dp"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="16dp">
 
-</LinearLayout>
+        <ImageView
+            android:id="@+id/thumbnail"
+            android:layout_width="48dip"
+            android:layout_height="48dip"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true"
+            android:scaleType="center"
+            android:src="@drawable/ic_folder_grey_24dp" />
+
+
+        <Button
+            android:id="@+id/file_list_entry_add"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginLeft="16dip"
+            android:layout_toLeftOf="@+id/action_remove_file_from_list"
+            android:layout_toRightOf="@+id/thumbnail"
+            android:text="@string/btn_add_files"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+    </RelativeLayout>
+
+</android.support.v7.widget.CardView>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -184,6 +184,10 @@
     <string name="label_enable_compression">"Enable compression"</string>
     <string name="label_encrypt_filenames">"Encrypt filenames"</string>
     <string name="label_hidden_recipients">"Hide recipients"</string>
+    <string name="label_input">"Input:"</string>
+    <string name="label_output">"Output:"</string>
+    <string name="label_size">"Size:"</string>
+    <string name="label_output_filename">"Output filename:"</string>
 
     <string name="label_verify_keyserver_connection">"Test connection"</string>
     <string name="label_only_trusted_keyserver">"Only trusted keyserver"</string>


### PR DESCRIPTION
We have some limitations in EncryptFilesFragment. Mainly:
- Saving of files not supported <= KitKat
- Saving of multiple files not supported
- No control on output filenames (useful when sharing with email..)

So, i spent some time to improve the situation by solving these problems.
This is a screenshot after this PR at this time (remember it's WIP)

![screenshot_20160306-225101](https://cloud.githubusercontent.com/assets/2026137/13557418/4a2e67dc-e3f0-11e5-9c9a-dcacbacb5b4a.png)

Here we have the list of files we want to Encrypt.
If you tap on a file you get:

![screenshot_20160306-225117](https://cloud.githubusercontent.com/assets/2026137/13557424/741e8a18-e3f0-11e5-807b-5be2616e688f.png)

Here you can set the filename of the output file. (Probably we can add other file specific options..)
This filename will be used for saving and share actions.

If you tap the save icon in the action bar you get a folder picker to set the path where you want to place the output files. Now i'm using a library for the folder picker because i wanted to share a more or less completed idea in the shortest time to get feedback. But the plan is to write an own folder picker, specific for our use case.

This PR is a WIP because code needs a bit of clean up, some checks are needed, UI need to be improved, bugs need to be fixed, granting of storage permission, i need to write a proper folder picker, i will add gestures etc..
But i wanted to start sharing this work to hear your opinions.
Do you like this idea? Do you have any suggestions before i go deep on this way?

I think all these things are pretty useful.
