### PR TITLE
Sync only when unmetered internet is available? #1670

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -76,6 +76,8 @@
 
     <!-- other group (for free) -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
@@ -89,6 +91,18 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.Keychain.Light">
+        <!-- broadcast receiver for Wi-Fi Connection -->
+        <receiver
+            android:name=".receiver.NetworkReceiver"
+            android:enabled="true"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.net.wifi.WIFI_STATE_CHANGE"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.net.wifi.STATE_CHANGE"/>
+            </intent-filter>
+        </receiver>
         <!-- singleTop for NFC dispatch, see SecurityTokenOperationActivity -->
         <activity
             android:name=".ui.MainActivity"

--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -94,7 +94,7 @@
         <!-- broadcast receiver for Wi-Fi Connection -->
         <receiver
             android:name=".receiver.NetworkReceiver"
-            android:enabled="true"
+            android:enabled="false"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.net.wifi.WIFI_STATE_CHANGE"/>

--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -97,10 +97,7 @@
             android:enabled="false"
             android:exported="true" >
             <intent-filter>
-                <action android:name="android.net.wifi.WIFI_STATE_CHANGE"/>
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.net.wifi.STATE_CHANGE"/>
+                <action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>
             </intent-filter>
         </receiver>
         <!-- singleTop for NFC dispatch, see SecurityTokenOperationActivity -->

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -118,6 +118,7 @@ public final class Constants {
         // keyserver sync settings
         public static final String SYNC_CONTACTS = "syncContacts";
         public static final String SYNC_KEYSERVER = "syncKeyserver";
+        public static final String ENABLE_WIFI_SYNC_ONLY = "enableWifiSyncOnly";
         // other settings
         public static final String EXPERIMENTAL_ENABLE_WORD_CONFIRM = "experimentalEnableWordConfirm";
         public static final String EXPERIMENTAL_ENABLE_LINKED_IDENTITIES = "experimentalEnableLinkedIdentities";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
@@ -3,6 +3,7 @@ package org.sufficientlysecure.keychain.receiver;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
+import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
@@ -12,6 +13,7 @@ import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.util.Log;
 
 public class NetworkReceiver extends BroadcastReceiver {
+    private static final String ACTION_UPDATE_ALL = "update_all";
 
     Context context;
     public NetworkReceiver(){}
@@ -27,7 +29,8 @@ public class NetworkReceiver extends BroadcastReceiver {
 
             // broadcaster receiver disabled
             setWifiReceiverComponent(false, context);
-            //KeyserverSyncAdapterService.enableKeyserverSync(context);
+            Intent serviceIntent = new Intent(context, KeyserverSyncAdapterService.class);
+            serviceIntent.setAction(ACTION_UPDATE_ALL);
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
@@ -13,10 +13,6 @@ import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.util.Log;
 
 public class NetworkReceiver extends BroadcastReceiver {
-    private static final String ACTION_UPDATE_ALL = "update_all";
-
-    Context context;
-    public NetworkReceiver(){}
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -30,7 +26,7 @@ public class NetworkReceiver extends BroadcastReceiver {
             // broadcaster receiver disabled
             setWifiReceiverComponent(false, context);
             Intent serviceIntent = new Intent(context, KeyserverSyncAdapterService.class);
-            serviceIntent.setAction(ACTION_UPDATE_ALL);
+            serviceIntent.setAction(KeyserverSyncAdapterService.ACTION_UPDATE_ALL);
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
@@ -1,0 +1,51 @@
+package org.sufficientlysecure.keychain.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.util.Log;
+
+public class NetworkReceiver extends BroadcastReceiver {
+
+    Context context;
+    public NetworkReceiver(){}
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        ConnectivityManager conn = (ConnectivityManager)
+                context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = conn.getActiveNetworkInfo();
+
+        if (networkInfo != null && networkInfo.getType() == ConnectivityManager.TYPE_WIFI) {
+
+            // broadcaster receiver disabled
+            setWifiReceiverComponent(false, context);
+            //KeyserverSyncAdapterService.enableKeyserverSync(context);
+        }
+    }
+
+    public void setWifiReceiverComponent(Boolean isEnabled, Context context){
+
+        PackageManager pm = context.getPackageManager();
+        ComponentName compName = new ComponentName(context,
+                NetworkReceiver.class);
+
+        if(isEnabled) {
+            pm.setComponentEnabledSetting(compName,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED, PackageManager.DONT_KILL_APP);
+            Log.d(Constants.TAG, "Wifi Receiver is enabled!");
+        }
+        else {
+            pm.setComponentEnabledSetting(compName,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
+            Log.d(Constants.TAG, "Wifi Receiver is disabled!");
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/receiver/NetworkReceiver.java
@@ -3,13 +3,13 @@ package org.sufficientlysecure.keychain.receiver;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
-import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
 import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
 import org.sufficientlysecure.keychain.util.Log;
 
 public class NetworkReceiver extends BroadcastReceiver {
@@ -27,6 +27,7 @@ public class NetworkReceiver extends BroadcastReceiver {
             setWifiReceiverComponent(false, context);
             Intent serviceIntent = new Intent(context, KeyserverSyncAdapterService.class);
             serviceIntent.setAction(KeyserverSyncAdapterService.ACTION_UPDATE_ALL);
+            context.startService(serviceIntent);
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
@@ -144,9 +144,10 @@ public class ContactSyncAdapterService extends Service {
 
     public static void requestContactsSync() {
         // if user has disabled automatic sync, do nothing
-        if (!ContentResolver.getSyncAutomatically(
-                new Account(Constants.ACCOUNT_NAME, Constants.ACCOUNT_TYPE),
-                ContactsContract.AUTHORITY)) {
+        boolean isSyncEnabled = ContentResolver.getSyncAutomatically(new Account
+                        (Constants.ACCOUNT_NAME, Constants.ACCOUNT_TYPE), ContactsContract.AUTHORITY);
+
+        if (!isSyncEnabled) {
             return;
         }
         

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -530,8 +530,7 @@ public class KeyserverSyncAdapterService extends Service {
         return builder.build();
     }
 
-    public static void enableKeyserverSync(Context context) {
-        //Preferences.getPreferences(context).setAllowSync(true);
+    public static void enableKeyserverSync(Context context) {]
         Account account = KeychainApplication.createAccountIfNecessary(context);
 
         if (account == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -16,6 +16,8 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -35,6 +37,7 @@ import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.ProviderHelper;
+import org.sufficientlysecure.keychain.receiver.NetworkReceiver;
 import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
 import org.sufficientlysecure.keychain.ui.OrbotRequiredDialogActivity;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
@@ -74,6 +77,10 @@ public class KeyserverSyncAdapterService extends Service {
     private static final String ACTION_CANCEL = "cancel";
 
     private AtomicBoolean mCancelled = new AtomicBoolean(false);
+    Context context;
+
+    //zero argument constructor
+    public KeyserverSyncAdapterService(){}
 
     @Override
     public int onStartCommand(final Intent intent, int flags, final int startId) {
@@ -176,8 +183,26 @@ public class KeyserverSyncAdapterService extends Service {
         @Override
         public void onPerformSync(Account account, Bundle extras, String authority,
                                   ContentProviderClient provider, SyncResult syncResult) {
-            Log.d(Constants.TAG, "Performing a keyserver sync!");
 
+            Preferences prefs = Preferences.getPreferences(getContext());
+
+            // for a wifi-ONLY sync
+            if(prefs.getWifiOnlySync()){
+
+                ConnectivityManager connMgr = (ConnectivityManager)
+                        getSystemService(Context.CONNECTIVITY_SERVICE);
+                @SuppressWarnings("deprecation") // our min is API 15, deprecated only in 23
+                        NetworkInfo networkInfo = connMgr.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+                boolean isWifiConn = networkInfo.isConnected();
+
+                // if Wi-Fi connection doesn't exist then receiver is enabled
+                if(!isWifiConn){
+                    new NetworkReceiver().setWifiReceiverComponent(true, getContext());
+                    //postponeSync();
+                    return;
+                }
+            }
+            Log.d(Constants.TAG, "Performing a keyserver sync!");
             PowerManager pm = (PowerManager) KeyserverSyncAdapterService.this
                     .getSystemService(Context.POWER_SERVICE);
             @SuppressWarnings("deprecation") // our min is API 15, deprecated only in 20
@@ -510,6 +535,7 @@ public class KeyserverSyncAdapterService extends Service {
     }
 
     public static void enableKeyserverSync(Context context) {
+        //Preferences.getPreferences(context).setAllowSync(true);
         Account account = KeychainApplication.createAccountIfNecessary(context);
 
         if (account == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -70,7 +70,7 @@ public class KeyserverSyncAdapterService extends Service {
 
 
     private static final String ACTION_IGNORE_TOR = "ignore_tor";
-    private static final String ACTION_UPDATE_ALL = "update_all";
+    public static final String ACTION_UPDATE_ALL = "update_all";
     private static final String ACTION_SYNC_NOW = "sync_now";
     private static final String ACTION_DISMISS_NOTIFICATION = "cancel_sync";
     private static final String ACTION_START_ORBOT = "start_orbot";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -79,9 +79,6 @@ public class KeyserverSyncAdapterService extends Service {
     private AtomicBoolean mCancelled = new AtomicBoolean(false);
     Context context;
 
-    //zero argument constructor
-    public KeyserverSyncAdapterService(){}
-
     @Override
     public int onStartCommand(final Intent intent, int flags, final int startId) {
         if (intent == null || intent.getAction() == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -77,7 +77,6 @@ public class KeyserverSyncAdapterService extends Service {
     private static final String ACTION_CANCEL = "cancel";
 
     private AtomicBoolean mCancelled = new AtomicBoolean(false);
-    Context context;
 
     @Override
     public int onStartCommand(final Intent intent, int flags, final int startId) {
@@ -530,7 +529,7 @@ public class KeyserverSyncAdapterService extends Service {
         return builder.build();
     }
 
-    public static void enableKeyserverSync(Context context) {]
+    public static void enableKeyserverSync(Context context) {
         Account account = KeychainApplication.createAccountIfNecessary(context);
 
         if (account == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -198,7 +198,6 @@ public class KeyserverSyncAdapterService extends Service {
                 // if Wi-Fi connection doesn't exist then receiver is enabled
                 if(!isWifiConn){
                     new NetworkReceiver().setWifiReceiverComponent(true, getContext());
-                    //postponeSync();
                     return;
                 }
             }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -436,18 +436,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                     account,
                     ContactsContract.AUTHORITY
             );
-
-            SwitchPreference pref = (SwitchPreference) findPreference(Constants.Pref.ENABLE_WIFI_SYNC_ONLY);
-            pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-
-                @Override
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    Preferences prefs = Preferences.getPreferences(getContext());
-                    prefs.setWifiOnlySync((Boolean) newValue);
-
-                    return true;
-                }
-            });
         }
 
         private void initializeSyncCheckBox(final SwitchPreference syncCheckBox,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -19,8 +19,6 @@
 package org.sufficientlysecure.keychain.ui;
 
 
-import java.util.List;
-
 import android.Manifest;
 import android.accounts.Account;
 import android.accounts.AccountManager;
@@ -58,6 +56,8 @@ import org.sufficientlysecure.keychain.ui.util.ThemeChanger;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Preferences;
 import org.sufficientlysecure.keychain.util.orbot.OrbotHelper;
+
+import java.util.List;
 
 public class SettingsActivity extends AppCompatPreferenceActivity {
 
@@ -405,7 +405,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     }
 
     /**
-     * This fragment shows the keyserver/contacts sync preferences
+     * This fragment shows the keyserver/wifi-only-sync/contacts sync preferences
      */
     public static class SyncPrefsFragment extends PresetPreferenceFragment {
 
@@ -436,6 +436,18 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                     account,
                     ContactsContract.AUTHORITY
             );
+
+            SwitchPreference pref = (SwitchPreference) findPreference(Constants.Pref.ENABLE_WIFI_SYNC_ONLY);
+            pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    Preferences prefs = Preferences.getPreferences(getContext());
+                    prefs.setWifiOnlySync((Boolean) newValue);
+
+                    return true;
+                }
+            });
         }
 
         private void initializeSyncCheckBox(final SwitchPreference syncCheckBox,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -426,12 +426,6 @@ public class Preferences {
 
     // sync preferences
 
-    public void setWifiOnlySync(Boolean isSyncEnabled){
-        SharedPreferences.Editor editor = mSharedPreferences.edit();
-        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, isSyncEnabled);
-        editor.commit();
-    }
-
     public boolean getWifiOnlySync() {
         return mSharedPreferences.getBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, false);
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -19,19 +19,6 @@
 package org.sufficientlysecure.keychain.util;
 
 
-import java.io.Serializable;
-import java.net.Proxy;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -44,6 +31,19 @@ import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.Constants.Pref;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
+
+import java.io.Serializable;
+import java.net.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
 
 /**
  * Singleton Implementation of a Preference Helper
@@ -422,6 +422,18 @@ public class Preferences {
                 return new CloudSearchPrefs[size];
             }
         };
+    }
+
+    // sync preferences
+
+    public void setWifiOnlySync(Boolean isSyncEnabled){
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, isSyncEnabled);
+        editor.commit();
+    }
+
+    public boolean getWifiOnlySync() {
+        return mSharedPreferences.getBoolean(Pref.ENABLE_WIFI_SYNC_ONLY, false);
     }
 
     // experimental prefs

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="label_sync_settings_keyserver_title">"Automatic key updates"</string>
     <string name="label_sync_settings_keyserver_summary_on">"Every three days, keys are updated from the preferred keyserver"</string>
     <string name="label_sync_settings_keyserver_summary_off">"Keys are not automatically updated"</string>
+    <string name="label_sync_settings_wifi_title">"Sync only on Wi-Fi"</string>
     <string name="label_sync_settings_contacts_title">"Link keys to contacts"</string>
     <string name="label_sync_settings_contacts_summary_on">"Link keys to contacts based on names and email addresses. This happens completely offline on your device."</string>
     <string name="label_sync_settings_contacts_summary_off">"New keys will not be linked to contacts"</string>

--- a/OpenKeychain/src/main/res/xml/sync_preferences.xml
+++ b/OpenKeychain/src/main/res/xml/sync_preferences.xml
@@ -6,6 +6,7 @@
     <SwitchPreference
         android:key="enableWifiSyncOnly"
         android:persistent="true"
+        android:dependency="syncKeyserver"
         android:title="@string/label_sync_settings_wifi_title"/>
     <SwitchPreference
         android:key="syncContacts"

--- a/OpenKeychain/src/main/res/xml/sync_preferences.xml
+++ b/OpenKeychain/src/main/res/xml/sync_preferences.xml
@@ -4,6 +4,10 @@
         android:persistent="false"
         android:title="@string/label_sync_settings_keyserver_title"/>
     <SwitchPreference
+        android:key="enableWifiSyncOnly"
+        android:persistent="true"
+        android:title="@string/label_sync_settings_wifi_title"/>
+    <SwitchPreference
         android:key="syncContacts"
         android:persistent="false"
         android:title="@string/label_sync_settings_contacts_title" />


### PR DESCRIPTION
@adithyaphilip I have included the changes you suggested on the previous pull request.

However there were 2 issues left unresolved (refer notes). There might be a case where the wifi is off when the periodic sync takes place. The sync should either be postponed or resumed once wifi is back else it will never happen (unless wifi is active when next scheduled sync takes place, even then it can only possibly happen once in 3 days). What are your thoughts on that? 