### PR TITLE
Update Keyserver Sync if Sync Interval Changed

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
@@ -100,6 +100,11 @@ public class KeychainApplication extends Application {
         // Add OpenKeychain account to Android to link contacts with keys and keyserver sync
         createAccountIfNecessary(this);
 
+        if (Preferences.getKeyserverSyncEnabled(this)) {
+            // will update a keyserver sync if the interval has changed
+            KeyserverSyncAdapterService.enableKeyserverSync(this);
+        }
+
         // if first time, enable keyserver and contact sync
         if (Preferences.getPreferences(this).isFirstTime()) {
             KeyserverSyncAdapterService.enableKeyserverSync(this);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -47,6 +47,7 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.KeychainApplication;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.compatibility.AppCompatPreferenceActivity;
 import org.sufficientlysecure.keychain.service.ContactSyncAdapterService;
@@ -422,8 +423,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             super.onResume();
             // this needs to be done in onResume since the user can change sync values from Android
             // settings and we need to reflect that change when the user navigates back
-            AccountManager manager = AccountManager.get(getActivity());
-            final Account account = manager.getAccountsByType(Constants.ACCOUNT_TYPE)[0];
+            final Account account = KeychainApplication.createAccountIfNecessary(getActivity());
             // for keyserver sync
             initializeSyncCheckBox(
                     (SwitchPreference) findPreference(Constants.Pref.SYNC_KEYSERVER),
@@ -441,8 +441,11 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         private void initializeSyncCheckBox(final SwitchPreference syncCheckBox,
                                             final Account account,
                                             final String authority) {
-            boolean syncEnabled = ContentResolver.getSyncAutomatically(account, authority)
-                    && checkContactsPermission(authority);
+            // account is null if it could not be created for some reason
+            boolean syncEnabled =
+                    account != null
+                            && ContentResolver.getSyncAutomatically(account, authority)
+                            && checkContactsPermission(authority);
             syncCheckBox.setChecked(syncEnabled);
             setSummary(syncCheckBox, authority, syncEnabled);
 
@@ -464,6 +467,11 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                             return false;
                         }
                     } else {
+                        if (account == null) {
+                            // if account could not be created for some reason,
+                            // we can't have our sync
+                            return false;
+                        }
                         // disable syncs
                         ContentResolver.setSyncAutomatically(account, authority, false);
                         // immediately delete any linked contacts

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -19,7 +19,9 @@
 package org.sufficientlysecure.keychain.util;
 
 
+import android.accounts.Account;
 import android.annotation.SuppressLint;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Parcel;
@@ -29,6 +31,7 @@ import android.support.annotation.NonNull;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.Constants.Pref;
+import org.sufficientlysecure.keychain.KeychainApplication;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
 
@@ -76,9 +79,8 @@ public class Preferences {
 
     /**
      * Makes android's preference framework write to our file instead of default.
-     * This allows us to use the "persistent" attribute to simplify code, which automatically
+     * This allows us to use the xml "persistent" attribute to simplify code, which automatically
      * writes and reads preference values.
-     * @param manager
      */
     public static void setPreferenceManagerFileAndMode(PreferenceManager manager) {
         manager.setSharedPreferencesName(PREF_FILE_NAME);
@@ -300,6 +302,23 @@ public class Preferences {
             return parcelableProxy.getProxy();
         }
 
+    }
+
+    /**
+     * @return true if a periodic sync exists and is set to run automatically, false otherwise
+     */
+    public static boolean getKeyserverSyncEnabled(Context context) {
+        Account account = KeychainApplication.createAccountIfNecessary(context);
+
+        if (account == null) {
+            // if the account could not be created for some reason, we can't have a sync
+            return false;
+        }
+
+        String authority = Constants.PROVIDER_AUTHORITY;
+
+        return ContentResolver.getSyncAutomatically(account, authority) &&
+                !ContentResolver.getPeriodicSyncs(account, authority).isEmpty();
     }
 
     public CacheTTLPrefs getPassphraseCacheTtl() {


### PR DESCRIPTION
Until now the only way to update sync interval was uninstalling/re-installing the app. Shouldn't have affected any of our release builds since we never changed it.