### PR TITLE
Provisional backup-code text selection fix

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
@@ -43,6 +43,7 @@ import android.support.v4.app.FragmentManager.OnBackStackChangedListener;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
+import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -236,6 +237,30 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
         setupAutomaticLinebreak(mCodeEditText);
         mCodeEditText.setImeOptions(EditorInfo.IME_ACTION_DONE);
         setupEditTextSuccessListener(mCodeEditText);
+
+        // prevent selection action mode, partially circumventing text selection bug
+        mCodeEditText.setCustomSelectionActionModeCallback(new ActionMode.Callback() {
+            @Override
+            public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+                return false;
+            }
+
+            @Override
+            public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+                return false;
+            }
+
+            @Override
+            public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+                return false;
+            }
+
+            @Override
+            public void onDestroyActionMode(ActionMode mode) {
+
+            }
+        });
+
 
         TextView codeDisplayText = (TextView) view.findViewById(R.id.backup_code_display);
         setupAutomaticLinebreak(codeDisplayText);


### PR DESCRIPTION
For #[1779](https://github.com/open-keychain/open-keychain/issues/1779),
A provisional fix is made to make selection more difficult. Preventing selection altogether is not possible due to the internal implementation in the Masked-Edittext dependency.

To be updated when Masked-Edittext fixes this bug.