### PR TITLE
Fix Crash on encrypt using revoked key

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
@@ -254,6 +254,11 @@ public class KeyListFragment extends LoaderFragment
                 String keysSelected = getResources().getQuantityString(
                         R.plurals.key_list_selected_keys, count, count);
                 mode.setTitle(keysSelected);
+                if (mAdapter.isAnyRevokedKeySelected()) {
+                    mode.getMenu().getItem(0).setVisible(false);
+                } else {
+                    mode.getMenu().getItem(0).setVisible(true);
+                }
             }
 
         });
@@ -942,6 +947,15 @@ public class KeyListFragment extends LoaderFragment
                 ids[i++] = getMasterKeyId(pos);
             }
             return ids;
+        }
+
+        public boolean isAnyRevokedKeySelected() {
+            for (int pos : mSelection.keySet()) {
+                if (getItem(pos).mIsRevoked) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public void removeSelection(int position) {


### PR DESCRIPTION
To Reproduce
1. Revoke a key
2. Select it from the main screen 
3. Try encrypt file using menu icon in the action bar 

Fix:
Hide encrypt icon in the action bar if any selected key is revoked 