### PR TITLE
Prevent crashing caused by MaskedEditText

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
@@ -393,10 +393,10 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
 
             private void catchMassDelete(CharSequence s, int deleteStart, int deleteCount) {
                 if(processing) {
-                    // currently processing multi-delete
+                    // currently processing mass-delete
                     massDelete = false;
                 } else {
-                    // catch multi-delete if present
+                    // catch mass-delete if present
                     massDelete = (deleteCount > 1);
                     before = s.toString();
                     cursorPosition = deleteStart + deleteCount;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
@@ -41,6 +41,7 @@ import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentManager.OnBackStackChangedListener;
 import android.text.Editable;
+import android.text.InputFilter;
 import android.text.InputType;
 import android.text.TextWatcher;
 import android.view.ActionMode;
@@ -53,10 +54,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateInterpolator;
 import android.view.inputmethod.EditorInfo;
-import android.widget.EditText;
 import android.widget.TextView;
-
-import com.github.pinball83.maskededittext.MaskedEditText;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
@@ -64,6 +62,7 @@ import org.sufficientlysecure.keychain.operations.results.ExportResult;
 import org.sufficientlysecure.keychain.provider.TemporaryFileProvider;
 import org.sufficientlysecure.keychain.service.BackupKeyringParcel;
 import org.sufficientlysecure.keychain.ui.base.CryptoOperationFragment;
+import org.sufficientlysecure.keychain.ui.util.NoSelectionMaskedEditText;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.Notify.ActionListener;
 import org.sufficientlysecure.keychain.ui.util.Notify.Style;
@@ -96,7 +95,7 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
     private long[] mMasterKeyIds;
     String mBackupCode;
 
-    private MaskedEditText mCodeEditText;
+    private NoSelectionMaskedEditText mCodeEditText;
 
     private ToolableViewAnimator mStatusAnimator, mTitleAnimator, mCodeFieldsAnimator;
     private Integer mBackStackLevel;
@@ -231,12 +230,12 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
         mExportSecret = args.getBoolean(ARG_EXPORT_SECRET);
 
         // NOTE: order of these method calls matter, see setupAutomaticLinebreak()
-        mCodeEditText = (MaskedEditText) view.findViewById(R.id.backup_code_input);
+        mCodeEditText = (NoSelectionMaskedEditText) view.findViewById(R.id.backup_code_input);
         mCodeEditText.setInputType(
                 InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS);
         setupAutomaticLinebreak(mCodeEditText);
         mCodeEditText.setImeOptions(EditorInfo.IME_ACTION_DONE);
-        setupEditTextSuccessListener(mCodeEditText);
+        setupEditTextListener(mCodeEditText);
 
         // prevent selection action mode, partially circumventing text selection bug
         mCodeEditText.setCustomSelectionActionModeCallback(new ActionMode.Callback() {
@@ -359,11 +358,16 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
         textview.setHorizontallyScrolling(false);
     }
 
-    private void setupEditTextSuccessListener(final MaskedEditText backupCode) {
+    private void setupEditTextListener(final NoSelectionMaskedEditText backupCode) {
         backupCode.addTextChangedListener(new TextWatcher() {
+            private String before;
+            private boolean massDelete = false;
+            private boolean processing = false;
+            private int cursorPosition = -1;
+
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-
+                catchMassDelete(s, start, count);
             }
 
             @Override
@@ -372,15 +376,49 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
 
             @Override
             public void afterTextChanged(Editable s) {
+                preventMassDelete(s);
                 String currentBackupCode = backupCode.getText().toString();
+
                 boolean inInputState = mCurrentState == BackupCodeState.STATE_INPUT
                         || mCurrentState == BackupCodeState.STATE_INPUT_ERROR;
-                boolean partIsComplete = (currentBackupCode.indexOf(' ') == -1);
+                boolean partIsComplete = (currentBackupCode.length() > 0)
+                                        && (currentBackupCode.indexOf(' ') == -1);
+
                 if (!inInputState || !partIsComplete) {
                     return;
                 }
 
                 checkIfCodeIsCorrect(currentBackupCode);
+            }
+
+            private void catchMassDelete(CharSequence s, int deleteStart, int deleteCount) {
+                if(processing) {
+                    // currently processing multi-delete
+                    massDelete = false;
+                } else {
+                    // catch multi-delete if present
+                    massDelete = (deleteCount > 1);
+                    before = s.toString();
+                    cursorPosition = deleteStart + deleteCount;
+                }
+            }
+
+            private void preventMassDelete(Editable s) {
+                if(massDelete) {
+                    // TextWatcher catches editable being cleared and appended
+
+                    // InputFilters are removed temporarily to reduce complications
+                    processing = true;
+                    InputFilter[] oldFilters = s.getFilters();
+                    s.setFilters(new InputFilter[0]);
+                    s.clear();
+                    s.append(before);
+                    s.setFilters(oldFilters);
+                    processing = false;
+
+                    // emulate single delete behavior by deleting single char
+                    s.delete(cursorPosition - 1, cursorPosition);
+                }
             }
         });
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
@@ -392,20 +392,21 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
             }
 
             private void catchMassDelete(CharSequence s, int deleteStart, int deleteCount) {
-                if(processing) {
-                    // currently processing mass-delete
-                    massDelete = false;
-                } else {
+                if(!processing) {
                     // catch mass-delete if present
                     massDelete = (deleteCount > 1);
                     before = s.toString();
                     cursorPosition = deleteStart + deleteCount;
+                } else {
+                    // currently processing mass-delete, stop capturing
+                    massDelete = false;
                 }
             }
 
             private void preventMassDelete(Editable s) {
                 if(massDelete) {
-                    // TextWatcher catches editable being cleared and appended
+                    // TextWatcher catches editable being edited
+                    // catchMassDelete is set to ignore those operations
 
                     // InputFilters are removed temporarily to reduce complications
                     processing = true;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/NoSelectionMaskedEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/NoSelectionMaskedEditText.java
@@ -1,0 +1,69 @@
+package org.sufficientlysecure.keychain.ui.util;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.SystemClock;
+import android.text.InputFilter;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.ActionMode;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.ViewConfiguration;
+
+import com.github.pinball83.maskededittext.MaskedEditText;
+
+import java.util.ListIterator;
+
+public class NoSelectionMaskedEditText extends MaskedEditText {
+    private long mLastTouchTime = SystemClock.uptimeMillis();
+
+    public NoSelectionMaskedEditText(Context context) {
+        super(context);
+    }
+
+    public NoSelectionMaskedEditText(Context context, String mask, String notMaskedSymbol) {
+        super(context, mask, notMaskedSymbol);
+    }
+
+    public NoSelectionMaskedEditText(Context context, String mask, String notMaskedSymbol, Drawable maskIcon) {
+        super(context, mask, notMaskedSymbol, maskIcon);
+    }
+
+    public NoSelectionMaskedEditText(Context context, String mask, String notMaskedSymbol, Drawable maskIcon, MaskIconCallback maskIconCallback) {
+        super(context, mask, notMaskedSymbol, maskIcon, maskIconCallback);
+    }
+
+    public NoSelectionMaskedEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public NoSelectionMaskedEditText(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        int prevSelectionPosition = this.getSelectionStart();
+
+        boolean result = super.onTouchEvent(event);
+        if(isDoubleTap(event)) {
+            this.setSelection(prevSelectionPosition);
+        }
+
+        mLastTouchTime = SystemClock.uptimeMillis();
+        return result;
+    }
+
+    private boolean isDoubleTap(MotionEvent event) {
+        long currentTime = SystemClock.uptimeMillis();
+
+        return event.getActionMasked() == MotionEvent.ACTION_DOWN
+                && currentTime - mLastTouchTime <= ViewConfiguration.getDoubleTapTimeout();
+    }
+
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/NoSelectionMaskedEditText.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/NoSelectionMaskedEditText.java
@@ -48,11 +48,11 @@ public class NoSelectionMaskedEditText extends MaskedEditText {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        int prevSelectionPosition = this.getSelectionStart();
+        int positionBeforeSelection = this.getSelectionStart();
 
         boolean result = super.onTouchEvent(event);
         if(isDoubleTap(event)) {
-            this.setSelection(prevSelectionPosition);
+            this.setSelection(positionBeforeSelection);
         }
 
         mLastTouchTime = SystemClock.uptimeMillis();

--- a/OpenKeychain/src/main/res/layout-w600dp/backup_code_fragment.xml
+++ b/OpenKeychain/src/main/res/layout-w600dp/backup_code_fragment.xml
@@ -74,7 +74,7 @@
             tools:ignore="SpUsage"
             tools:text="AAAA-AAAA-AAAA-AAAA-AAAA-AAAA" />
 
-        <com.github.pinball83.maskededittext.MaskedEditText
+        <org.sufficientlysecure.keychain.ui.util.NoSelectionMaskedEditText
             android:id="@+id/backup_code_input"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/OpenKeychain/src/main/res/layout/backup_code_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/backup_code_fragment.xml
@@ -74,7 +74,7 @@
             tools:ignore="SpUsage"
             tools:text="AAAA-AAAA-AAAA-AAAA-AAAA-AAAA" />
 
-        <com.github.pinball83.maskededittext.MaskedEditText
+        <org.sufficientlysecure.keychain.ui.util.NoSelectionMaskedEditText
             android:id="@+id/backup_code_input"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Refer to #1809
Crashing is caused by mass deletion of text. Two fixes are introduced to prevent this.

1) Prevent mass delete when backspace button is held
SuccessTextWatcher is modified to watch for mass delete, and to emulate a single delete if detected.

2) Prevent mass selection when double tapping
OnTouch method of MaskedEditText is overridden, limiting selection size to 0.

Note that fix 2) is required as allowing mass selection but not allowing mass delete does not make sense in a UX perspective.