### PR TITLE
Correctly handle keys only having an email address

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/KeyRing.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/KeyRing.java
@@ -61,6 +61,8 @@ public abstract class KeyRing {
 
     private static final Pattern USER_ID_PATTERN = Pattern.compile("^(.*?)(?: \\((.*)\\))?(?: <(.*)>)?$");
 
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^.*@.*\\..*$");
+
     /**
      * Splits userId string into naming part, email part, and comment part
      * <p/>
@@ -71,7 +73,14 @@ public abstract class KeyRing {
         if (!TextUtils.isEmpty(userId)) {
             final Matcher matcher = USER_ID_PATTERN.matcher(userId);
             if (matcher.matches()) {
-                return new UserId(matcher.group(1), matcher.group(3), matcher.group(2));
+                String name = matcher.group(1).isEmpty() ? null : matcher.group(1);
+                String comment = matcher.group(2);
+                String email = matcher.group(3);
+                if (comment == null && email == null && name != null && EMAIL_PATTERN.matcher(name).matches()) {
+                    email = name;
+                    name = null;
+                }
+                return new UserId(name, email, comment);
             }
         }
         return new UserId(null, null, null);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
@@ -54,7 +54,7 @@ import java.io.IOException;
  */
 public class KeychainDatabase extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "openkeychain.db";
-    private static final int DATABASE_VERSION = 16;
+    private static final int DATABASE_VERSION = 17;
     static Boolean apgHack = false;
     private Context mContext;
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -456,12 +456,12 @@ public class KeychainProvider extends ContentProvider {
                             if (i != 0) {
                                 emailWhere += " OR ";
                             }
-                            emailWhere += "tmp." + UserPackets.USER_ID + " LIKE ";
-                            // match '*<email>', so it has to be at the *end* of the user id
                             if (match == KEY_RINGS_FIND_BY_EMAIL) {
-                                emailWhere += DatabaseUtils.sqlEscapeString("%<" + chunks[i] + ">");
+                                emailWhere += "tmp." + UserPackets.EMAIL + " LIKE "
+                                        + DatabaseUtils.sqlEscapeString(chunks[i]);
                             } else {
-                                emailWhere += DatabaseUtils.sqlEscapeString("%" + chunks[i] + "%");
+                                emailWhere += "tmp." + UserPackets.USER_ID + " LIKE "
+                                        + DatabaseUtils.sqlEscapeString("%" + chunks[i] + "%");
                             }
                             gotCondition = true;
                         }

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/SplitUserIdTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/SplitUserIdTest.java
@@ -28,7 +28,7 @@ import org.sufficientlysecure.keychain.WorkaroundBuildConfig;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = WorkaroundBuildConfig.class, sdk = 21, manifest = "src/main/AndroidManifest.xml")
-public class KeyRingTest {
+public class SplitUserIdTest {
 
     @Test
     public void splitCompleteUserIdShouldReturnAll3Components() throws Exception {
@@ -49,9 +49,40 @@ public class KeyRingTest {
     @Test
     public void splitUserIdWithAllButEmailShouldReturnNameAndComment() throws Exception {
         KeyRing.UserId info = KeyRing.splitUserId("Max Mustermann (this is a comment)");
-        Assert.assertEquals(info.name, "Max Mustermann");
-        Assert.assertEquals(info.comment, "this is a comment");
+        Assert.assertEquals("Max Mustermann", info.name);
+        Assert.assertEquals("this is a comment", info.comment);
         Assert.assertNull(info.email);
     }
 
+    @Test
+    public void splitUserIdWithCommentAndEmailShouldReturnCommentAndEmail() throws Exception {
+        KeyRing.UserId info = KeyRing.splitUserId(" (this is a comment) <max@example.com>");
+        Assert.assertNull(info.name);
+        Assert.assertEquals("this is a comment", info.comment);
+        Assert.assertEquals("max@example.com", info.email);
+    }
+
+    @Test
+    public void splitUserIdWithEmailShouldReturnEmail() throws Exception {
+        KeyRing.UserId info = KeyRing.splitUserId("max@example.com");
+        Assert.assertNull(info.name);
+        Assert.assertNull(info.comment);
+        Assert.assertEquals("max@example.com", info.email);
+    }
+
+    @Test
+    public void splitUserIdWithNameShouldReturnName() throws Exception {
+        KeyRing.UserId info = KeyRing.splitUserId("Max Mustermann");
+        Assert.assertEquals("Max Mustermann", info.name);
+        Assert.assertNull(info.comment);
+        Assert.assertNull(info.email);
+    }
+
+    @Test
+    public void splitUserIdWithCommentShouldReturnComment() throws Exception {
+        KeyRing.UserId info = KeyRing.splitUserId(" (this is a comment)");
+        Assert.assertNull(info.name);
+        Assert.assertEquals("this is a comment", info.comment);
+        Assert.assertNull(info.email);
+    }
 }


### PR DESCRIPTION
When a key has a user id only consisting of an email, that email is wrongly taken as name.
fixes #1699