### PR TITLE
Fix Unusable signing key not properly disabled, Issue #1468

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertifyKeySpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertifyKeySpinner.java
@@ -113,11 +113,6 @@ public class CertifyKeySpinner extends KeySpinner {
 
     @Override
     boolean isItemEnabled(Cursor cursor) {
-        // "none" entry is always enabled!
-        if (cursor.getPosition() == 0) {
-            return true;
-        }
-
         if (cursor.getInt(KeyAdapter.INDEX_IS_REVOKED) != 0) {
             return false;
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/SignKeySpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/SignKeySpinner.java
@@ -72,11 +72,6 @@ public class SignKeySpinner extends KeySpinner {
 
     @Override
     boolean isItemEnabled(Cursor cursor) {
-        // "none" entry is always enabled!
-        if (cursor.getPosition() == 0) {
-            return true;
-        }
-
         if (cursor.getInt(KeyAdapter.INDEX_IS_REVOKED) != 0) {
             return false;
         }


### PR DESCRIPTION
In CertifyKeySpinner and SignKeySpinner item at position 0 will not be "none" entry because they are inner adapters. Please see KeySpinner.java:156. That's why even if the first key is revoked or didn't have a signing subkey it is selectable because it consider them as "none" entries.