### PR TITLE
Fix Wrong file encrypted from cached input

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptFilesFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptFilesFragment.java
@@ -729,6 +729,8 @@ public class EncryptFilesFragment
                     // make sure this is correct at this point
                     mAfterEncryptAction = AfterEncryptAction.SAVE;
                     cryptoOperation(new CryptoInputParcel(new Date()));
+                } else if (resultCode == Activity.RESULT_CANCELED) {
+                    onCryptoOperationCancelled();
                 }
                 return;
             }


### PR DESCRIPTION
To reproduce it:

1.  Select a file to encrypt
2.  Click on the save icon
<< Now user might realize that he selected the wrong file to encrypt So, he/she will cancel it (don't save) >>
3.  Remove file
4.  Select correct file
5.  Save it

But it will still encrypt the previous file from cache.