### PR TITLE
WIP: Add Nitrokey support

### DIFF
--- a/OpenKeychain/src/main/res/xml/usb_device_filter.xml
+++ b/OpenKeychain/src/main/res/xml/usb_device_filter.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-    Based on https://github.com/Yubico/yubikey-personalization/blob/master/ykcore/ykdef.h
+    Based on
+    https://github.com/Yubico/yubikey-personalization/blob/master/ykcore/ykdef.h
+    https://www.nitrokey.com/de/documentation/installation#p:nitrokey-pro&os:linux
+
     Note that values are decimal.
 -->
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
@@ -23,5 +26,13 @@
     <usb-device class="11" vendor-id="4176" product-id="1030"/>
     <!-- Yubikey 4 OTP + U2F + CCID-->
     <usb-device class="11" vendor-id="4176" product-id="1031"/>
+
+
+    <!-- Nitrokey Pro-->
+    <usb-device class="11" vendor-id="8352" product-id="16648"/>
+    <!-- Nitrokey Storage-->
+    <usb-device class="11" vendor-id="8352" product-id="16649"/>
+    <!-- Nitrokey Start-->
+    <usb-device class="11" vendor-id="8352" product-id="16913"/>
 
 </resources>


### PR DESCRIPTION
Currently I get
```
AndroidRuntime  E  Process: org.sufficientlysecure.keychain.debug, PID: 1924
  1924         AndroidRuntime  E  java.lang.RuntimeException: An error occured while executing doInBackground()
  1924         AndroidRuntime  E  at android.os.AsyncTask$3.done(AsyncTask.java:304)
  1924         AndroidRuntime  E  at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:355)
  1924         AndroidRuntime  E  at java.util.concurrent.FutureTask.setException(FutureTask.java:222)
  1924         AndroidRuntime  E  at java.util.concurrent.FutureTask.run(FutureTask.java:242)
  1924         AndroidRuntime  E  at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:231)
  1924         AndroidRuntime  E  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
  1924         AndroidRuntime  E  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
  1924         AndroidRuntime  E  at java.lang.Thread.run(Thread.java:818)
  1924         AndroidRuntime  E  Caused by: java.lang.OutOfMemoryError: Failed to allocate a 688448510 byte allocation with 16777216 free bytes and 166MB until OOM
  1924         AndroidRuntime  E  at org.sufficientlysecure.keychain.securitytoken.UsbTransport.receive(UsbTransport.java:255)
  1924         AndroidRuntime  E  at org.sufficientlysecure.keychain.securitytoken.UsbTransport.setIccPower(UsbTransport.java:82)
  1924         AndroidRuntime  E  at org.sufficientlysecure.keychain.securitytoken.UsbTransport.connect(UsbTransport.java:192)
  1924         AndroidRuntime  E  at org.sufficientlysecure.keychain.securitytoken.SecurityTokenHelper.connectToDevice(SecurityTokenHelper.java:150)
  1924         AndroidRuntime  E  at org.sufficientlysecure.keychain.ui.base.BaseSecurityTokenNfcActivity.handleSecurityToken(BaseSecurityTokenNfcActivity.java:412)
  1924         AndroidRuntime  E  at org.sufficientlysecure.keychain.ui.base.BaseSecurityTokenNfcActivity$1.doInBackground(BaseSecurityTokenNfcActivity.java:171)
  1924         AndroidRuntime  E  at org.sufficientlysecure.keychain.ui.base.BaseSecurityTokenNfcActivity$1.doInBackground(BaseSecurityTokenNfcActivity.java:161)
  1924         AndroidRuntime  E  at android.os.AsyncTask$2.call(AsyncTask.java:292)
  1924         AndroidRuntime  E  at java.util.concurrent.FutureTask.run(FutureTask.java:237)
  1924         AndroidRuntime  E  ... 4 more
```