### PR TITLE
Adds support for ACTION_DECODE_PUBLIC_KEY

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -69,6 +69,8 @@ import org.sufficientlysecure.keychain.pgp.PgpSignEncryptData;
 import org.sufficientlysecure.keychain.pgp.PgpSignEncryptInputParcel;
 import org.sufficientlysecure.keychain.pgp.PgpSignEncryptOperation;
 import org.sufficientlysecure.keychain.pgp.Progressable;
+import org.sufficientlysecure.keychain.pgp.UncachedKeyRing;
+import org.sufficientlysecure.keychain.pgp.UncachedPublicKey;
 import org.sufficientlysecure.keychain.pgp.exception.PgpKeyNotFoundException;
 import org.sufficientlysecure.keychain.provider.ApiDataAccessObject;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
@@ -625,6 +627,34 @@ public class OpenPgpService extends Service {
         }
     }
 
+    private Intent decodeKeyImpl(InputStream inputStream) {
+        Intent result = new Intent();
+
+        UncachedKeyRing.IteratorWithIOThrow<UncachedKeyRing> iterator =
+                UncachedKeyRing.fromStream(inputStream);
+        try {
+            if (iterator.hasNext()) {
+                UncachedPublicKey publicKey = iterator.next().getPublicKey();
+
+                result.putExtra(OpenPgpApi.RESULT_KEY_ID, publicKey.getKeyId());
+
+                ArrayList<String> userIds = publicKey.getUnorderedUserIds();
+                result.putExtra(OpenPgpApi.RESULT_USER_IDS,
+                        userIds.toArray(new String[userIds.size()]));
+
+                result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+            } else {
+                // not even a single keyring present
+                throw new IOException("No valid key data!");
+            }
+        } catch (IOException e) {
+            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
+            result.putExtra(OpenPgpApi.RESULT_ERROR,
+                    new OpenPgpError(OpenPgpError.GENERIC_ERROR, e.getMessage()));
+        }
+        return result;
+    }
+
     private Intent getKeyImpl(Intent data, OutputStream outputStream) {
         try {
             ApiPendingIntentFactory piFactory = new ApiPendingIntentFactory(getBaseContext());
@@ -971,6 +1001,9 @@ public class OpenPgpService extends Service {
             }
             case OpenPgpApi.ACTION_GET_KEY: {
                 return getKeyImpl(data, outputStream);
+            }
+            case OpenPgpApi.ACTION_DECODE_PUBLIC_KEY: {
+                return decodeKeyImpl(inputStream);
             }
             case OpenPgpApi.ACTION_BACKUP: {
                 return backupImpl(data, outputStream);


### PR DESCRIPTION
Reads a public key in from the InputStream and returns the master key id, and user ids.
Necessary for the contact key retrieval portion in OX.

Was tested with Conversations (the action and result strings were hardcoded).

Current workflow in Conversations:
- Contact key downloaded, key ID and user IDs retrieved via this action.
- If xmpp:user@email is one of the user IDs, ACTION_GET_KEY is used with the key id to check if the key already exists in OK. Else, an error is toasted saying contact key does not contain the required user id.
- If the key does not exist in OK, it should be added (would firing an "Import Key via OK" intent suffice?).
- If the key exists in OK, it is associated with the contact in Conversations.

Depends on https://github.com/open-keychain/openpgp-api/pull/6 being merged before the corresponding submodule can be updated.
