### PR TITLE
Signature message digest

### DIFF
--- a/OpenKeychain/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPContentDigest.java
+++ b/OpenKeychain/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPContentDigest.java
@@ -1,0 +1,46 @@
+package org.bouncycastle.openpgp.operator.jcajce;
+
+
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+
+import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
+import org.bouncycastle.openpgp.PGPException;
+
+
+public class JcaPGPContentDigest {
+    private MessageDigest digest;
+
+    private JcaPGPContentDigest(MessageDigest digest) {
+        this.digest = digest;
+    }
+
+    public static JcaPGPContentDigest newInstance(String providerName, int hashAlgorithm) {
+        OperatorHelper helper = new OperatorHelper(new NamedJcaJceHelper(providerName));
+
+        try {
+            MessageDigest digest = helper.createDigest(hashAlgorithm);
+            return new JcaPGPContentDigest(digest);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("Unknown algorithm!");
+        } catch (PGPException e) {
+            throw new IllegalArgumentException("Unknown algorithm!");
+        }
+    }
+
+    public void update(byte b) {
+        digest.update(b);
+    }
+
+    public void update(byte[] input) {
+        digest.update(input, 0, input.length);
+    }
+
+    public void update(byte[] input, int offset, int len) {
+        digest.update(input, offset, len);
+    }
+
+    public byte[] digest() {
+        return digest.digest();
+    }
+}

--- a/OpenKeychain/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPRawDigestContentVerifierBuilderProvider.java
+++ b/OpenKeychain/src/main/java/org/bouncycastle/openpgp/operator/jcajce/JcaPGPRawDigestContentVerifierBuilderProvider.java
@@ -1,0 +1,153 @@
+package org.bouncycastle.openpgp.operator.jcajce;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.InvalidKeyException;
+import java.security.Provider;
+import java.security.Signature;
+import java.security.SignatureException;
+
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERNull;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.DigestInfo;
+import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
+import org.bouncycastle.jcajce.provider.util.DigestFactory;
+import org.bouncycastle.jcajce.util.DefaultJcaJceHelper;
+import org.bouncycastle.jcajce.util.NamedJcaJceHelper;
+import org.bouncycastle.jcajce.util.ProviderJcaJceHelper;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPRuntimeOperationException;
+import org.bouncycastle.openpgp.operator.PGPContentVerifier;
+import org.bouncycastle.openpgp.operator.PGPContentVerifierBuilder;
+import org.bouncycastle.openpgp.operator.PGPContentVerifierBuilderProvider;
+
+public class JcaPGPRawDigestContentVerifierBuilderProvider
+        implements PGPContentVerifierBuilderProvider
+{
+    private OperatorHelper helper = new OperatorHelper(new DefaultJcaJceHelper());
+    private JcaPGPKeyConverter keyConverter = new JcaPGPKeyConverter();
+
+    public JcaPGPRawDigestContentVerifierBuilderProvider()
+    {
+    }
+
+    public JcaPGPRawDigestContentVerifierBuilderProvider setProvider(Provider provider)
+    {
+        this.helper = new OperatorHelper(new ProviderJcaJceHelper(provider));
+        keyConverter.setProvider(provider);
+
+        return this;
+    }
+
+    public JcaPGPRawDigestContentVerifierBuilderProvider setProvider(String providerName)
+    {
+        this.helper = new OperatorHelper(new NamedJcaJceHelper(providerName));
+        keyConverter.setProvider(providerName);
+
+        return this;
+    }
+
+    public PGPContentVerifierBuilder get(int keyAlgorithm, int hashAlgorithm)
+            throws PGPException
+    {
+        return new JcaPGPRawDigestContentVerifierBuilder(keyAlgorithm, hashAlgorithm);
+    }
+
+    private class JcaPGPRawDigestContentVerifierBuilder
+            implements PGPContentVerifierBuilder
+    {
+        private int hashAlgorithm;
+        private int keyAlgorithm;
+        private ByteArrayOutputStream outputStream;
+
+        public JcaPGPRawDigestContentVerifierBuilder(int keyAlgorithm, int hashAlgorithm)
+        {
+            this.keyAlgorithm = keyAlgorithm;
+            this.hashAlgorithm = hashAlgorithm;
+        }
+
+        public PGPContentVerifier build(final PGPPublicKey publicKey)
+                throws PGPException
+        {
+            final Signature signature = helper.createSignature(keyAlgorithm);
+
+            outputStream = new ByteArrayOutputStream();
+
+            try
+            {
+                signature.initVerify(keyConverter.getPublicKey(publicKey));
+            }
+            catch (InvalidKeyException e)
+            {
+                throw new PGPException("invalid key.", e);
+            }
+
+            return new PGPContentVerifier()
+            {
+                public int getHashAlgorithm()
+                {
+                    return hashAlgorithm;
+                }
+
+                public int getKeyAlgorithm()
+                {
+                    return keyAlgorithm;
+                }
+
+                public long getKeyID()
+                {
+                    return publicKey.getKeyID();
+                }
+
+                public boolean verify(byte[] expected)
+                {
+                    try {
+                        byte[] rawBytes = outputStream.toByteArray();
+                        byte[] encodedBytes = applyDigestEncoding(keyAlgorithm, hashAlgorithm, rawBytes);
+
+                        signature.update(encodedBytes);
+
+                        return signature.verify(expected);
+                    }
+                    catch (SignatureException e)
+                    {
+                        throw new PGPRuntimeOperationException("unable to verify signature: " + e.getMessage(), e);
+                    }
+                    catch (IOException e)
+                    {
+                        throw new IllegalStateException(e);
+                    }
+                }
+
+                public OutputStream getOutputStream()
+                {
+                    return outputStream;
+                }
+            };
+        }
+    }
+
+    private static byte[] applyDigestEncoding(int keyAlgorithm, int hashAlgorithm, byte[] bytes) throws IOException {
+        switch (keyAlgorithm) {
+            case PublicKeyAlgorithmTags.RSA_GENERAL:
+            case PublicKeyAlgorithmTags.RSA_SIGN:
+                try {
+                    String digestName = PGPUtil.getDigestName(hashAlgorithm);
+                    ASN1ObjectIdentifier digestIdentifier = DigestFactory.getOID(digestName);
+                    DigestInfo dInfo = new DigestInfo(
+                            new AlgorithmIdentifier(digestIdentifier, DERNull.INSTANCE), bytes);
+
+                    return dInfo.getEncoded(ASN1Encoding.DER);
+                } catch (PGPException e) {
+                    throw new IOException("Unknown hashing algorithm!", e);
+                }
+
+            default:
+                return bytes;
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpDecryptVerifyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpDecryptVerifyOperation.java
@@ -355,7 +355,7 @@ public class PgpDecryptVerifyOperation extends BaseOperation<PgpDecryptVerifyInp
         }
 
         PgpSignatureChecker signatureChecker = new PgpSignatureChecker(mProviderHelper, input.getSenderAddress());
-        if (signatureChecker.initializeOnePassSignature(dataChunk, log, indent +1)) {
+        if (signatureChecker.initializeSignatureOnePass(dataChunk, log, indent +1)) {
             dataChunk = plainFact.nextObject();
         }
 
@@ -875,7 +875,7 @@ public class PgpDecryptVerifyOperation extends BaseOperation<PgpDecryptVerifyInp
         PgpSignatureChecker signatureChecker = new PgpSignatureChecker(mProviderHelper, input.getSenderAddress());
 
         Object o = pgpFact.nextObject();
-        if (!signatureChecker.initializeSignature(o, log, indent+1)) {
+        if (!signatureChecker.initializeSignatureCleartext(o, log, indent+1)) {
             log.add(LogType.MSG_DC_ERROR_INVALID_DATA, 0);
             return new DecryptVerifyResult(DecryptVerifyResult.RESULT_ERROR, log);
         }
@@ -885,7 +885,7 @@ public class PgpDecryptVerifyOperation extends BaseOperation<PgpDecryptVerifyInp
                 updateProgress(R.string.progress_verifying_signature, 90, 100);
 
                 signatureChecker.updateSignatureWithCleartext(clearText);
-                signatureChecker.verifySignature(log, indent);
+                signatureChecker.verifySignatureCleartext(log, indent);
 
             } catch (SignatureException e) {
                 Log.d(Constants.TAG, "SignatureException", e);
@@ -929,7 +929,7 @@ public class PgpDecryptVerifyOperation extends BaseOperation<PgpDecryptVerifyInp
 
         PgpSignatureChecker signatureChecker = new PgpSignatureChecker(mProviderHelper, input.getSenderAddress());
 
-        if ( ! signatureChecker.initializeSignature(o, log, indent+1)) {
+        if ( ! signatureChecker.initializeSignatureDetached(o, log, indent+1)) {
             log.add(LogType.MSG_DC_ERROR_INVALID_DATA, 0);
             return new DecryptVerifyResult(DecryptVerifyResult.RESULT_ERROR, log);
         }
@@ -964,9 +964,8 @@ public class PgpDecryptVerifyOperation extends BaseOperation<PgpDecryptVerifyInp
             }
 
             updateProgress(R.string.progress_verifying_signature, 90, 100);
-            log.add(LogType.MSG_DC_CLEAR_SIGNATURE_CHECK, indent);
 
-            signatureChecker.verifySignature(log, indent);
+            signatureChecker.verifySignatureDetached(log, indent);
 
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignatureChecker.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignatureChecker.java
@@ -289,9 +289,11 @@ class PgpSignatureChecker {
         PGPContentVerifierBuilder pgpContentVerifierBuilder = new JcaPGPRawDigestContentVerifierBuilderProvider()
                 .get(signingKey.getAlgorithm(), signature.getHashAlgorithm());
         PGPContentVerifier pgpContentVerifier = pgpContentVerifierBuilder.build(signingKey.getPublicKey());
+        byte[] signedMessageDigest = digest.digest();
+
         try {
             OutputStream outputStream = pgpContentVerifier.getOutputStream();
-            outputStream.write(digest.digest());
+            outputStream.write(signedMessageDigest);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -310,6 +312,7 @@ class PgpSignatureChecker {
         }
 
         signatureResultBuilder.setValidSignature(validSignature);
+        signatureResultBuilder.setSignedMessageDigest(signedMessageDigest);
     }
 
     public byte[] getSigningFingerprint() {


### PR DESCRIPTION
This PR changes `PgpSignatureChecker` to obtain the computed message digest as an intermediate result, which is then placed in OpenPgpSignatureResult.

Unfortunately, I had to work around BouncyCastle a bit more than I would have liked. Most importantly, I ended up doing the PKCS1 DER formatting for RSA signatures manually which uh, sort of sucks. It seems to be the intended way though, since there is a comment "For raw RSA, the DigestInfo must be prepared externally" in DigestSignatureSpi.

The point of this is that this digest can be cached, and revisited at a later point. This is helpful internally because we can "refresh" the key status simply by running the verification again. It also means we don't have to decrypt and verify all data again after download if we didn't have a signing key available when we first processed the data.

The same applies for client apps. Decryption delay in K-9 is a serious problem, which is why I would like to cache some of the decryption results in K-9 at some point. However, just caching the decrypted data isn't enough, and I really wouldn't feel comfortable "caching" the signature status, since it can change over time (due to expiry or revocation).
