### PR TITLE
Travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ env:
 
 # force non-container build
 sudo: required
-# OpenJDK 6 and OpenJDK 7 processes will encounter buffer overflows when the host name is too long.
-# hostname addon disabled due to https://github.com/travis-ci/travis-ci/issues/5669
-# https://docs.travis-ci.com/user/hostname
-#addons:
-#    hostname: short-hostname
-# workaround from https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
 before_install:
   - sudo add-apt-repository ppa:openjdk-r/ppa -y
   - sudo apt-get update
@@ -19,15 +13,10 @@ before_install:
   - sudo update-alternatives --auto java
   - sudo update-alternatives --auto javac
   - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-  - cat /etc/hosts # optionally check the content *before*
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-  - cat /etc/hosts # optionally check the content *after*
 
 android:
   components:
     - tools
-    - tools # Per https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943
     - android-22
     - android-23
     - android-24


### PR DESCRIPTION
~~Testing, ignore this PR for now~~
Actually wanted to use trusty so using ppa's won't be needed, but `language: android` doesn't work there :/ Anyway cleaned up a bit as a side effect of testing.