### PR TITLE
KeychainDatabase: enable secure_delete explicitly to address GH #1905

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
@@ -238,6 +238,8 @@ public class KeychainDatabase extends SQLiteOpenHelper {
         if (!db.isReadOnly()) {
             // Enable foreign key constraints
             db.execSQL("PRAGMA foreign_keys=ON;");
+            // Enable secure delete for older Android versions not using it by default
+            db.execSQL("PRAGMA secure_delete=ON;");
         }
     }
 


### PR DESCRIPTION
When the database is open, alongside enabling foreign key support, enable secure_delete so that platforms that support secure_delete will use it even if the default wasn't to enable it.