### PR TITLE
OpenPgpSignatureResult v5

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/OpenPgpSignatureResultBuilder.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/OpenPgpSignatureResultBuilder.java
@@ -21,6 +21,7 @@ package org.sufficientlysecure.keychain.pgp;
 import java.util.ArrayList;
 
 import org.openintents.openpgp.OpenPgpSignatureResult;
+import org.openintents.openpgp.OpenPgpSignatureResult.SenderStatusResult;
 import org.openintents.openpgp.util.OpenPgpUtils;
 import org.openintents.openpgp.util.OpenPgpUtils.UserId;
 import org.sufficientlysecure.keychain.Constants;
@@ -42,7 +43,7 @@ public class OpenPgpSignatureResultBuilder {
     private ArrayList<String> mUserIds = new ArrayList<>();
     private ArrayList<String> mConfirmedUserIds;
     private long mKeyId;
-    private int mSenderStatus;
+    private SenderStatusResult mSenderStatusResult;
 
     // builder
     private boolean mSignatureAvailable = false;
@@ -125,14 +126,14 @@ public class OpenPgpSignatureResultBuilder {
 
             if (mSenderAddress != null) {
                 if (userIdListContainsAddress(mSenderAddress, confirmedUserIds)) {
-                    setSenderStatus(OpenPgpSignatureResult.SENDER_RESULT_UID_CONFIRMED);
+                    mSenderStatusResult = SenderStatusResult.USER_ID_CONFIRMED;
                 } else if (userIdListContainsAddress(mSenderAddress, allUserIds)) {
-                    setSenderStatus(OpenPgpSignatureResult.SENDER_RESULT_UID_UNCONFIRMED);
+                    mSenderStatusResult = SenderStatusResult.USER_ID_UNCONFIRMED;
                 } else {
-                    setSenderStatus(OpenPgpSignatureResult.SENDER_RESULT_UID_MISSING);
+                    mSenderStatusResult = SenderStatusResult.USER_ID_MISSING;
                 }
             } else {
-                setSenderStatus(OpenPgpSignatureResult.SENDER_RESULT_NO_SENDER);
+                mSenderStatusResult = SenderStatusResult.UNKNOWN;
             }
 
         } catch (NotFoundException e) {
@@ -189,14 +190,11 @@ public class OpenPgpSignatureResultBuilder {
         }
 
         return OpenPgpSignatureResult.createWithValidSignature(
-                signatureStatus, mPrimaryUserId, mKeyId, mUserIds, mConfirmedUserIds, mSenderStatus);
+                signatureStatus, mPrimaryUserId, mKeyId, mUserIds, mConfirmedUserIds, mSenderStatusResult);
     }
 
     public void setSenderAddress(String senderAddress) {
         mSenderAddress = senderAddress;
     }
 
-    public void setSenderStatus(int senderStatus) {
-        mSenderStatus = senderStatus;
-    }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/OpenPgpSignatureResultBuilder.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/OpenPgpSignatureResultBuilder.java
@@ -19,6 +19,7 @@ package org.sufficientlysecure.keychain.pgp;
 
 
 import java.util.ArrayList;
+import java.util.Date;
 
 import org.openintents.openpgp.OpenPgpSignatureResult;
 import org.openintents.openpgp.OpenPgpSignatureResult.SenderStatusResult;
@@ -54,6 +55,7 @@ public class OpenPgpSignatureResultBuilder {
     private boolean mIsKeyExpired = false;
     private boolean mInsecure = false;
     private String mSenderAddress;
+    private Date mSignatureTimestamp;
 
     public OpenPgpSignatureResultBuilder(ProviderHelper providerHelper) {
         this.mProviderHelper = providerHelper;
@@ -65,6 +67,10 @@ public class OpenPgpSignatureResultBuilder {
 
     public void setKeyId(long keyId) {
         this.mKeyId = keyId;
+    }
+
+    public void setSignatureTimestamp(Date signatureTimestamp) {
+        mSignatureTimestamp = signatureTimestamp;
     }
 
     public void setKnownKey(boolean knownKey) {
@@ -163,7 +169,7 @@ public class OpenPgpSignatureResultBuilder {
 
         if (!mKnownKey) {
             Log.d(Constants.TAG, "RESULT_KEY_MISSING");
-            return OpenPgpSignatureResult.createWithKeyMissing(mKeyId);
+            return OpenPgpSignatureResult.createWithKeyMissing(mKeyId, mSignatureTimestamp);
         }
 
         if (!mValidSignature) {
@@ -190,7 +196,7 @@ public class OpenPgpSignatureResultBuilder {
         }
 
         return OpenPgpSignatureResult.createWithValidSignature(
-                signatureStatus, mPrimaryUserId, mKeyId, mUserIds, mConfirmedUserIds, mSenderStatusResult);
+                signatureStatus, mPrimaryUserId, mKeyId, mUserIds, mConfirmedUserIds, mSenderStatusResult, mSignatureTimestamp);
     }
 
     public void setSenderAddress(String senderAddress) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignatureChecker.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignatureChecker.java
@@ -237,6 +237,7 @@ class PgpSignatureChecker {
             signatureResultBuilder.setInsecure(true);
         }
 
+        signatureResultBuilder.setSignatureTimestamp(signature.getCreationTime());
         signatureResultBuilder.setValidSignature(validSignature);
 
     }
@@ -271,6 +272,7 @@ class PgpSignatureChecker {
             signatureResultBuilder.setInsecure(true);
         }
 
+        signatureResultBuilder.setSignatureTimestamp(messageSignature.getCreationTime());
         signatureResultBuilder.setValidSignature(validSignature);
 
         return true;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -519,11 +519,11 @@ public class OpenPgpService extends Service {
                                         signatureResult.getKeyId()));
                         break;
                     }
-                    case OpenPgpSignatureResult.RESULT_VALID_CONFIRMED:
-                    case OpenPgpSignatureResult.RESULT_VALID_UNCONFIRMED:
+                    case OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED:
+                    case OpenPgpSignatureResult.RESULT_VALID_KEY_UNCONFIRMED:
                     case OpenPgpSignatureResult.RESULT_INVALID_KEY_REVOKED:
                     case OpenPgpSignatureResult.RESULT_INVALID_KEY_EXPIRED:
-                    case OpenPgpSignatureResult.RESULT_INVALID_INSECURE: {
+                    case OpenPgpSignatureResult.RESULT_INVALID_KEY_INSECURE: {
                         // If signature key is known, return PendingIntent to show key
                         result.putExtra(OpenPgpApi.RESULT_INTENT,
                                 piFactory.createShowKeyPendingIntent(data, signatureResult.getKeyId()));
@@ -546,7 +546,7 @@ public class OpenPgpService extends Service {
 
                 if (data.getIntExtra(OpenPgpApi.EXTRA_API_VERSION, -1) < 8) {
                     // RESULT_INVALID_INSECURE has been added in version 8, fallback to RESULT_INVALID_SIGNATURE
-                    if (signatureResult.getResult() == OpenPgpSignatureResult.RESULT_INVALID_INSECURE) {
+                    if (signatureResult.getResult() == OpenPgpSignatureResult.RESULT_INVALID_KEY_INSECURE) {
                         signatureResult = OpenPgpSignatureResult.createWithInvalidSignature();
                     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
@@ -327,7 +327,7 @@ public abstract class DecryptFragment extends Fragment implements LoaderManager.
         // revoked/expired subkeys
         boolean isRevoked = mSignatureResult.getResult() == OpenPgpSignatureResult.RESULT_INVALID_KEY_REVOKED;
         boolean isExpired = mSignatureResult.getResult() == OpenPgpSignatureResult.RESULT_INVALID_KEY_EXPIRED;
-        boolean isInsecure = mSignatureResult.getResult() == OpenPgpSignatureResult.RESULT_INVALID_INSECURE;
+        boolean isInsecure = mSignatureResult.getResult() == OpenPgpSignatureResult.RESULT_INVALID_KEY_INSECURE;
         boolean isVerified = data.getInt(INDEX_VERIFIED) > 0;
         boolean isYours = data.getInt(INDEX_HAS_ANY_SECRET) != 0;
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/KeyFormattingUtils.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/KeyFormattingUtils.java
@@ -507,7 +507,7 @@ public class KeyFormattingUtils {
                 break;
             }
 
-            case OpenPgpSignatureResult.RESULT_VALID_CONFIRMED: {
+            case OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED: {
                 sigText = R.string.decrypt_result_signature_certified;
                 sigIcon = R.drawable.status_signature_verified_cutout_24dp;
                 sigColor = R.color.key_flag_green;
@@ -516,7 +516,7 @@ public class KeyFormattingUtils {
                 break;
             }
 
-            case OpenPgpSignatureResult.RESULT_VALID_UNCONFIRMED: {
+            case OpenPgpSignatureResult.RESULT_VALID_KEY_UNCONFIRMED: {
                 sigText = R.string.decrypt_result_signature_uncertified;
                 sigIcon = R.drawable.status_signature_unverified_cutout_24dp;
                 sigColor = R.color.key_flag_orange;
@@ -552,7 +552,7 @@ public class KeyFormattingUtils {
                 break;
             }
 
-            case OpenPgpSignatureResult.RESULT_INVALID_INSECURE: {
+            case OpenPgpSignatureResult.RESULT_INVALID_KEY_INSECURE: {
                 sigText = R.string.decrypt_result_insecure_cryptography;
                 sigIcon = R.drawable.status_signature_invalid_cutout_24dp;
                 sigColor = R.color.key_flag_red;

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpEncryptDecryptTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpEncryptDecryptTest.java
@@ -28,6 +28,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 
 import org.apache.tools.ant.util.StringUtils;
+import org.bouncycastle.bcpg.BCPGInputStream;
+import org.bouncycastle.bcpg.Packet;
+import org.bouncycastle.bcpg.PacketTags;
+import org.bouncycastle.bcpg.PublicKeyEncSessionPacket;
+import org.bouncycastle.bcpg.sig.KeyFlags;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -40,13 +46,6 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
-import org.bouncycastle.bcpg.BCPGInputStream;
-import org.bouncycastle.bcpg.Packet;
-import org.bouncycastle.bcpg.PacketTags;
-import org.bouncycastle.bcpg.PublicKeyEncSessionPacket;
-import org.bouncycastle.bcpg.sig.KeyFlags;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openpgp.PGPKeyFlags;
 import org.sufficientlysecure.keychain.WorkaroundBuildConfig;
 import org.sufficientlysecure.keychain.operations.results.DecryptVerifyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult.LogType;
@@ -336,7 +335,7 @@ public class PgpEncryptDecryptTest {
             Assert.assertEquals("decryptionResult should be RESULT_NOT_ENCRYPTED",
                     OpenPgpDecryptionResult.RESULT_NOT_ENCRYPTED, result.getDecryptionResult().getResult());
             Assert.assertEquals("signatureResult should be RESULT_VALID_CONFIRMED",
-                    OpenPgpSignatureResult.RESULT_VALID_CONFIRMED, result.getSignatureResult().getResult());
+                    OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED, result.getSignatureResult().getResult());
 
             OpenPgpMetadata metadata = result.getDecryptionMetadata();
             Assert.assertEquals("filesize must be correct",
@@ -398,7 +397,7 @@ public class PgpEncryptDecryptTest {
             Assert.assertEquals("decryptionResult should be RESULT_NOT_ENCRYPTED",
                     OpenPgpDecryptionResult.RESULT_NOT_ENCRYPTED, result.getDecryptionResult().getResult());
             Assert.assertEquals("signatureResult should be RESULT_VALID_CONFIRMED",
-                    OpenPgpSignatureResult.RESULT_VALID_CONFIRMED, result.getSignatureResult().getResult());
+                    OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED, result.getSignatureResult().getResult());
 
             OpenPgpMetadata metadata = result.getDecryptionMetadata();
             Assert.assertEquals("filesize must be correct",
@@ -454,7 +453,7 @@ public class PgpEncryptDecryptTest {
             Assert.assertEquals("decryptionResult should be RESULT_NOT_ENCRYPTED",
                     OpenPgpDecryptionResult.RESULT_NOT_ENCRYPTED, result.getDecryptionResult().getResult());
             Assert.assertEquals("signatureResult should be RESULT_VALID_CONFIRMED",
-                    OpenPgpSignatureResult.RESULT_VALID_CONFIRMED, result.getSignatureResult().getResult());
+                    OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED, result.getSignatureResult().getResult());
 
             // TODO should detached verify return any metadata?
             // OpenPgpMetadata metadata = result.getDecryptionMetadata();
@@ -901,7 +900,7 @@ public class PgpEncryptDecryptTest {
             Assert.assertArrayEquals("decrypted ciphertext with cached passphrase  should equal plaintext",
                     out.toByteArray(), plaintext.getBytes());
             Assert.assertEquals("signature should be verified and certified",
-                    OpenPgpSignatureResult.RESULT_VALID_CONFIRMED, result.getSignatureResult().getResult());
+                    OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED, result.getSignatureResult().getResult());
 
             OpenPgpMetadata metadata = result.getDecryptionMetadata();
             Assert.assertEquals("filesize must be correct",

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/provider/InteropTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/provider/InteropTest.java
@@ -158,8 +158,8 @@ public class InteropTest {
             // Certain keys are too short, so we check appropriately.
             int code = result.getSignatureResult().getResult();
             Assert.assertTrue(base + ": should have a signature",
-                    (code == OpenPgpSignatureResult.RESULT_INVALID_INSECURE) ||
-                    (code == OpenPgpSignatureResult.RESULT_VALID_UNCONFIRMED));
+                    (code == OpenPgpSignatureResult.RESULT_INVALID_KEY_INSECURE) ||
+                    (code == OpenPgpSignatureResult.RESULT_VALID_KEY_UNCONFIRMED));
         }
         OpenPgpMetadata metadata = result.getDecryptionMetadata();
         Assert.assertEquals(base + ": filesize must be correct",


### PR DESCRIPTION
This PR primarily deprecates v3 of OpenPgpSignatureResult, switching out the int constants of sender result info for an enum. Note that this breaks *forward* compatibility, i.e. if OpenKeychain cannot be newer than the client app it won't work. However, v3 (i.e. sender result) has so far only been used experimentally in the K-9 beta, so if we leave some time between rolling out a new version in K-9 and only then mergereleasing this, it should be fine.

While I was at it, I added a field for the signature timestamp in version 5. No concrete plans to use it yet, but the timestamp definitely belongs next to other signature info. (this closes #1949)