### PR TITLE
fix loading of multiple keys simultaneously

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/processing/ImportKeysOperationCallback.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/processing/ImportKeysOperationCallback.java
@@ -24,15 +24,18 @@ import org.sufficientlysecure.keychain.ui.base.CryptoOperationHelper;
 public class ImportKeysOperationCallback implements
         CryptoOperationHelper.Callback<ImportKeyringParcel, ImportKeyResult> {
 
-    private ImportKeysResultListener mResultListener;
-    private ImportKeyringParcel mKeyringParcel;
+    private final ImportKeysResultListener mResultListener;
+    private final ImportKeyringParcel mKeyringParcel;
+    private final Integer mPosition;
 
     public ImportKeysOperationCallback(
             ImportKeysResultListener resultListener,
-            ImportKeyringParcel inputParcel
+            ImportKeyringParcel inputParcel,
+            Integer position
     ) {
         this.mResultListener = resultListener;
         this.mKeyringParcel = inputParcel;
+        this.mPosition = position;
     }
 
     @Override
@@ -42,7 +45,7 @@ public class ImportKeysOperationCallback implements
 
     @Override
     public void onCryptoOperationSuccess(ImportKeyResult result) {
-        mResultListener.handleResult(result);
+        mResultListener.handleResult(result, mPosition);
     }
 
     @Override
@@ -52,7 +55,7 @@ public class ImportKeysOperationCallback implements
 
     @Override
     public void onCryptoOperationError(ImportKeyResult result) {
-        mResultListener.handleResult(result);
+        mResultListener.handleResult(result, mPosition);
     }
 
     @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/processing/ImportKeysResultListener.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/processing/ImportKeysResultListener.java
@@ -21,6 +21,6 @@ import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 
 public interface ImportKeysResultListener {
 
-    void handleResult(ImportKeyResult result);
+    void handleResult(ImportKeyResult result, Integer position);
 
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteImportKeysActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteImportKeysActivity.java
@@ -37,7 +37,7 @@ public class RemoteImportKeysActivity extends ImportKeysActivity {
     }
 
     @Override
-    public void handleResult(ImportKeyResult result) {
+    public void handleResult(ImportKeyResult result, Integer position) {
         setResult(RESULT_OK, mPendingIntentData);
         finish();
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
@@ -359,13 +359,13 @@ public class ImportKeysActivity extends BaseActivity implements ImportKeysListen
         }
 
         ImportKeyringParcel inputParcel = new ImportKeyringParcel(null, null);
-        ImportKeysOperationCallback callback = new ImportKeysOperationCallback(this, inputParcel);
+        ImportKeysOperationCallback callback = new ImportKeysOperationCallback(this, inputParcel, null);
         mOpHelper = new CryptoOperationHelper<>(1, this, callback, R.string.progress_importing);
         mOpHelper.cryptoOperation();
     }
 
     @Override
-    public void handleResult(ImportKeyResult result) {
+    public void handleResult(ImportKeyResult result, Integer position) {
         String intentAction = getIntent().getAction();
 
         if (ImportKeysActivity.ACTION_IMPORT_KEY_FROM_KEYSERVER_AND_RETURN_RESULT.equals(intentAction)


### PR DESCRIPTION
the way `mCurrent` was used simply wasn't capable of handling multiple processes at once. proposed fix