### PR TITLE
Move key extraction logic into its own class

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpServiceKeyIdExtractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpServiceKeyIdExtractor.java
@@ -1,0 +1,213 @@
+package org.sufficientlysecure.keychain.remote;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+
+import android.app.PendingIntent;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+import org.openintents.openpgp.OpenPgpError;
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.openintents.openpgp.util.OpenPgpUtils;
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.pgp.KeyRing;
+import org.sufficientlysecure.keychain.provider.KeychainContract;
+import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
+import org.sufficientlysecure.keychain.provider.KeychainDatabase.Tables;
+import org.sufficientlysecure.keychain.util.Log;
+
+
+class OpenPgpServiceKeyIdExtractor {
+    @VisibleForTesting
+    static final String[] KEY_SEARCH_PROJECTION = new String[]{
+            KeyRings._ID,
+            KeyRings.MASTER_KEY_ID,
+            KeyRings.IS_EXPIRED, // referenced in where clause!
+            KeyRings.IS_REVOKED, // referenced in where clause!
+    };
+    private static final int INDEX_MASTER_KEY_ID = 1;
+
+    // do not pre-select revoked or expired keys
+    private static final String KEY_SEARCH_WHERE = Tables.KEYS + "." + KeychainContract.KeyRings.IS_REVOKED
+            + " = 0 AND " + KeychainContract.KeyRings.IS_EXPIRED + " = 0";
+
+
+    private final ApiPendingIntentFactory apiPendingIntentFactory;
+    private final ContentResolver contentResolver;
+
+
+    static OpenPgpServiceKeyIdExtractor getInstance(ContentResolver contentResolver, ApiPendingIntentFactory apiPendingIntentFactory) {
+        return new OpenPgpServiceKeyIdExtractor(contentResolver, apiPendingIntentFactory);
+    }
+
+    private OpenPgpServiceKeyIdExtractor(ContentResolver contentResolver,
+            ApiPendingIntentFactory apiPendingIntentFactory) {
+        this.contentResolver = contentResolver;
+        this.apiPendingIntentFactory = apiPendingIntentFactory;
+    }
+
+
+    KeyIdResult returnKeyIdsFromIntent(Intent data, boolean askIfNoUserIdsProvided) {
+        HashSet<Long> encryptKeyIds = new HashSet<>();
+
+        boolean hasKeysFromSelectPubkeyActivity = data.hasExtra(OpenPgpApi.EXTRA_KEY_IDS_SELECTED);
+        if (hasKeysFromSelectPubkeyActivity) {
+            for (long keyId : data.getLongArrayExtra(OpenPgpApi.EXTRA_KEY_IDS_SELECTED)) {
+                encryptKeyIds.add(keyId);
+            }
+        } else if (data.hasExtra(OpenPgpApi.EXTRA_USER_IDS) || askIfNoUserIdsProvided) {
+            String[] userIds = data.getStringArrayExtra(OpenPgpApi.EXTRA_USER_IDS);
+            boolean isOpportunistic = data.getBooleanExtra(OpenPgpApi.EXTRA_OPPORTUNISTIC_ENCRYPTION, false);
+            KeyIdResult result = returnKeyIdsFromEmails(data, userIds, isOpportunistic);
+
+            if (result.mResultIntent != null) {
+                return result;
+            }
+            encryptKeyIds.addAll(result.mKeyIds);
+        }
+
+        // add key ids from non-ambiguous key id extra
+        if (data.hasExtra(OpenPgpApi.EXTRA_KEY_IDS)) {
+            for (long keyId : data.getLongArrayExtra(OpenPgpApi.EXTRA_KEY_IDS)) {
+                encryptKeyIds.add(keyId);
+            }
+        }
+
+        if (encryptKeyIds.isEmpty()) {
+            Intent result = new Intent();
+            result.putExtra(OpenPgpApi.RESULT_ERROR,
+                    new OpenPgpError(OpenPgpError.NO_USER_IDS, "No encryption keys or user ids specified!" +
+                            "(pass empty user id array to get dialog without preselection)"));
+            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
+            return new KeyIdResult(result);
+        }
+
+        return new KeyIdResult(encryptKeyIds);
+    }
+
+    private KeyIdResult returnKeyIdsFromEmails(Intent data, String[] encryptionUserIds, boolean isOpportunistic) {
+        boolean hasUserIds = (encryptionUserIds != null && encryptionUserIds.length > 0);
+
+        HashSet<Long> keyIds = new HashSet<>();
+        ArrayList<String> missingEmails = new ArrayList<>();
+        ArrayList<String> duplicateEmails = new ArrayList<>();
+        if (hasUserIds) {
+            for (String rawUserId : encryptionUserIds) {
+                OpenPgpUtils.UserId userId = KeyRing.splitUserId(rawUserId);
+                String email = userId.email != null ? userId.email : rawUserId;
+                // try to find the key for this specific email
+                Uri uri = KeyRings.buildUnifiedKeyRingsFindByEmailUri(email);
+                Cursor cursor = contentResolver.query(uri, KEY_SEARCH_PROJECTION, KEY_SEARCH_WHERE, null, null);
+                if (cursor == null) {
+                    throw new IllegalStateException("Internal error, received null cursor!");
+                }
+                try {
+                    // result should be one entry containing the key id
+                    if (cursor.moveToFirst()) {
+                        long id = cursor.getLong(INDEX_MASTER_KEY_ID);
+                        keyIds.add(id);
+
+                        // another entry for this email -> two keys with the same email inside user id
+                        if (!cursor.isLast()) {
+                            Log.d(Constants.TAG, "more than one user id with the same email");
+                            duplicateEmails.add(email);
+
+                            // also pre-select
+                            while (cursor.moveToNext()) {
+                                long duplicateId = cursor.getLong(INDEX_MASTER_KEY_ID);
+                                keyIds.add(duplicateId);
+                            }
+                        }
+                    } else {
+                        missingEmails.add(email);
+                        Log.d(Constants.TAG, "user id missing");
+                    }
+                } finally {
+                    cursor.close();
+                }
+            }
+        }
+
+        boolean hasMissingUserIds = !missingEmails.isEmpty();
+        boolean hasDuplicateUserIds = !duplicateEmails.isEmpty();
+        if (isOpportunistic && (!hasUserIds || hasMissingUserIds)) {
+            Intent result = new Intent();
+            result.putExtra(OpenPgpApi.RESULT_ERROR,
+                    new OpenPgpError(OpenPgpError.OPPORTUNISTIC_MISSING_KEYS, "missing keys in opportunistic mode"));
+            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
+            return new KeyIdResult(result);
+        }
+
+        if (!hasUserIds || hasMissingUserIds || hasDuplicateUserIds) {
+            long[] keyIdsArray = getUnboxedLongArray(keyIds);
+            PendingIntent pi = apiPendingIntentFactory.createSelectPublicKeyPendingIntent(data, keyIdsArray,
+                    missingEmails, duplicateEmails, hasUserIds);
+
+            // return PendingIntent to be executed by client
+            Intent result = new Intent();
+            result.putExtra(OpenPgpApi.RESULT_INTENT, pi);
+            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED);
+            return new KeyIdResult(result);
+        }
+
+        if (keyIds.isEmpty()) {
+            throw new AssertionError("keyIdsArray.length == 0, should never happen!");
+        }
+
+        return new KeyIdResult(keyIds);
+    }
+
+    @NonNull
+    private static long[] getUnboxedLongArray(@NonNull Collection<Long> arrayList) {
+        long[] result = new long[arrayList.size()];
+        int i = 0;
+        for (Long e : arrayList) {
+            result[i++] = e;
+        }
+        return result;
+    }
+
+    static class KeyIdResult {
+        private final Intent mResultIntent;
+        private final HashSet<Long> mKeyIds;
+
+        private KeyIdResult(Intent resultIntent) {
+            mResultIntent = resultIntent;
+            mKeyIds = null;
+        }
+        private KeyIdResult(HashSet<Long> keyIds) {
+            mResultIntent = null;
+            mKeyIds = keyIds;
+        }
+
+        boolean hasResultIntent() {
+            return mResultIntent != null;
+        }
+        Intent getResultIntent() {
+            if (mResultIntent == null) {
+                throw new AssertionError("result intent must not be null when getResultIntent is called!");
+            }
+            if (mKeyIds != null) {
+                throw new AssertionError("key ids must be null when getKeyIds is called!");
+            }
+            return mResultIntent;
+        }
+        long[] getKeyIds() {
+            if (mResultIntent != null) {
+                throw new AssertionError("result intent must be null when getKeyIds is called!");
+            }
+            if (mKeyIds == null) {
+                throw new AssertionError("key ids must not be null when getKeyIds is called!");
+            }
+            return getUnboxedLongArray(mKeyIds);
+        }
+    }
+
+}

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/OpenPgpServiceKeyIdExtractorTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/OpenPgpServiceKeyIdExtractorTest.java
@@ -1,0 +1,274 @@
+package org.sufficientlysecure.keychain.remote;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import android.app.PendingIntent;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openintents.openpgp.OpenPgpError;
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.sufficientlysecure.keychain.WorkaroundBuildConfig;
+import org.sufficientlysecure.keychain.remote.OpenPgpServiceKeyIdExtractor.KeyIdResult;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = WorkaroundBuildConfig.class, sdk = 23, manifest = "src/main/AndroidManifest.xml")
+public class OpenPgpServiceKeyIdExtractorTest {
+
+    private static final long[] KEY_IDS = new long[] { 123L, 234L };
+    private static final String[] USER_IDS = new String[] { "user1@example.org", "User 2 <user2@example.org>" };
+    private OpenPgpServiceKeyIdExtractor openPgpServiceKeyIdExtractor;
+    private ContentResolver contentResolver;
+    private ApiPendingIntentFactory apiPendingIntentFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        contentResolver = mock(ContentResolver.class);
+        apiPendingIntentFactory = mock(ApiPendingIntentFactory.class);
+
+        openPgpServiceKeyIdExtractor = OpenPgpServiceKeyIdExtractor.getInstance(contentResolver,
+                apiPendingIntentFactory);
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withKeyIdsExtra() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, KEY_IDS);
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+        assertFalse(keyIdResult.hasResultIntent());
+        assertArrayEqualsSorted(KEY_IDS, keyIdResult.getKeyIds());
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withKeyIdsSelectedExtra() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_KEY_IDS_SELECTED, KEY_IDS);
+        intent.putExtra(OpenPgpApi.EXTRA_USER_IDS, USER_IDS); // should be ignored
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+        assertFalse(keyIdResult.hasResultIntent());
+        assertArrayEqualsSorted(KEY_IDS, keyIdResult.getKeyIds());
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withUserIds__withEmptyQueryResult() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_USER_IDS, USER_IDS);
+
+        setupContentResolverResult();
+
+        PendingIntent pendingIntent = mock(PendingIntent.class);
+        setupPendingIntentFactoryResult(pendingIntent);
+
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+
+        assertTrue(keyIdResult.hasResultIntent());
+        Intent resultIntent = keyIdResult.getResultIntent();
+        assertEquals(OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED,
+                resultIntent.getIntExtra(OpenPgpApi.RESULT_CODE, Integer.MAX_VALUE));
+        assertEquals(pendingIntent, resultIntent.getParcelableExtra(OpenPgpApi.RESULT_INTENT));
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withNoData() throws Exception {
+        Intent intent = new Intent();
+
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+
+        assertTrue(keyIdResult.hasResultIntent());
+        Intent resultIntent = keyIdResult.getResultIntent();
+        assertEquals(OpenPgpApi.RESULT_CODE_ERROR,
+                resultIntent.getIntExtra(OpenPgpApi.RESULT_CODE, Integer.MAX_VALUE));
+        assertEquals(OpenPgpError.NO_USER_IDS,
+                resultIntent.<OpenPgpError>getParcelableExtra(OpenPgpApi.RESULT_ERROR).getErrorId());
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withEmptyUserId() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_USER_IDS, new String[0]);
+
+        PendingIntent pendingIntent = mock(PendingIntent.class);
+        setupPendingIntentFactoryResult(pendingIntent);
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+
+        assertTrue(keyIdResult.hasResultIntent());
+        Intent resultIntent = keyIdResult.getResultIntent();
+        assertEquals(OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED,
+                resultIntent.getIntExtra(OpenPgpApi.RESULT_CODE, Integer.MAX_VALUE));
+        assertEquals(pendingIntent, resultIntent.getParcelableExtra(OpenPgpApi.RESULT_INTENT));
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withNoData__askIfNoData() throws Exception {
+        Intent intent = new Intent();
+
+        setupContentResolverResult();
+
+        PendingIntent pendingIntent = mock(PendingIntent.class);
+        setupPendingIntentFactoryResult(pendingIntent);
+
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, true);
+
+
+        assertTrue(keyIdResult.hasResultIntent());
+        Intent resultIntent = keyIdResult.getResultIntent();
+        assertEquals(OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED,
+                resultIntent.getIntExtra(OpenPgpApi.RESULT_CODE, Integer.MAX_VALUE));
+        assertEquals(pendingIntent, resultIntent.getParcelableExtra(OpenPgpApi.RESULT_INTENT));
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withUserIds__withEmptyQueryResult__inOpportunisticMode() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_USER_IDS, USER_IDS);
+        intent.putExtra(OpenPgpApi.EXTRA_OPPORTUNISTIC_ENCRYPTION, true);
+
+        setupContentResolverResult();
+
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+
+        assertTrue(keyIdResult.hasResultIntent());
+        Intent resultIntent = keyIdResult.getResultIntent();
+        assertEquals(OpenPgpApi.RESULT_CODE_ERROR, resultIntent.getIntExtra(OpenPgpApi.RESULT_CODE, Integer.MAX_VALUE));
+        assertEquals(OpenPgpError.OPPORTUNISTIC_MISSING_KEYS,
+                resultIntent.<OpenPgpError>getParcelableExtra(OpenPgpApi.RESULT_ERROR).getErrorId());
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withUserIds() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_USER_IDS, USER_IDS);
+
+        setupContentResolverResult(new long[][] {
+                new long[] { 123L },
+                new long[] { 234L }
+        });
+
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+
+        assertFalse(keyIdResult.hasResultIntent());
+        assertArrayEqualsSorted(KEY_IDS, keyIdResult.getKeyIds());
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withUserIds__withDuplicate() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_USER_IDS, USER_IDS);
+
+        setupContentResolverResult(new long[][] {
+                new long[] { 123L, 345L },
+                new long[] { 234L }
+        });
+
+        PendingIntent pendingIntent = mock(PendingIntent.class);
+        setupPendingIntentFactoryResult(pendingIntent);
+
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+
+        assertTrue(keyIdResult.hasResultIntent());
+        Intent resultIntent = keyIdResult.getResultIntent();
+        assertEquals(OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED,
+                resultIntent.getIntExtra(OpenPgpApi.RESULT_CODE, Integer.MAX_VALUE));
+        assertEquals(pendingIntent, resultIntent.getParcelableExtra(OpenPgpApi.RESULT_INTENT));
+    }
+
+    @Test
+    public void returnKeyIdsFromIntent__withUserIds__withMissing() throws Exception {
+        Intent intent = new Intent();
+        intent.putExtra(OpenPgpApi.EXTRA_USER_IDS, USER_IDS);
+
+        setupContentResolverResult(new long[][] {
+                new long[] { },
+                new long[] { 234L }
+        });
+
+        PendingIntent pendingIntent = mock(PendingIntent.class);
+        setupPendingIntentFactoryResult(pendingIntent);
+
+
+        KeyIdResult keyIdResult = openPgpServiceKeyIdExtractor.returnKeyIdsFromIntent(intent, false);
+
+
+        assertTrue(keyIdResult.hasResultIntent());
+        Intent resultIntent = keyIdResult.getResultIntent();
+        assertEquals(OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED,
+                resultIntent.getIntExtra(OpenPgpApi.RESULT_CODE, Integer.MAX_VALUE));
+        assertEquals(pendingIntent, resultIntent.getParcelableExtra(OpenPgpApi.RESULT_INTENT));
+    }
+
+    private void setupContentResolverResult() {
+        MatrixCursor resultCursor = new MatrixCursor(OpenPgpServiceKeyIdExtractor.KEY_SEARCH_PROJECTION);
+        when(contentResolver.query(
+                any(Uri.class), any(String[].class), any(String.class), any(String[].class), any(String.class)))
+                .thenReturn(resultCursor);
+    }
+
+    private void setupContentResolverResult(long[][] resultKeyIds) {
+        Cursor[] resultCursors = new MatrixCursor[resultKeyIds.length];
+        for (int i = 0; i < resultKeyIds.length; i++) {
+            MatrixCursor resultCursor = new MatrixCursor(OpenPgpServiceKeyIdExtractor.KEY_SEARCH_PROJECTION);
+            for (long keyId : resultKeyIds[i]) {
+                resultCursor.addRow(new Object[] { keyId, keyId, 0L, 0L });
+            }
+
+            resultCursors[i] = resultCursor;
+        }
+
+        when(contentResolver.query(
+                any(Uri.class), any(String[].class), any(String.class), any(String[].class), any(String.class)))
+                .thenReturn(resultCursors[0], Arrays.copyOfRange(resultCursors, 1, resultCursors.length));
+    }
+
+    private void setupPendingIntentFactoryResult(PendingIntent pendingIntent) {
+        when(apiPendingIntentFactory.createSelectPublicKeyPendingIntent(
+                any(Intent.class), any(long[].class), any(ArrayList.class), any(ArrayList.class), any(Boolean.class)))
+                .thenReturn(pendingIntent);
+    }
+
+
+    private static void assertArrayEqualsSorted(long[] a, long[] b) {
+        long[] tmpA = Arrays.copyOf(a, a.length);
+        long[] tmpB = Arrays.copyOf(b, b.length);
+        Arrays.sort(tmpA);
+        Arrays.sort(tmpB);
+
+        assertArrayEquals(tmpA, tmpB);
+    }
+}


### PR DESCRIPTION
This PR extracts the key logic ("which encryption keys to use, given a bunch of extras, possibly returning a pending intent for user interaction") from OpenPgpService into its own, testable class - and adds tests for it! Woop woop.

Also fixes #1990