### PR TITLE
[WIP] replaced some splitUserId (#1846)

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
@@ -109,6 +109,40 @@ public class CachedPublicKeyRing extends KeyRing {
         return getPrimaryUserId();
     }
 
+    public String getName() throws PgpKeyNotFoundException {
+        try {
+            Object data = mProviderHelper.getGenericData(mUri,
+                    KeyRings.NAME,
+                    ProviderHelper.FIELD_TYPE_STRING);
+            return (String) data;
+        } catch(ProviderHelper.NotFoundException e) {
+            throw new PgpKeyNotFoundException(e);
+        }
+    }
+
+    public String getEmail() throws PgpKeyNotFoundException {
+        try {
+            Object data = mProviderHelper.getGenericData(mUri,
+                    KeyRings.EMAIL,
+                    ProviderHelper.FIELD_TYPE_STRING);
+            return (String) data;
+        } catch(ProviderHelper.NotFoundException e) {
+            throw new PgpKeyNotFoundException(e);
+        }
+    }
+
+
+    public String getComment() throws PgpKeyNotFoundException {
+        try {
+            Object data = mProviderHelper.getGenericData(mUri,
+                    KeyRings.COMMENT,
+                    ProviderHelper.FIELD_TYPE_STRING);
+            return (String) data;
+        } catch(ProviderHelper.NotFoundException e) {
+            throw new PgpKeyNotFoundException(e);
+        }
+    }
+
     @Override
     public boolean isRevoked() throws PgpKeyNotFoundException {
         try {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -526,6 +526,9 @@ public class KeychainProvider extends ContentProvider {
                 projectionMap.put(UserPackets.MASTER_KEY_ID, Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID);
                 projectionMap.put(UserPackets.TYPE, Tables.USER_PACKETS + "." + UserPackets.TYPE);
                 projectionMap.put(UserPackets.USER_ID, Tables.USER_PACKETS + "." + UserPackets.USER_ID);
+                projectionMap.put(UserPackets.NAME, Tables.USER_PACKETS + "." + UserPackets.NAME);
+                projectionMap.put(UserPackets.EMAIL, Tables.USER_PACKETS + "." + UserPackets.EMAIL);
+                projectionMap.put(UserPackets.COMMENT, Tables.USER_PACKETS + "." + UserPackets.COMMENT);
                 projectionMap.put(UserPackets.ATTRIBUTE_DATA, Tables.USER_PACKETS + "." + UserPackets.ATTRIBUTE_DATA);
                 projectionMap.put(UserPackets.RANK, Tables.USER_PACKETS + "." + UserPackets.RANK);
                 projectionMap.put(UserPackets.IS_PRIMARY, Tables.USER_PACKETS + "." + UserPackets.IS_PRIMARY);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectEncryptKeyAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectEncryptKeyAdapter.java
@@ -181,14 +181,15 @@ public class SelectEncryptKeyAdapter extends KeyCursorAdapter<SelectEncryptKeyAd
             Context context = itemView.getContext();
 
             { // set name and stuff, common to both key types
-                OpenPgpUtils.UserId userIdSplit = cursor.getUserId();
-                if (userIdSplit.name != null) {
-                    mUserIdText.setText(highlighter.highlight(userIdSplit.name));
+                String name = cursor.getName();
+                String email = cursor.getEmail();
+                if (name != null) {
+                    mUserIdText.setText(highlighter.highlight(name));
                 } else {
                     mUserIdText.setText(R.string.user_id_no_name);
                 }
-                if (userIdSplit.email != null) {
-                    mUserIdRestText.setText(highlighter.highlight(userIdSplit.email));
+                if (email != null) {
+                    mUserIdRestText.setText(highlighter.highlight(email));
                     mUserIdRestText.setVisibility(View.VISIBLE);
                 } else {
                     mUserIdRestText.setVisibility(View.GONE);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectSignKeyAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectSignKeyAdapter.java
@@ -141,14 +141,15 @@ public class SelectSignKeyAdapter extends KeyCursorAdapter<CursorAdapter.KeyCurs
             Context context = itemView.getContext();
 
             { // set name and stuff, common to both key types
-                OpenPgpUtils.UserId userIdSplit = cursor.getUserId();
-                if (userIdSplit.name != null) {
-                    mUserIdText.setText(highlighter.highlight(userIdSplit.name));
+                String name = cursor.getName();
+                String email = cursor.getEmail();
+                if (name != null) {
+                    mUserIdText.setText(highlighter.highlight(name));
                 } else {
                     mUserIdText.setText(R.string.user_id_no_name);
                 }
-                if (userIdSplit.email != null) {
-                    mUserIdRestText.setText(highlighter.highlight(userIdSplit.email));
+                if (email != null) {
+                    mUserIdRestText.setText(highlighter.highlight(email));
                     mUserIdRestText.setVisibility(View.VISIBLE);
                 } else {
                     mUserIdRestText.setVisibility(View.GONE);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
@@ -275,6 +275,9 @@ public abstract class DecryptFragment extends Fragment implements LoaderManager.
             KeychainContract.KeyRings.USER_ID,
             KeychainContract.KeyRings.VERIFIED,
             KeychainContract.KeyRings.HAS_ANY_SECRET,
+            KeyRings.NAME,
+            KeyRings.EMAIL,
+            KeyRings.COMMENT,
     };
 
     @SuppressWarnings("unused")
@@ -282,6 +285,9 @@ public abstract class DecryptFragment extends Fragment implements LoaderManager.
     static final int INDEX_USER_ID = 2;
     static final int INDEX_VERIFIED = 3;
     static final int INDEX_HAS_ANY_SECRET = 4;
+    static final int INDEX_NAME = 5;
+    static final int INDEX_EMAIL = 6;
+    static final int INDEX_COMMENT = 7;
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
@@ -309,15 +315,15 @@ public abstract class DecryptFragment extends Fragment implements LoaderManager.
 
         long signatureKeyId = mSignatureResult.getKeyId();
 
-        String userId = data.getString(INDEX_USER_ID);
-        OpenPgpUtils.UserId userIdSplit = KeyRing.splitUserId(userId);
-        if (userIdSplit.name != null) {
-            mSignatureName.setText(userIdSplit.name);
+        String name = data.getString(INDEX_NAME);
+        String email = data.getString(INDEX_EMAIL);
+        if (name != null) {
+            mSignatureName.setText(name);
         } else {
             mSignatureName.setText(R.string.user_id_no_name);
         }
-        if (userIdSplit.email != null) {
-            mSignatureEmail.setText(userIdSplit.email);
+        if (email != null) {
+            mSignatureEmail.setText(email);
         } else {
             mSignatureEmail.setText(KeyFormattingUtils.beautifyKeyIdWithPrefix(
                     mSignatureResult.getKeyId()));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DeleteKeyDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DeleteKeyDialogActivity.java
@@ -93,7 +93,7 @@ public class DeleteKeyDialogActivity extends FragmentActivity {
             try {
                 HashMap<String, Object> data = new ProviderHelper(this).getUnifiedData(
                         mMasterKeyIds[0], new String[]{
-                                KeychainContract.KeyRings.USER_ID,
+                                KeychainContract.KeyRings.NAME,
                                 KeychainContract.KeyRings.IS_REVOKED
                         }, new int[]{
                                 ProviderHelper.FIELD_TYPE_STRING,
@@ -102,11 +102,10 @@ public class DeleteKeyDialogActivity extends FragmentActivity {
                 );
 
                 String name;
-                OpenPgpUtils.UserId mainUserId = KeyRing.splitUserId(
-                        (String) data.get(KeychainContract.KeyRings.USER_ID));
-                if (mainUserId.name != null) {
-                    name = mainUserId.name;
-                } else {
+
+                name = (String) data.get(KeychainContract.KeyRings.NAME);
+
+                if (name == null) {
                     name = getString(R.string.user_id_no_name);
                 }
 
@@ -274,7 +273,7 @@ public class DeleteKeyDialogActivity extends FragmentActivity {
                 try {
                     HashMap<String, Object> data = new ProviderHelper(activity).getUnifiedData(
                             masterKeyId, new String[]{
-                                    KeychainContract.KeyRings.USER_ID,
+                                    KeychainContract.KeyRings.NAME,
                                     KeychainContract.KeyRings.HAS_ANY_SECRET
                             }, new int[]{
                                     ProviderHelper.FIELD_TYPE_STRING,
@@ -282,10 +281,9 @@ public class DeleteKeyDialogActivity extends FragmentActivity {
                             }
                     );
                     String name;
-                    OpenPgpUtils.UserId mainUserId = KeyRing.splitUserId((String) data.get(KeychainContract.KeyRings.USER_ID));
-                    if (mainUserId.name != null) {
-                        name = mainUserId.name;
-                    } else {
+
+                    name = (String) data.get(KeychainContract.KeyRings.NAME);
+                    if (name == null) {
                         name = getString(R.string.user_id_no_name);
                     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MultiUserIdsFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MultiUserIdsFragment.java
@@ -59,7 +59,10 @@ public class MultiUserIdsFragment extends Fragment implements LoaderManager.Load
             KeychainContract.UserPackets.MASTER_KEY_ID,
             KeychainContract.UserPackets.USER_ID,
             KeychainContract.UserPackets.IS_PRIMARY,
-            KeychainContract.UserPackets.IS_REVOKED
+            KeychainContract.UserPackets.IS_REVOKED,
+            KeychainContract.UserPackets.NAME,
+            KeychainContract.UserPackets.EMAIL,
+            KeychainContract.UserPackets.COMMENT,
     };
     private static final int INDEX_MASTER_KEY_ID = 1;
     private static final int INDEX_USER_ID = 2;
@@ -67,6 +70,9 @@ public class MultiUserIdsFragment extends Fragment implements LoaderManager.Load
     private static final int INDEX_IS_PRIMARY = 3;
     @SuppressWarnings("unused")
     private static final int INDEX_IS_REVOKED = 4;
+    private static final int INDEX_NAME = 5;
+    private static final int INDEX_EMAIL = 6;
+    private static final int INDEX_COMMENT = 7;
 
     @Nullable
     @Override
@@ -169,14 +175,14 @@ public class MultiUserIdsFragment extends Fragment implements LoaderManager.Load
         while (!data.isAfterLast()) {
             long masterKeyId = data.getLong(INDEX_MASTER_KEY_ID);
             String userId = data.getString(INDEX_USER_ID);
-            OpenPgpUtils.UserId pieces = KeyRing.splitUserId(userId);
+            String name = data.getString(INDEX_NAME);
 
             // Two cases:
 
             boolean grouped = masterKeyId == lastMasterKeyId;
-            boolean subGrouped = data.isFirst() || grouped && lastName.equals(pieces.name);
+            boolean subGrouped = data.isFirst() || grouped && lastName.equals(name);
             // Remember for next loop
-            lastName = pieces.name;
+            lastName = name;
 
             Log.d(Constants.TAG, Long.toString(masterKeyId, 16) + (grouped ? "grouped" : "not grouped"));
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyActivity.java
@@ -822,7 +822,10 @@ public class ViewKeyActivity extends BaseSecurityTokenActivity implements
             KeychainContract.KeyRings.VERIFIED,
             KeychainContract.KeyRings.HAS_ANY_SECRET,
             KeychainContract.KeyRings.FINGERPRINT,
-            KeychainContract.KeyRings.HAS_ENCRYPT
+            KeychainContract.KeyRings.HAS_ENCRYPT,
+            KeyRings.NAME,
+            KeyRings.EMAIL,
+            KeyRings.COMMENT
     };
 
     static final int INDEX_MASTER_KEY_ID = 1;
@@ -833,6 +836,9 @@ public class ViewKeyActivity extends BaseSecurityTokenActivity implements
     static final int INDEX_HAS_ANY_SECRET = 6;
     static final int INDEX_FINGERPRINT = 7;
     static final int INDEX_HAS_ENCRYPT = 8;
+    static final int INDEX_NAME = 9;
+    static final int INDEX_EMAIL = 10;
+    static final int INDEX_COMMENT = 11;
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
@@ -885,12 +891,10 @@ public class ViewKeyActivity extends BaseSecurityTokenActivity implements
 
                 if (data.moveToFirst()) {
                     // get name, email, and comment from USER_ID
-                    OpenPgpUtils.UserId mainUserId = KeyRing.splitUserId(data.getString(INDEX_USER_ID));
-                    if (mainUserId.name != null) {
-                        mCollapsingToolbarLayout.setTitle(mainUserId.name);
-                    } else {
-                        mCollapsingToolbarLayout.setTitle(getString(R.string.user_id_no_name));
-                    }
+
+                    String name = data.getString(INDEX_NAME);
+
+                    mCollapsingToolbarLayout.setTitle(name != null ? name : getString(R.string.user_id_no_name));
 
                     mMasterKeyId = data.getLong(INDEX_MASTER_KEY_ID);
                     mFingerprint = data.getBlob(INDEX_FINGERPRINT);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvActivity.java
@@ -179,6 +179,9 @@ public class ViewKeyAdvActivity extends BaseActivity implements
             KeychainContract.KeyRings.VERIFIED,
             KeychainContract.KeyRings.HAS_ANY_SECRET,
             KeychainContract.KeyRings.FINGERPRINT,
+            KeychainContract.KeyRings.NAME,
+            KeychainContract.KeyRings.EMAIL,
+            KeychainContract.KeyRings.COMMENT,
     };
 
     static final int INDEX_MASTER_KEY_ID = 1;
@@ -188,6 +191,9 @@ public class ViewKeyAdvActivity extends BaseActivity implements
     static final int INDEX_VERIFIED = 5;
     static final int INDEX_HAS_ANY_SECRET = 6;
     static final int INDEX_FINGERPRINT = 7;
+    static final int INDEX_NAME = 8;
+    static final int INDEX_EMAIL = 9;
+    static final int INDEX_COMMENT = 10;
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
@@ -214,9 +220,10 @@ public class ViewKeyAdvActivity extends BaseActivity implements
             case LOADER_ID_UNIFIED: {
                 if (data.moveToFirst()) {
                     // get name, email, and comment from USER_ID
-                    OpenPgpUtils.UserId mainUserId = KeyRing.splitUserId(data.getString(INDEX_USER_ID));
-                    if (mainUserId.name != null) {
-                        setTitle(mainUserId.name);
+                    String name = data.getString(INDEX_NAME);
+
+                    if (name != null) {
+                        setTitle(name);
                     } else {
                         setTitle(R.string.user_id_no_name);
                     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/CertSectionedListAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/CertSectionedListAdapter.java
@@ -233,8 +233,19 @@ public class CertSectionedListAdapter extends SectionCursorAdapter<CertSectioned
             return getString(index);
         }
 
-        public OpenPgpUtils.UserId getUserId() {
-            return KeyRing.splitUserId(getRawUserId());
+        public String getName() {
+            int index = getColumnIndexOrThrow(KeychainContract.Certs.NAME);
+            return getString(index);
+        }
+
+        public String getEmail() {
+            int index = getColumnIndexOrThrow(KeychainContract.Certs.EMAIL);
+            return getString(index);
+        }
+
+        public String getComment() {
+            int index = getColumnIndexOrThrow(KeychainContract.Certs.COMMENT);
+            return getString(index);
         }
 
         public OpenPgpUtils.UserId getSignerUserId() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeyAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeyAdapter.java
@@ -66,7 +66,10 @@ public class KeyAdapter extends CursorAdapter {
             KeyRings.HAS_DUPLICATE_USER_ID,
             KeyRings.FINGERPRINT,
             KeyRings.CREATION,
-            KeyRings.HAS_ENCRYPT
+            KeyRings.HAS_ENCRYPT,
+            KeyRings.NAME,
+            KeyRings.EMAIL,
+            KeyRings.COMMENT
     };
 
     public static final int INDEX_MASTER_KEY_ID = 1;
@@ -79,6 +82,9 @@ public class KeyAdapter extends CursorAdapter {
     public static final int INDEX_FINGERPRINT = 8;
     public static final int INDEX_CREATION = 9;
     public static final int INDEX_HAS_ENCRYPT = 10;
+    public static final int INDEX_NAME = 11;
+    public static final int INDEX_EMAIL = 12;
+    public static final int INDEX_COMMENT = 13;
 
     public KeyAdapter(Context context, Cursor c, int flags) {
         super(context, c, flags);
@@ -266,6 +272,9 @@ public class KeyAdapter extends CursorAdapter {
 
         public final String mUserIdFull;
         public final OpenPgpUtils.UserId mUserId;
+        public final String mName;
+        public final String mEmail;
+        public final String mComment;
         public final long mKeyId;
         public final boolean mHasDuplicate;
         public final boolean mHasEncrypt;
@@ -276,6 +285,9 @@ public class KeyAdapter extends CursorAdapter {
         private KeyItem(Cursor cursor) {
             String userId = cursor.getString(INDEX_USER_ID);
             mUserId = KeyRing.splitUserId(userId);
+            mName = cursor.getString(INDEX_NAME);
+            mEmail = cursor.getString(INDEX_EMAIL);
+            mComment = cursor.getString(INDEX_COMMENT);
             mUserIdFull = userId;
             mKeyId = cursor.getLong(INDEX_MASTER_KEY_ID);
             mHasDuplicate = cursor.getLong(INDEX_HAS_DUPLICATE_USER_ID) > 0;
@@ -293,6 +305,9 @@ public class KeyAdapter extends CursorAdapter {
             CanonicalizedPublicKey key = ring.getPublicKey();
             String userId = key.getPrimaryUserIdWithFallback();
             mUserId = KeyRing.splitUserId(userId);
+            mName = mUserId.name;
+            mEmail = mUserId.email;
+            mComment = mUserId.comment;
             mUserIdFull = userId;
             mKeyId = ring.getMasterKeyId();
             mHasDuplicate = false;
@@ -309,10 +324,10 @@ public class KeyAdapter extends CursorAdapter {
         }
 
         public String getReadableName() {
-            if (mUserId.name != null) {
-                return mUserId.name;
+            if (mName != null) {
+                return mName;
             } else {
-                return mUserId.email;
+                return mEmail;
             }
         }
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
@@ -380,14 +380,15 @@ public class KeySectionedListAdapter extends SectionCursorAdapter<KeySectionedLi
             Context context = itemView.getContext();
 
             { // set name and stuff, common to both key types
-                OpenPgpUtils.UserId userIdSplit = keyItem.getUserId();
-                if (userIdSplit.name != null) {
-                    mMainUserId.setText(highlighter.highlight(userIdSplit.name));
+                String name = keyItem.getName();
+                String email = keyItem.getEmail();
+                if (name != null) {
+                    mMainUserId.setText(highlighter.highlight(name));
                 } else {
                     mMainUserId.setText(R.string.user_id_no_name);
                 }
-                if (userIdSplit.email != null) {
-                    mMainUserIdRest.setText(highlighter.highlight(userIdSplit.email));
+                if (email != null) {
+                    mMainUserIdRest.setText(highlighter.highlight(email));
                     mMainUserIdRest.setVisibility(View.VISIBLE);
                 } else {
                     mMainUserIdRest.setVisibility(View.GONE);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserAttributesAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserAttributesAdapter.java
@@ -33,7 +33,10 @@ public abstract class UserAttributesAdapter extends CursorAdapter {
             UserPackets.RANK,
             UserPackets.VERIFIED,
             UserPackets.IS_PRIMARY,
-            UserPackets.IS_REVOKED
+            UserPackets.IS_REVOKED,
+            UserPackets.NAME,
+            UserPackets.EMAIL,
+            UserPackets.COMMENT,
     };
     public static final int INDEX_ID = 0;
     public static final int INDEX_TYPE = 1;
@@ -43,6 +46,9 @@ public abstract class UserAttributesAdapter extends CursorAdapter {
     public static final int INDEX_VERIFIED = 5;
     public static final int INDEX_IS_PRIMARY = 6;
     public static final int INDEX_IS_REVOKED = 7;
+    public static final int INDEX_NAME = 8;
+    public static final int INDEX_EMAIL = 9;
+    public static final int INDEX_COMMENT = 10;
 
     public UserAttributesAdapter(Context context, Cursor c, int flags) {
         super(context, c, flags);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAdapter.java
@@ -71,20 +71,22 @@ public class UserIdsAdapter extends UserAttributesAdapter {
         vDeleteButton.setVisibility(View.GONE); // not used
 
         String userId = cursor.getString(INDEX_USER_ID);
-        OpenPgpUtils.UserId splitUserId = KeyRing.splitUserId(userId);
-        if (splitUserId.name != null) {
-            vName.setText(splitUserId.name);
+        String name = cursor.getString(INDEX_NAME);
+        String email = cursor.getString(INDEX_EMAIL);
+        String comment = cursor.getString(INDEX_COMMENT);
+        if (name != null) {
+            vName.setText(name);
         } else {
             vName.setText(R.string.user_id_no_name);
         }
-        if (splitUserId.email != null) {
-            vAddress.setText(splitUserId.email);
+        if (email != null) {
+            vAddress.setText(email);
             vAddress.setVisibility(View.VISIBLE);
         } else {
             vAddress.setVisibility(View.GONE);
         }
-        if (splitUserId.comment != null) {
-            vComment.setText(splitUserId.comment);
+        if (comment != null) {
+            vComment.setText(comment);
             vComment.setVisibility(View.VISIBLE);
         } else {
             vComment.setVisibility(View.GONE);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/adapter/CursorAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/adapter/CursorAdapter.java
@@ -390,7 +390,10 @@ public abstract class CursorAdapter<C extends CursorAdapter.AbstractCursor, VH e
                     KeychainContract.KeyRings.IS_REVOKED,
                     KeychainContract.KeyRings.IS_EXPIRED,
                     KeychainContract.KeyRings.HAS_DUPLICATE_USER_ID,
-                    KeychainContract.KeyRings.CREATION
+                    KeychainContract.KeyRings.CREATION,
+                    KeychainContract.KeyRings.NAME,
+                    KeychainContract.KeyRings.EMAIL,
+                    KeychainContract.KeyRings.COMMENT
             ));
 
             PROJECTION = arr.toArray(new String[arr.size()]);
@@ -423,6 +426,22 @@ public abstract class CursorAdapter<C extends CursorAdapter.AbstractCursor, VH e
             return getString(index);
         }
 
+        public String getName() {
+            int index = getColumnIndexOrThrow(KeychainContract.KeyRings.NAME);
+            return getString(index);
+        }
+
+        public String getEmail() {
+            int index = getColumnIndexOrThrow(KeychainContract.KeyRings.EMAIL);
+            return getString(index);
+        }
+
+        public String getComment() {
+            int index = getColumnIndexOrThrow(KeychainContract.KeyRings.COMMENT);
+            return getString(index);
+        }
+
+        @Deprecated
         public OpenPgpUtils.UserId getUserId() {
             return KeyRing.splitUserId(getRawUserId());
         }


### PR DESCRIPTION
#1846 

replaced some splitUserId that could be taken place directly by the new database columns.

seems that the other occurrences of splitUserId are irrelevant to database, e.g. The way to import key from clipboard is retrieving userId at first, and then get name etc by splitUserId. How should I deal with them?