### PR TITLE
Update English message for security_token_reset_or_import

### DIFF
--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1600,7 +1600,7 @@
     <string name="security_token_status_unbound">"Security Token matches, can be bound to key"</string>
     <string name="security_token_status_partly">"Security Token matches, partly bound to key"</string>
     <string name="security_token_create">"Hold Security Token against the back of your device."</string>
-    <string name="security_token_reset_or_import">"This Security Token already contains a key. To use it, we need additional key information. These information can be searched on a keyserver or imported from a file."</string>
+    <string name="security_token_reset_or_import">"This Security Token already contains a key. To use it, we need additional key information. This information can be searched for on a keyserver or imported from a file."</string>
     <string name="btn_reset">"Reset"</string>
     <string name="security_token_import_radio">"Search key information on keyserver"</string>
     <string name="security_token_file_radio">"Import key information from file"</string>


### PR DESCRIPTION
I feel like this version sounds more natural. If you disagree, feel free to decline the PR. :smiley: 

(Also, see [this chart](https://books.google.com/ngrams/graph?content=this+information+can%2C+these+information+can&case_insensitive=on&year_start=1800&year_end=2000&corpus=15&smoothing=3&share=&direct_url=t4%3B%2Cthis%20information%20can%3B%2Cc0%3B%2Cs0%3B%3BThis%20information%20can%3B%2Cc0%3B%3Bthis%20information%20can%3B%2Cc0%3B.t4%3B%2Cthese%20information%20can%3B%2Cc0%3B%2Cs0%3B%3BThese%20information%20can%3B%2Cc0%3B%3Bthese%20information%20can%3B%2Cc0) on Google Ngram viewer.)