### PR TITLE
API: Restrict secret keys for sign operation

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
@@ -731,6 +731,7 @@ public abstract class OperationResult implements Parcelable {
         MSG_PSE_ERROR_PGP (LogLevel.ERROR, R.string.msg_pse_error_pgp),
         MSG_PSE_ERROR_SIG (LogLevel.ERROR, R.string.msg_pse_error_sig),
         MSG_PSE_ERROR_UNLOCK (LogLevel.ERROR, R.string.msg_pse_error_unlock),
+        MSG_PSE_ERROR_KEY_NOT_ALLOWED(LogLevel.ERROR, R.string.msg_pse_error_key_not_allowed),
         MSG_PSE_ERROR_REVOKED_OR_EXPIRED (LogLevel.ERROR, R.string.msg_pse_error_revoked_or_expired),
         MSG_PSE_KEY_OK (LogLevel.OK, R.string.msg_pse_key_ok),
         MSG_PSE_KEY_UNKNOWN (LogLevel.DEBUG, R.string.msg_pse_key_unknown),

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/PgpSignEncryptResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/PgpSignEncryptResult.java
@@ -25,6 +25,8 @@ import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
 
 public class PgpSignEncryptResult extends InputPendingResult {
 
+    public static final int RESULT_KEY_DISALLOWED = RESULT_ERROR + 32;
+
     byte[] mOutputBytes;
 
     byte[] mDetachedSignature;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptInputParcel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptInputParcel.java
@@ -22,6 +22,8 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import java.util.HashSet;
+
 
 public class PgpSignEncryptInputParcel implements Parcelable {
 
@@ -30,6 +32,8 @@ public class PgpSignEncryptInputParcel implements Parcelable {
     private Uri mInputUri;
     private Uri mOutputUri;
     private byte[] mInputBytes;
+
+    private HashSet<Long> mAllowedKeyIds;
 
     public PgpSignEncryptInputParcel(PgpSignEncryptData data) {
         this.data = data;
@@ -41,6 +45,8 @@ public class PgpSignEncryptInputParcel implements Parcelable {
         mInputBytes = source.createByteArray();
 
         data = source.readParcelable(getClass().getClassLoader());
+
+        mAllowedKeyIds  = (HashSet<Long>) source.readSerializable();
     }
 
     @Override
@@ -55,6 +61,8 @@ public class PgpSignEncryptInputParcel implements Parcelable {
         dest.writeByteArray(mInputBytes);
 
         data.writeToParcel(dest, 0);
+
+        dest.writeSerializable(mAllowedKeyIds);
     }
 
     public void setInputBytes(byte[] inputBytes) {
@@ -89,6 +97,14 @@ public class PgpSignEncryptInputParcel implements Parcelable {
 
     public PgpSignEncryptData getData() {
         return data;
+    }
+
+    HashSet<Long> getAllowedKeyIds() {
+        return mAllowedKeyIds;
+    }
+
+    public void setAllowedKeyIds(HashSet<Long> allowedKeyIds) {
+        mAllowedKeyIds = allowedKeyIds;
     }
 
     public static final Creator<PgpSignEncryptInputParcel> CREATOR = new Creator<PgpSignEncryptInputParcel>() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptOperation.java
@@ -21,7 +21,6 @@ package org.sufficientlysecure.keychain.pgp;
 
 import android.content.Context;
 import android.net.Uri;
-import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import org.bouncycastle.bcpg.ArmoredOutputStream;
@@ -40,8 +39,6 @@ import org.bouncycastle.openpgp.operator.jcajce.PGPUtil;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.operations.BaseOperation;
-import org.sufficientlysecure.keychain.operations.results.DecryptVerifyResult;
-import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult.LogType;
 import org.sufficientlysecure.keychain.operations.results.OperationResult.OperationLog;
 import org.sufficientlysecure.keychain.operations.results.PgpSignEncryptResult;
@@ -228,6 +225,15 @@ public class PgpSignEncryptOperation extends BaseOperation<PgpSignEncryptInputPa
                 CanonicalizedSecretKeyRing signingKeyRing =
                         mProviderHelper.getCanonicalizedSecretKeyRing(signingMasterKeyId);
                 signingKey = signingKeyRing.getSecretKey(data.getSignatureSubKeyId());
+
+                if (input.getAllowedKeyIds() != null) {
+                    if (!input.getAllowedKeyIds().contains(signingMasterKeyId)) {
+                        // this key is in our db, but NOT allowed!
+                        log.add(LogType.MSG_DC_ASKIP_NOT_ALLOWED, indent + 1);
+                        log.add(LogType.MSG_DC_ERROR_NO_KEY, indent + 1);
+                        return new PgpSignEncryptResult(PgpSignEncryptResult.RESULT_KEY_DISALLOWED, log);
+                    }
+                }
 
 
                 // Make sure key is not expired or revoked

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpSignEncryptOperation.java
@@ -229,8 +229,7 @@ public class PgpSignEncryptOperation extends BaseOperation<PgpSignEncryptInputPa
                 if (input.getAllowedKeyIds() != null) {
                     if (!input.getAllowedKeyIds().contains(signingMasterKeyId)) {
                         // this key is in our db, but NOT allowed!
-                        log.add(LogType.MSG_DC_ASKIP_NOT_ALLOWED, indent + 1);
-                        log.add(LogType.MSG_DC_ERROR_NO_KEY, indent + 1);
+                        log.add(LogType.MSG_PSE_ERROR_KEY_NOT_ALLOWED, indent + 1);
                         return new PgpSignEncryptResult(PgpSignEncryptResult.RESULT_KEY_DISALLOWED, log);
                     }
                 }

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1297,7 +1297,7 @@
     <string name="msg_pse_error_pgp">"Internal OpenPGP error!"</string>
     <string name="msg_pse_error_sig">"Encountered OpenPGP signature exception!"</string>
     <string name="msg_pse_error_unlock">"Unknown error unlocking key!"</string>
-    <string name="msg_pse_error_key_not_allowed">"Key used for encrypting is not allowed"</string>
+    <string name="msg_pse_error_key_not_allowed">"Key selected for encryption is not allowed"</string>
     <string name="msg_pse_error_revoked_or_expired">"Revoked/Expired key cannot be used for sign or encryption"</string>
     <string name="msg_pse_key_ok">"Encrypting for key: %s"</string>
     <string name="msg_pse_key_unknown">"Missing key for encryption: %s"</string>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1297,6 +1297,7 @@
     <string name="msg_pse_error_pgp">"Internal OpenPGP error!"</string>
     <string name="msg_pse_error_sig">"Encountered OpenPGP signature exception!"</string>
     <string name="msg_pse_error_unlock">"Unknown error unlocking key!"</string>
+    <string name="msg_pse_error_key_not_allowed">"Key used for encrypting is not allowed"</string>
     <string name="msg_pse_error_revoked_or_expired">"Revoked/Expired key cannot be used for sign or encryption"</string>
     <string name="msg_pse_key_ok">"Encrypting for key: %s"</string>
     <string name="msg_pse_key_unknown">"Missing key for encryption: %s"</string>


### PR DESCRIPTION
## Description
- Added fields for storing allowed keys and indicating that a disallowed key was used.
- Assigned the fields to related values in the API Service
- Added the checks in the related Operation file

## Motivation and Context
For #1830 

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
