### PR TITLE
Backup API, implement EXTRA_REQUEST_ASCII_ARMOR

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/BackupOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/BackupOperation.java
@@ -174,7 +174,7 @@ public class BackupOperation extends BaseOperation<BackupKeyringParcel> {
 
         PgpSignEncryptData data = new PgpSignEncryptData();
         data.setSymmetricPassphrase(cryptoInput.getPassphrase());
-        data.setEnableAsciiArmorOutput(true);
+        data.setEnableAsciiArmorOutput(backupInput.mEnableAsciiArmorOutput);
         data.setAddBackupHeader(true);
         PgpSignEncryptInputParcel inputParcel = new PgpSignEncryptInputParcel(data);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -615,6 +615,7 @@ public class OpenPgpService extends Service {
         try {
             long[] masterKeyIds = data.getLongArrayExtra(OpenPgpApi.EXTRA_KEY_IDS);
             boolean backupSecret = data.getBooleanExtra(OpenPgpApi.EXTRA_BACKUP_SECRET, false);
+            boolean enableAsciiArmorOutput = data.getBooleanExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
 
             CryptoInputParcel inputParcel = CryptoInputParcelCacheService.getCryptoInputParcel(this, data);
             if (inputParcel == null) {
@@ -626,7 +627,7 @@ public class OpenPgpService extends Service {
             // after user interaction with RemoteBackupActivity,
             // the backup code is cached in CryptoInputParcelCacheService, now we can proceed
 
-            BackupKeyringParcel input = new BackupKeyringParcel(masterKeyIds, backupSecret, true, null);
+            BackupKeyringParcel input = new BackupKeyringParcel(masterKeyIds, backupSecret, true, enableAsciiArmorOutput, null);
             BackupOperation op = new BackupOperation(this, mProviderHelper, null);
             ExportResult pgpResult = op.execute(input, inputParcel, outputStream);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/BackupKeyringParcel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/BackupKeyringParcel.java
@@ -23,22 +23,22 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import org.sufficientlysecure.keychain.util.Passphrase;
-
 
 public class BackupKeyringParcel implements Parcelable {
     public Uri mCanonicalizedPublicKeyringUri;
 
     public final boolean mExportSecret;
     public final boolean mIsEncrypted;
+    public final boolean mEnableAsciiArmorOutput;
     public final long mMasterKeyIds[];
     public final Uri mOutputUri;
 
-    public BackupKeyringParcel(long[] masterKeyIds, boolean exportSecret, boolean isEncrypted, Uri outputUri) {
+    public BackupKeyringParcel(long[] masterKeyIds, boolean exportSecret, boolean isEncrypted, boolean enableAsciiArmorOutput, Uri outputUri) {
         mMasterKeyIds = masterKeyIds;
         mExportSecret = exportSecret;
         mOutputUri = outputUri;
         mIsEncrypted = isEncrypted;
+        mEnableAsciiArmorOutput = enableAsciiArmorOutput;
     }
 
     protected BackupKeyringParcel(Parcel in) {
@@ -47,6 +47,7 @@ public class BackupKeyringParcel implements Parcelable {
         mOutputUri = (Uri) in.readValue(Uri.class.getClassLoader());
         mMasterKeyIds = in.createLongArray();
         mIsEncrypted = in.readInt() != 0;
+        mEnableAsciiArmorOutput = in.readInt() != 0;
     }
 
     @Override
@@ -61,6 +62,7 @@ public class BackupKeyringParcel implements Parcelable {
         dest.writeValue(mOutputUri);
         dest.writeLongArray(mMasterKeyIds);
         dest.writeInt(mIsEncrypted ? 1 : 0);
+        dest.writeInt(mEnableAsciiArmorOutput ? 1 : 0);
     }
 
     public static final Parcelable.Creator<BackupKeyringParcel> CREATOR = new Parcelable.Creator<BackupKeyringParcel>() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
@@ -605,7 +605,7 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
     @Nullable
     @Override
     public BackupKeyringParcel createOperationInput() {
-        return new BackupKeyringParcel(mMasterKeyIds, mExportSecret, true, mCachedBackupUri);
+        return new BackupKeyringParcel(mMasterKeyIds, mExportSecret, true, true, mCachedBackupUri);
     }
 
     @Override

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/BackupOperationTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/BackupOperationTest.java
@@ -18,14 +18,6 @@
 package org.sufficientlysecure.keychain.operations;
 
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.io.PrintStream;
-import java.security.Security;
-import java.util.Iterator;
-
 import android.app.Application;
 import android.content.ContentResolver;
 import android.content.ContentValues;
@@ -65,6 +57,14 @@ import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.util.Passphrase;
 import org.sufficientlysecure.keychain.util.ProgressScaler;
 import org.sufficientlysecure.keychain.util.TestingUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.PrintStream;
+import java.security.Security;
+import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -255,7 +255,7 @@ public class BackupOperationTest {
                 new ProviderHelper(RuntimeEnvironment.application), null);
 
         BackupKeyringParcel parcel = new BackupKeyringParcel(
-                new long[] { mStaticRing1.getMasterKeyId() }, false, false, fakeOutputUri);
+                new long[] { mStaticRing1.getMasterKeyId() }, false, false, true, fakeOutputUri);
 
         ExportResult result = op.execute(parcel, null);
 
@@ -312,7 +312,7 @@ public class BackupOperationTest {
                     new ProviderHelper(RuntimeEnvironment.application), null);
 
             BackupKeyringParcel parcel = new BackupKeyringParcel(
-                    new long[] { mStaticRing1.getMasterKeyId() }, false, true, fakeOutputUri);
+                    new long[] { mStaticRing1.getMasterKeyId() }, false, true, true, fakeOutputUri);
             CryptoInputParcel inputParcel = new CryptoInputParcel(passphrase);
             ExportResult result = op.execute(parcel, inputParcel);
 


### PR DESCRIPTION
## Description
Added a new instance variable mEnableAsciiArmorOutput to BackupKeyringParcel and updated it's usages.

## Motivation and Context
For #1856
Replacing #2017 

## How Has This Been Tested?
Created a backup with and without ASCII armor using the Backup screen in the app and opened the file to verify it's contents.


## Types of changes
- ✅ New feature (non-breaking change which adds functionality)
