### PR TITLE
fix transparent header

### DIFF
--- a/OpenKeychain/src/main/res/layout/view_key_adv_certs_header.xml
+++ b/OpenKeychain/src/main/res/layout/view_key_adv_certs_header.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
 
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="?android:colorBackground">
 
     <TextView
         android:id="@+id/stickylist_header_text"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fix transparent header in ViewKeyAdvCertsFragment
## Description
<!--- Describe your changes in detail -->
When working on #1957 , I found that the header in ViewKeyAdvCertsFragment is transparent

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before modification:
![photo6111930782709819305](https://cloud.githubusercontent.com/assets/11607199/22699446/6bda85b2-ed92-11e6-9d7b-a1aca6b4a5ee.jpg)

After modification:
![photo6111930782709819306](https://cloud.githubusercontent.com/assets/11607199/22699583/da96838e-ed92-11e6-81e7-e0ac7691dd0b.jpg)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
