### PR TITLE
Fix crash inside MultiUserIdsFrag because of null lastName

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MultiUserIdsFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MultiUserIdsFragment.java
@@ -180,7 +180,7 @@ public class MultiUserIdsFragment extends Fragment implements LoaderManager.Load
             // Two cases:
 
             boolean grouped = masterKeyId == lastMasterKeyId;
-            boolean subGrouped = data.isFirst() || grouped && lastName.equals(name);
+            boolean subGrouped = data.isFirst() || grouped && lastName != null && lastName.equals(name);
             // Remember for next loop
             lastName = name;
 


### PR DESCRIPTION
## Description
Add a null safety check before calling the `String#equals` method.

## Motivation and Context

There is a crash whenever the `lastName` variable happens to be null.
This is documented inside issue #2044 

## How Has This Been Tested?
Tested the changes on Travis CI. The build passes.

[Build #1](https://travis-ci.org/icyflame/open-keychain/builds/203469302) (First draft of the commit message)

[Build #2](https://travis-ci.org/icyflame/open-keychain/jobs/203541336) (Present commit)

## Types of changes

- ✅ Bug fix (non-breaking change which fixes an issue)