### PR TITLE
Use KeychainExternalProvider for resolving encryption keys in api

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
@@ -37,8 +37,9 @@ public class KeychainExternalContract {
 
     public static class EmailStatus implements BaseColumns {
         public static final String EMAIL_ADDRESS = "email_address";
-        public static final String EMAIL_STATUS = "email_status";
         public static final String USER_ID = "user_id";
+        public static final String USER_ID_STATUS = "email_status";
+        public static final String MASTER_KEY_ID = "master_key_id";
 
         public static final Uri CONTENT_URI = BASE_CONTENT_URI_EXTERNAL.buildUpon()
                 .appendPath(BASE_EMAIL_STATUS).build();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
@@ -25,6 +25,8 @@ import org.sufficientlysecure.keychain.Constants;
 
 
 public class KeychainExternalContract {
+    public static final int KEY_STATUS_UNVERIFIED = 1;
+    public static final int KEY_STATUS_VERIFIED = 2;
 
     // this is in KeychainExternalContract already, but we want to be double
     // sure this isn't mixed up with the internal one!

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/KeychainExternalProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/KeychainExternalProvider.java
@@ -170,10 +170,9 @@ public class KeychainExternalProvider extends ContentProvider implements SimpleC
                 // we take the minimum (>0) here, where "1" is "verified by known secret key", "2" is "self-certified"
                 projectionMap.put(EmailStatus.USER_ID_STATUS, "CASE ( MIN (" + Certs.VERIFIED + " ) ) "
                         // remap to keep this provider contract independent from our internal representation
-                        + " WHEN NULL THEN 1"
-                        + " WHEN " + Certs.VERIFIED_SELF + " THEN 1"
-                        + " WHEN " + Certs.VERIFIED_SECRET + " THEN 2"
-                        + " WHEN NULL THEN NULL"
+                        + " WHEN " + Certs.VERIFIED_SELF + " THEN " + KeychainExternalContract.KEY_STATUS_UNVERIFIED
+                        + " WHEN " + Certs.VERIFIED_SECRET + " THEN " + KeychainExternalContract.KEY_STATUS_VERIFIED
+                        + " WHEN NULL THEN " + KeychainExternalContract.KEY_STATUS_UNVERIFIED
                         + " END AS " + EmailStatus.USER_ID_STATUS);
                 projectionMap.put(EmailStatus.USER_ID, Tables.USER_PACKETS + "." + UserPackets.USER_ID + " AS " + EmailStatus.USER_ID);
                 projectionMap.put(EmailStatus.MASTER_KEY_ID,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -189,11 +189,7 @@ public class OpenPgpService extends Service {
             }
         } catch (Exception e) {
             Log.d(Constants.TAG, "signImpl", e);
-            Intent result = new Intent();
-            result.putExtra(OpenPgpApi.RESULT_ERROR,
-                    new OpenPgpError(OpenPgpError.GENERIC_ERROR, e.getMessage()));
-            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-            return result;
+            return createErrorResultIntent(OpenPgpError.GENERIC_ERROR, e.getMessage());
         }
     }
 
@@ -247,11 +243,8 @@ public class OpenPgpService extends Service {
             if (keyIdResult.hasKeySelectionPendingIntent()) {
                 if ((keyIdResultStatus == KeyIdResultStatus.MISSING || keyIdResultStatus == KeyIdResultStatus.NO_KEYS ||
                         keyIdResultStatus == KeyIdResultStatus.NO_KEYS_ERROR) && isOpportunistic) {
-                    Intent result = new Intent();
-                    result.putExtra(OpenPgpApi.RESULT_ERROR,
-                            new OpenPgpError(OpenPgpError.OPPORTUNISTIC_MISSING_KEYS, "missing keys in opportunistic mode"));
-                    result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-                    return result;
+                    return createErrorResultIntent(OpenPgpError.OPPORTUNISTIC_MISSING_KEYS,
+                            "missing keys in opportunistic mode");
                 }
 
                 Intent result = new Intent();
@@ -301,11 +294,7 @@ public class OpenPgpService extends Service {
             }
         } catch (Exception e) {
             Log.d(Constants.TAG, "encryptAndSignImpl", e);
-            Intent result = new Intent();
-            result.putExtra(OpenPgpApi.RESULT_ERROR,
-                    new OpenPgpError(OpenPgpError.GENERIC_ERROR, e.getMessage()));
-            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-            return result;
+            return createErrorResultIntent(OpenPgpError.GENERIC_ERROR, e.getMessage());
         }
     }
 
@@ -389,18 +378,12 @@ public class OpenPgpService extends Service {
                 }
 
                 String errorMsg = getString(pgpResult.getLog().getLast().mType.getMsgId());
-                Intent result = new Intent();
-                result.putExtra(OpenPgpApi.RESULT_ERROR, new OpenPgpError(OpenPgpError.GENERIC_ERROR, errorMsg));
-                result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-                return result;
+                return createErrorResultIntent(OpenPgpError.GENERIC_ERROR, errorMsg);
             }
 
         } catch (Exception e) {
             Log.e(Constants.TAG, "decryptAndVerifyImpl", e);
-            Intent result = new Intent();
-            result.putExtra(OpenPgpApi.RESULT_ERROR, new OpenPgpError(OpenPgpError.GENERIC_ERROR, e.getMessage()));
-            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-            return result;
+            return createErrorResultIntent(OpenPgpError.GENERIC_ERROR, e.getMessage());
         }
     }
 
@@ -536,12 +519,17 @@ public class OpenPgpService extends Service {
             }
         } catch (Exception e) {
             Log.d(Constants.TAG, "getKeyImpl", e);
-            Intent result = new Intent();
-            result.putExtra(OpenPgpApi.RESULT_ERROR,
-                    new OpenPgpError(OpenPgpError.GENERIC_ERROR, e.getMessage()));
-            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-            return result;
+            return createErrorResultIntent(OpenPgpError.GENERIC_ERROR, e.getMessage());
         }
+    }
+
+    @NonNull
+    private Intent createErrorResultIntent(int errorCode, String errorMsg) {
+        Intent result = new Intent();
+        result.putExtra(OpenPgpApi.RESULT_ERROR,
+                new OpenPgpError(errorCode, errorMsg));
+        result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
+        return result;
     }
 
     private Intent getSignKeyIdImpl(Intent data) {
@@ -613,18 +601,11 @@ public class OpenPgpService extends Service {
             } else {
                 // should not happen normally...
                 String errorMsg = getString(pgpResult.getLog().getLast().mType.getMsgId());
-                Intent result = new Intent();
-                result.putExtra(OpenPgpApi.RESULT_ERROR, new OpenPgpError(OpenPgpError.GENERIC_ERROR, errorMsg));
-                result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-                return result;
+                return createErrorResultIntent(OpenPgpError.GENERIC_ERROR, errorMsg);
             }
         } catch (Exception e) {
             Log.d(Constants.TAG, "backupImpl", e);
-            Intent result = new Intent();
-            result.putExtra(OpenPgpApi.RESULT_ERROR,
-                    new OpenPgpError(OpenPgpError.GENERIC_ERROR, e.getMessage()));
-            result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-            return result;
+            return createErrorResultIntent(OpenPgpError.GENERIC_ERROR, e.getMessage());
         }
     }
 

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
@@ -79,6 +79,15 @@ public class KeychainExternalProviderTest {
     }
 
     @Test(expected = AccessControlException.class)
+    public void testPermission__withExplicitPackage() throws Exception {
+        contentResolver.query(
+                EmailStatus.CONTENT_URI.buildUpon().appendPath("fake_pkg").build(),
+                new String[] { EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID },
+                null, new String [] { }, null
+        );
+    }
+
+    @Test(expected = AccessControlException.class)
     public void testPermission__withWrongPackageCert() throws Exception {
         apiDao.deleteApiApp(PACKAGE_NAME);
         apiDao.insertApiApp(new AppSettings(PACKAGE_NAME, new byte[] { 1, 2, 4 }));
@@ -94,7 +103,7 @@ public class KeychainExternalProviderTest {
     public void testQuery__withNonExistentAddress() throws Exception {
         Cursor cursor = contentResolver.query(
                 EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_STATUS, EmailStatus.USER_ID },
+                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
                 null, new String [] { MAIL_ADDRESS_1 }, null
         );
 
@@ -111,7 +120,7 @@ public class KeychainExternalProviderTest {
 
         Cursor cursor = contentResolver.query(
                 EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_STATUS, EmailStatus.USER_ID },
+                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
                 null, new String [] { MAIL_ADDRESS_1 }, null
         );
 
@@ -129,7 +138,7 @@ public class KeychainExternalProviderTest {
 
         Cursor cursor = contentResolver.query(
                 EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_STATUS, EmailStatus.USER_ID },
+                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
                 null, new String [] { MAIL_ADDRESS_1, MAIL_ADDRESS_2 }, null
         );
 
@@ -151,7 +160,7 @@ public class KeychainExternalProviderTest {
 
         Cursor cursor = contentResolver.query(
                 EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_STATUS, EmailStatus.USER_ID },
+                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
                 null, new String [] { MAIL_ADDRESS_SEC_1 }, null
         );
 
@@ -172,7 +181,7 @@ public class KeychainExternalProviderTest {
 
         Cursor cursor = contentResolver.query(
                 EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_STATUS, EmailStatus.USER_ID },
+                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
                 null, new String [] { MAIL_ADDRESS_1 }, null
         );
 


### PR DESCRIPTION
This PR unifies the way key lookup (user id -> key id) is done. This affects primarily OpenPgpServiceKeyIdExtractor, which previously had its own logic, but now queries the external provider for key ids instead.

This PR *also* introduces EXTRA_DRY_RUN, which causes a SIGN_ENCRYPT operation to abort once all input parameters are determined, and returns a status of keys that would be used in the process. This change is quite simple and isolated in a commit of its own.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)
