### PR TITLE
set cache notification to low priority

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/PassphraseCacheService.java
@@ -503,7 +503,8 @@ public class PassphraseCacheService extends Service {
                 .setColor(getResources().getColor(R.color.primary))
                 .setContentTitle(getResources().getQuantityString(R.plurals.passp_cache_notif_n_keys,
                         mPassphraseCache.size(), mPassphraseCache.size()))
-                .setContentText(getString(R.string.passp_cache_notif_touch_to_clear));
+                .setContentText(getString(R.string.passp_cache_notif_touch_to_clear))
+                .setPriority(NotificationCompat.PRIORITY_MIN);
 
         NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
 


### PR DESCRIPTION
Super small PR: This sets the notification priority for our passphrase cache service to "min", which (at least on my phone) hides the notification from the lock screen and also the icon bar on top.

This seems appropriate to me, given we require no attention whatsoever from the user. And from what I can tell, it doesn't mess with foreground status of the service.