### PR TITLE
Fix Constants.java Orbot proxy settings

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -161,8 +161,8 @@ public final class Constants {
      */
     public static final class Orbot {
         public static final String PROXY_HOST = "127.0.0.1";
-        public static final int PROXY_PORT = 8118;
-        public static final Proxy.Type PROXY_TYPE = Proxy.Type.HTTP;
+        public static final int PROXY_PORT = 9050;
+        public static final Proxy.Type PROXY_TYPE = Proxy.Type.SOCKS;
     }
 
     public static final class Defaults {


### PR DESCRIPTION
Fix settings to correct default Orbot proxy port and type

## Description
Change Orbot proxy port and type to `9050` and `SOCKS`, respectively.

## Motivation and Context
Does not correctly connect to Orbot because the proxy settings do not match those set by default by Orbot. Failure occurs silently; to the user, appears as if Tor connection is not active.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
