### PR TITLE
fix issue #2049

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/OpenPgpCapabilities.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/OpenPgpCapabilities.java
@@ -108,7 +108,16 @@ public class OpenPgpCapabilities {
         mHasKeyImport = (v[0] & MASK_KEY_IMPORT) != 0;
         mAttriburesChangable = (v[0] & MASK_ATTRIBUTES_CHANGABLE) != 0;
 
-        mSMAESKeySize = (v[1] == 1) ? 16 : 32;
+        mSMAESKeySize = 0;
+
+        switch(v[1]) {
+        case 1:
+            mSMAESKeySize = 16;
+            break;
+        case 2:
+            mSMAESKeySize = 32;
+            break;
+        }
 
         mMaxCmdLen = (v[6] << 8) + v[7];
         mMaxRspLen = (v[8] << 8) + v[9];
@@ -140,6 +149,10 @@ public class OpenPgpCapabilities {
 
     public int getSMAESKeySize() {
         return mSMAESKeySize;
+    }
+
+    public boolean isHasAESSM() {
+        return isHasSM() && ((mSMAESKeySize == 16) || (mSMAESKeySize == 32));
     }
 
     public int getMaxCmdLen() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
@@ -206,7 +206,7 @@ public class SecurityTokenHelper {
         mPw1ValidatedForDecrypt = false;
         mPw3Validated = false;
 
-        if (mOpenPgpCapabilities.isHasSM()) {
+        if (mOpenPgpCapabilities.isHasAESSM()) {
             try {
                 SCP11bSecureMessaging.establish(this, ctx);
             } catch (SecureMessagingException e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Temporary workaround to fix issue #2049.

## Description
<!--- Describe your changes in detail -->
The temporary workaround proposed does not rely only on the "secure messaging" bit from the "extended capabilities", but also on the "secure messaging key size" declared in the "extended capabilities" to trigger on SmartPGP secure messaging only if secure messaging is configured for AES (appeared in specification v3) and not DES.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A regression with OpenPGP applets other than SmartPGP that support secure messaging was introduced by commit a6b7b2bf4ec204cd647db9f0bead53476069d34f, including Yubikey NEO (issue #2049).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No test as been done on Yubikey NEO to verify the issue is fixed.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
