### PR TITLE
Update SecureMessaging/SCP11b wrt OpenPGP card v3.3

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/OpenPgpCapabilities.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/OpenPgpCapabilities.java
@@ -34,7 +34,7 @@ public class OpenPgpCapabilities {
     private boolean mAttriburesChangable;
     private boolean mHasKeyImport;
 
-    private int mSMAESKeySize;
+    private int mSMType;
     private int mMaxCmdLen;
     private int mMaxRspLen;
 
@@ -108,16 +108,7 @@ public class OpenPgpCapabilities {
         mHasKeyImport = (v[0] & MASK_KEY_IMPORT) != 0;
         mAttriburesChangable = (v[0] & MASK_ATTRIBUTES_CHANGABLE) != 0;
 
-        mSMAESKeySize = 0;
-
-        switch(v[1]) {
-        case 1:
-            mSMAESKeySize = 16;
-            break;
-        case 2:
-            mSMAESKeySize = 32;
-            break;
-        }
+        mSMType = v[1];
 
         mMaxCmdLen = (v[6] << 8) + v[7];
         mMaxRspLen = (v[8] << 8) + v[9];
@@ -147,12 +138,12 @@ public class OpenPgpCapabilities {
         return mHasKeyImport;
     }
 
-    public int getSMAESKeySize() {
-        return mSMAESKeySize;
+    public boolean isHasAESSM() {
+        return isHasSM() && ((mSMType == 1) || (mSMType == 2));
     }
 
-    public boolean isHasAESSM() {
-        return isHasSM() && ((mSMAESKeySize == 16) || (mSMAESKeySize == 32));
+    public boolean isHasSCP11bSM() {
+        return isHasSM() && (mSMType == 3);
     }
 
     public int getMaxCmdLen() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
@@ -358,8 +358,10 @@ class SCP11bSecureMessaging implements SecureMessaging {
                 throw new SecureMessagingException("No key in token for secure messaging");
             }
 
-            final int fieldSize = pkcard.getParams().getCurve().getField().getFieldSize();
+            final EllipticCurve curve = pkcard.getParams().getCurve();
+            final int fieldSize = curve.getField().getFieldSize();
             int keySize;
+
             if(fieldSize < 512) {
                 keySize = 16;
             } else {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
@@ -277,18 +277,11 @@ class SCP11bSecureMessaging implements SecureMessaging {
     public static void establish(final SecurityTokenHelper t, final Context ctx)
             throws SecureMessagingException, IOException {
 
-        final int keySize = t.getOpenPgpCapabilities().getSMAESKeySize();
-
-        t.clearSecureMessaging();
-
-        if ((keySize != 16)
-                && (keySize != 32)) {
-            throw  new SecureMessagingException("invalid key size");
-        }
-
         CommandAPDU cmd;
         ResponseAPDU resp;
         Iso7816TLV[] tlvs;
+
+        t.clearSecureMessaging();
 
         // retrieving key algorithm
         cmd = new CommandAPDU(0, (byte)0xCA, (byte)0x00,
@@ -363,6 +356,14 @@ class SCP11bSecureMessaging implements SecureMessaging {
 
             if (pkcard == null) {
                 throw new SecureMessagingException("No key in token for secure messaging");
+            }
+
+            final int fieldSize = pkcard.getParams().getCurve().getField().getFieldSize();
+            int keySize;
+            if(fieldSize < 512) {
+                keySize = 16;
+            } else {
+                keySize = 32;
             }
 
             final KeyPair ekoce = generateECDHKeyPair(eckf);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
@@ -60,6 +60,7 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
+import java.security.spec.EllipticCurve;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 import java.util.ArrayList;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
@@ -206,7 +206,7 @@ public class SecurityTokenHelper {
         mPw1ValidatedForDecrypt = false;
         mPw3Validated = false;
 
-        if (mOpenPgpCapabilities.isHasAESSM()) {
+        if (mOpenPgpCapabilities.isHasSCP11bSM()) {
             try {
                 SCP11bSecureMessaging.establish(this, ctx);
             } catch (SecureMessagingException e) {


### PR DESCRIPTION
OpenPGP card specification v3.3 introduces a bit for secure messaging using SCP11b. It should now be used to avoid any conflict with the AES secure messaging described in the specification.

## Description
Use the correct secure messaging type to trigger SCP11b establishment.
As the AES key sizes cannot be inferred from the secure messaging type, they are now fixed and determined by the size of the field of the curve used for secure messaging, as recommended in SCP11 specification.

## Motivation and Context
Correction of the existing workaround which can trigger a SCP11b establishment while the token is not supporting it.

## How Has This Been Tested?
Tested on SmartPGP version 1.3 with SCP11b enabled.
Should not impact other cards (the value 03 for the secure messaging type was unused until OpenPGP card v3.3).

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
