### PR TITLE
Fix #2080 by adding Javascript 

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateGithubFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateGithubFragment.java
@@ -537,6 +537,7 @@ public class LinkedIdCreateGithubFragment extends CryptoOperationFragment<SaveKe
         auth_dialog.setContentView(R.layout.oauth_webview);
         WebView web = (WebView) auth_dialog.findViewById(R.id.web_view);
         web.getSettings().setSaveFormData(false);
+        web.getSettings().setJavaScriptEnabled(true);
         web.getSettings().setUserAgentString("OpenKeychain " + BuildConfig.VERSION_NAME);
         web.setWebViewClient(new WebViewClient() {
 


### PR DESCRIPTION
Enables Javascript for the github OAuth webView.
## Description
Enables Javascript in the webView used by the github OAuth 

## Motivation and Context
This fixes #2080 

## How Has This Been Tested?
Runs OK, single line of code should not effect other areas

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
