### PR TITLE
remove "Move to Card" action from subkey edit ui

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvSubkeysFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvSubkeysFragment.java
@@ -17,6 +17,7 @@
 
 package org.sufficientlysecure.keychain.ui;
 
+
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -38,9 +39,6 @@ import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.ViewAnimator;
 
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
-import org.bouncycastle.bcpg.PublicKeyAlgorithmTags;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.compatibility.DialogFragmentWorkaround;
@@ -56,7 +54,6 @@ import org.sufficientlysecure.keychain.ui.base.LoaderFragment;
 import org.sufficientlysecure.keychain.ui.dialog.AddSubkeyDialogFragment;
 import org.sufficientlysecure.keychain.ui.dialog.EditSubkeyDialogFragment;
 import org.sufficientlysecure.keychain.ui.dialog.EditSubkeyExpiryDialogFragment;
-import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.Log;
 
 public class ViewKeyAdvSubkeysFragment extends LoaderFragment implements
@@ -339,51 +336,6 @@ public class ViewKeyAdvSubkeysFragment extends LoaderFragment implements
                         SubkeyChange change = mEditModeSkpBuilder.getSubkeyChange(keyId);
                         if (change == null || !change.getDummyStrip()) {
                             mEditModeSkpBuilder.addOrReplaceSubkeyChange(SubkeyChange.createStripChange(keyId));
-                        } else {
-                            mEditModeSkpBuilder.removeSubkeyChange(change);
-                        }
-                        break;
-                    }
-                    case EditSubkeyDialogFragment.MESSAGE_MOVE_KEY_TO_SECURITY_TOKEN: {
-                        SecretKeyType secretKeyType = mSubkeysAdapter.getSecretKeyType(position);
-                        if (secretKeyType == SecretKeyType.DIVERT_TO_CARD ||
-                                secretKeyType == SecretKeyType.GNU_DUMMY) {
-                            Notify.create(getActivity(), R.string.edit_key_error_bad_security_token_stripped, Notify.Style.ERROR)
-                                    .show();
-                            break;
-                        }
-
-                        switch (mSubkeysAdapter.getAlgorithm(position)) {
-                            case PublicKeyAlgorithmTags.RSA_GENERAL:
-                            case PublicKeyAlgorithmTags.RSA_ENCRYPT:
-                            case PublicKeyAlgorithmTags.RSA_SIGN:
-                                if (mSubkeysAdapter.getKeySize(position) < 2048) {
-                                    Notify.create(getActivity(), R.string.edit_key_error_bad_security_token_size, Notify.Style.ERROR)
-                                            .show();
-                                }
-                                break;
-
-                            case PublicKeyAlgorithmTags.ECDH:
-                            case PublicKeyAlgorithmTags.ECDSA:
-                                final ASN1ObjectIdentifier curve = NISTNamedCurves.getOID(mSubkeysAdapter.getCurveOid(position));
-                                if (!curve.equals(NISTNamedCurves.getOID("P-256")) &&
-                                        !curve.equals(NISTNamedCurves.getOID("P-384")) &&
-                                        !curve.equals(NISTNamedCurves.getOID("P-521"))) {
-                                    Notify.create(getActivity(), R.string.edit_key_error_bad_security_token_curve, Notify.Style.ERROR)
-                                            .show();
-                                }
-                                break;
-
-                            default:
-                                Notify.create(getActivity(), R.string.edit_key_error_bad_security_token_algo, Notify.Style.ERROR)
-                                        .show();
-                                break;
-                        }
-
-                        SubkeyChange change = mEditModeSkpBuilder.getSubkeyChange(keyId);
-                        if (change == null || !change.getMoveKeyToSecurityToken()) {
-                            mEditModeSkpBuilder.addOrReplaceSubkeyChange(
-                                    SubkeyChange.createMoveToSecurityTokenChange(keyId));
                         } else {
                             mEditModeSkpBuilder.removeSubkeyChange(change);
                         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyDialogFragment.java
@@ -35,11 +35,9 @@ public class EditSubkeyDialogFragment extends DialogFragment {
     public static final int MESSAGE_CHANGE_EXPIRY = 1;
     public static final int MESSAGE_REVOKE = 2;
     public static final int MESSAGE_STRIP = 3;
-    public static final int MESSAGE_MOVE_KEY_TO_SECURITY_TOKEN = 4;
     public static final int SUBKEY_MENU_CHANGE_EXPIRY = 0;
     public static final int SUBKEY_MENU_REVOKE_SUBKEY = 1;
     public static final int SUBKEY_MENU_STRIP_SUBKEY = 2;
-    public static final int SUBKEY_MENU_MOVE_TO_SECURITY_TOKEN = 3;
 
     private Messenger mMessenger;
 
@@ -80,9 +78,6 @@ public class EditSubkeyDialogFragment extends DialogFragment {
                         break;
                     case SUBKEY_MENU_STRIP_SUBKEY:
                         showAlertDialog();
-                        break;
-                    case SUBKEY_MENU_MOVE_TO_SECURITY_TOKEN:
-                        sendMessageToHandler(MESSAGE_MOVE_KEY_TO_SECURITY_TOKEN, null);
                         break;
                     default:
                         break;

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -776,7 +776,6 @@
         <item>"Change Expiry"</item>
         <item>"Revoke Subkey"</item>
         <item>"Strip Subkey"</item>
-        <item>"Move Subkey to Security Token"</item>
     </string-array>
     <string name="edit_key_new_subkey">"new subkey"</string>
     <string name="edit_key_select_usage">"Please select key usage!"</string>


### PR DESCRIPTION
This PR removes the "Move to Card" feature from the subkey edit UI. This is due to a number of reasons:

- as implemented, the operation invariably led to an NPE. from what I could see in the git history, this has been the case for a long time, so it's unlikely this feature was actually used
- beyond the crash, this would only work if the admin pin was set to 12345678, and we don't have a very good concept yet of what to do if this isn't true (see also #1844). this is not quite trivial since we only have three attempts at wrong pins. consequently, assuming it's the default first will use up one of these attempts, but assuming otherwise (which should rarely be the case) makes the operation as a whole much less user friendly.
- even if this had worked as intended, the feature would have been very difficult to use correctly, and dangerous if used incorrectly, e.g. involuntarily deleting subkeys in openkeychain or overwriting them on the token

If we do want to support this, we should probably spend time on the whiteboard to think it through some more. From my point of view though, setting up subkeys and security tokens in a custom manner seems like a use case we can safely defer to GunPG.

## Types of changes
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
