### PR TITLE
Reformat public key blocks when loaded from clipboard

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysFileFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysFileFragment.java
@@ -24,6 +24,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -105,21 +106,27 @@ public class ImportKeysFileFragment extends Fragment {
                         Uri.fromFile(Constants.Path.APP_DIR), "*/*", false, REQUEST_CODE_FILE);
                 return true;
             case R.id.menu_import_keys_file_paste:
-                CharSequence clipboardText = ClipboardReflection.getClipboardText(getActivity());
-                String sendText = "";
-                if (clipboardText != null) {
-                    sendText = clipboardText.toString();
-                    sendText = PgpHelper.getPgpKeyContent(sendText);
-                    if (sendText == null) {
-                        Notify.create(mActivity, R.string.error_bad_data, Style.ERROR).show();
-                    } else {
-                        mCallback.loadKeys(new BytesLoaderState(sendText.getBytes(), null));
-                    }
-                }
+                importFromClipboard();
                 return true;
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    private void importFromClipboard() {
+        CharSequence clipboardText = ClipboardReflection.getClipboardText(getActivity());
+        if (TextUtils.isEmpty(clipboardText)) {
+            Notify.create(mActivity, R.string.error_clipboard_empty, Style.ERROR).show();
+            return;
+        }
+
+        String keyText = PgpHelper.getPgpPublicKeyContent(clipboardText);
+        if (keyText == null) {
+            Notify.create(mActivity, R.string.error_clipboard_bad, Style.ERROR).show();
+            return;
+        }
+
+        mCallback.loadKeys(new BytesLoaderState(keyText.getBytes(), null));
     }
 
     @Override

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1648,6 +1648,7 @@
     <string name="file_delete_exception">"Original file could not be deleted!"</string>
     <string name="error_clipboard_empty">"Clipboard is empty!"</string>
     <string name="error_clipboard_copy">"Error copying data to clipboard!"</string>
+    <string name="error_clipboard_bad">"Could not read keys from clipboard!"</string>
     <string name="error_scan_fp">"Error scanning fingerprint!"</string>
     <string name="error_scan_match">"Fingerprints did not match!"</string>
     <string name="error_expiry_past">"Expiry date is in the past!"</string>

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpHelperTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpHelperTest.java
@@ -1,0 +1,76 @@
+package org.sufficientlysecure.keychain.pgp;
+
+
+import java.io.ByteArrayInputStream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sufficientlysecure.keychain.KeychainTestRunner;
+import org.sufficientlysecure.keychain.pgp.UncachedKeyRing.IteratorWithIOThrow;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+
+
+@SuppressWarnings("WeakerAccess")
+@RunWith(KeychainTestRunner.class)
+public class PgpHelperTest {
+
+    static final String INPUT_KEY_BLOCK = "-----BEGIN PGP PUBLIC KEY BLOCK----- Version: GnuPG v2 " +
+            "mQENBFnA7Y0BCAC+pdQ1mV9QguWvAyMsKiKkzeP5VxbIDUyQ8OBDFKIrZKZGTzjZ " +
+            "xvZs22j5pXWYlyDi4HU4+nuQmAMo6jxJMKQQkW7Y5AmRYijboLN+lZ8L28bYJC4o " +
+            "PcAnS3xlib2lE7aNK2BRUbctkhahhb2hohAxiXTUdGmfr9sHgZ2+B9sPTfuhrvtI " +
+            "9cFHZ5/0Wp4pLhLB53gduYeLuw4vVfUd7t0C4IhqB+t5HE+F3lolgya7hXxdH0ji " +
+            "oFNldCWT2qNdmmehIyY0WaoIrnUm2gVA4LMZ2fQTfsInpec5YT85OZaPEeBs3Opg " +
+            "3aGxV4mhXOxHkfREJRuYXcqL1s/UERGNprp9ABEBAAG0E01yLiBNYWxmb3JtZWQg " +
+            "QXNjaWmJAVQEEwEIAD4WIQTLHyFqT4uzqqEXR5Zz6vdoZVkMnwUCWcDtjQIbAwUJ " +
+            "A8JnAAULCQgHAgYVCAkKCwIEFgIDAQIeAQIXgAAKCRBz6vdoZVkMnwpcB/985UbR " +
+            "qxG5pzaLGePdl+Cm6JBra2mC3AfMbJobjHR8YVufDw1tA6qyCMW0emHFi8t/rG8j " +
+            "tzPIadcl30rOzaGUTF85G5SqbwgAFHddZ01af36F6em0d5tY3+FCclQR7ynFPQlA " +
+            "+KB9k/M5X91ty6Q3/EAaXst5Uwh1WnKNC1js9RAcYL1s1MXKxg2iMmtE0DvwMAWq " +
+            "XRR+ADjzqkVdpdrzanTY7b72nuiGfe/H75b7/StIAfyxSZc5BU5535J0wF7Boz4p " +
+            "A6zRFXTphabmAE9FIKhgj5X7fbU64Hsrc5OkvWt4dF/6VRE4oXgUYwLKaDEH7A0k " +
+            "32GBGOkmnQGLKuqhuQENBFnA7Y0BCADKxQ1APSraxNKMpJv9vEVcXK3Sr91SYpGY " +
+            "s/ugYNio2xvIt9Qe2AjYGNSE9+wS6qLRxbbzucIRxl9jbn2QTNbJr7epLVdj3wtL " +
+            "JlkKsv13iao77Hg9WMvKh+NHpGoIFn4g5LOeYYG0QkZOvdu6b4Eg0RAryTLBh9jB " +
+            "eMLELkZTFDuQAgOSrVY0XgoURNcaDRtVarnVNBIO1N7/7TNXtmL22wR0wpqh4mKv " +
+            "vIvhE5itlIrthJHWzTcLDv5BHfyX23wqEpQFEffs1D72k9Ruh60OGgU0XAiVF654 " +
+            "WjgZCUoscPCLWcDGDOlcN7FpBxMDi1Ao3+7sLOMi9zES0InJ9q8LABEBAAGJATwE " +
+            "GAEIACYWIQTLHyFqT4uzqqEXR5Zz6vdoZVkMnwUCWcDtjQIbDAUJA8JnAAAKCRBz " +
+            "6vdoZVkMn3/+B/9B0vrDITV2FpdT+99WVsXJsoiXOsqLfv3WkC0l0RBAcCaUeXxp " +
+            "EqzyXQ0dVi6RoXu67dSnah6bdgfVnH14hJE8jc30GJ4QEpPD9kAKyodej15ledR5 " +
+            "sbdjeEfsavn9tvACJ0svfu8YVJjUjJLOj5axXy8wUBm5UvCdZuSL4EjPq7hXdq+j " +
+            "O/eTJGOfMl6hC4rRxRUbM+piZzbYcQ0lO3R2yPlEwzlO+asM9820V9bkviJUrXiY " +
+            "c5EX44mwFdhpXuHbRS18DJjCVcMhEsPG6rQ0Qy/6/dafow5HExRBmZl6ZkfjR2Lb " +
+            "alOZH0SNi47bvn6QKqKgiqT4f9mImyEDtSj/ =2V66 -----END PGP PUBLIC KEY BLOCK-----";
+
+    @Test
+    public void reformatPgpPublicKeyBlock() throws Exception {
+        String reformattedKey = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK);
+
+        assertNotNull(reformattedKey);
+        UncachedKeyRing.decodeFromData(reformattedKey.getBytes());
+    }
+
+    @Test
+    public void reformatPgpPublicKeyBlock_consecutiveKeys() throws Exception {
+        String reformattedKey = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK + INPUT_KEY_BLOCK);
+
+        assertNotNull(reformattedKey);
+        IteratorWithIOThrow<UncachedKeyRing> uncachedKeyRingIteratorWithIOThrow =
+                UncachedKeyRing.fromStream(new ByteArrayInputStream(reformattedKey.getBytes()));
+        assertNotNull(uncachedKeyRingIteratorWithIOThrow.next());
+        assertNotNull(uncachedKeyRingIteratorWithIOThrow.next());
+        assertFalse(uncachedKeyRingIteratorWithIOThrow.hasNext());
+    }
+
+    @Test
+    public void reformatPgpPublicKeyBlock_shouldBeIdempotent() throws Exception {
+        String reformattedKey1 = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK);
+        String reformattedKey2 = PgpHelper.reformatPgpPublicKeyBlock(reformattedKey1);
+
+        assertEquals(reformattedKey1, reformattedKey2);
+    }
+
+}

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpHelperTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpHelperTest.java
@@ -17,7 +17,7 @@ import static junit.framework.Assert.assertNotNull;
 @RunWith(KeychainTestRunner.class)
 public class PgpHelperTest {
 
-    static final String INPUT_KEY_BLOCK = "-----BEGIN PGP PUBLIC KEY BLOCK----- Version: GnuPG v2 " +
+    static final String INPUT_KEY_BLOCK_TWO_OCTET_LENGTH = "-----BEGIN PGP PUBLIC KEY BLOCK----- Version: GnuPG v2 " +
             "mQENBFnA7Y0BCAC+pdQ1mV9QguWvAyMsKiKkzeP5VxbIDUyQ8OBDFKIrZKZGTzjZ " +
             "xvZs22j5pXWYlyDi4HU4+nuQmAMo6jxJMKQQkW7Y5AmRYijboLN+lZ8L28bYJC4o " +
             "PcAnS3xlib2lE7aNK2BRUbctkhahhb2hohAxiXTUdGmfr9sHgZ2+B9sPTfuhrvtI " +
@@ -44,10 +44,23 @@ public class PgpHelperTest {
             "O/eTJGOfMl6hC4rRxRUbM+piZzbYcQ0lO3R2yPlEwzlO+asM9820V9bkviJUrXiY " +
             "c5EX44mwFdhpXuHbRS18DJjCVcMhEsPG6rQ0Qy/6/dafow5HExRBmZl6ZkfjR2Lb " +
             "alOZH0SNi47bvn6QKqKgiqT4f9mImyEDtSj/ =2V66 -----END PGP PUBLIC KEY BLOCK-----";
+    static final String INPUT_KEY_BLOCK_ONE_OCTET_LENGTH = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+            "\n" +
+            "mFIEVk2iwRMIKoZIzj0DAQcCAwTBaWEpVYOfZDm85s/zszd4J4CBW8FesYiYQTeX\n" +
+            "5WMtwXsqrG5/ZcIgHNBzI0EvUbm/oSBFUJNk7RhmOk6MpS2gtAdNci4gRUNDiHkE\n" +
+            "ExMIACEFAlZNosECGwMFCwkIBwIGFQgJCgsCBBYCAwECHgECF4AACgkQt60Zc7T/\n" +
+            "SfQTPAD/bZ0ld3UyqAt8oPoHyJduGMkbur5KYoht1w/MMtiogG0BAN8Anhy55kTe\n" +
+            "H4VmMWxzK9M+kIFPzqEVHOzsuE5nhJOouFYEVk2iwRIIKoZIzj0DAQcCAwSvfTrq\n" +
+            "kkVeD0cVM8FZwhjTaG+B9wgk7yeoMgjIrSuZLiRjGAYC7Kq+6OiczduoItC2oMuK\n" +
+            "GpymTF6t+CmQpUfuAwEIB4hhBBgTCAAJBQJWTaLBAhsMAAoJELetGXO0/0n00BwA\n" +
+            "/2d1w/A4xMwfIFrKDwHeHALUBaIOuhF2AKd/43HujmuLAQDdcWf3h/0zjgBTjSoB\n" +
+            "bcVr5AE/huKUnwKYa7SP7wzoZg==\n" +
+            "=ou9N\n" +
+            "-----END PGP PUBLIC KEY BLOCK-----\n";
 
     @Test
     public void reformatPgpPublicKeyBlock() throws Exception {
-        String reformattedKey = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK);
+        String reformattedKey = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK_TWO_OCTET_LENGTH);
 
         assertNotNull(reformattedKey);
         UncachedKeyRing.decodeFromData(reformattedKey.getBytes());
@@ -55,7 +68,8 @@ public class PgpHelperTest {
 
     @Test
     public void reformatPgpPublicKeyBlock_consecutiveKeys() throws Exception {
-        String reformattedKey = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK + INPUT_KEY_BLOCK);
+        String reformattedKey = PgpHelper.reformatPgpPublicKeyBlock(
+                INPUT_KEY_BLOCK_TWO_OCTET_LENGTH + INPUT_KEY_BLOCK_TWO_OCTET_LENGTH);
 
         assertNotNull(reformattedKey);
         IteratorWithIOThrow<UncachedKeyRing> uncachedKeyRingIteratorWithIOThrow =
@@ -67,10 +81,18 @@ public class PgpHelperTest {
 
     @Test
     public void reformatPgpPublicKeyBlock_shouldBeIdempotent() throws Exception {
-        String reformattedKey1 = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK);
-        String reformattedKey2 = PgpHelper.reformatPgpPublicKeyBlock(reformattedKey1);
+        String reformattedKey1 = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK_TWO_OCTET_LENGTH);
+        assertNotNull(reformattedKey1);
 
+        String reformattedKey2 = PgpHelper.reformatPgpPublicKeyBlock(reformattedKey1);
         assertEquals(reformattedKey1, reformattedKey2);
     }
 
+    @Test
+    public void reformatPgpPublicKeyBlock_withOneOctetLengthHeader() throws Exception {
+        String reformattedKey = PgpHelper.reformatPgpPublicKeyBlock(INPUT_KEY_BLOCK_ONE_OCTET_LENGTH);
+
+        assertNotNull(reformattedKey);
+        UncachedKeyRing.decodeFromData(reformattedKey.getBytes());
+    }
 }


### PR DESCRIPTION
This PR adds some logic that attempts to reformat public key blocks read from the clipboard. It checks for patterns in the first twelve bits of encoded key data, so it makes more assumptions than previously about the structure of these blocks.

This allows recovering keys from arbitrary whitespace changes. It also drops ascii armor headers, but we never use those for public keys so that shouldn't be an issue.

Fixes #2161

## How Has This Been Tested?
Unit tests included

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)
