### PR TITLE
Fix EC decipher template

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
@@ -297,6 +297,7 @@ public class SecurityTokenHelper {
         }
 
         byte[] data;
+        byte[] dataLen;
         int pLen = 0;
 
         X9ECParameters x9Params;
@@ -324,18 +325,24 @@ public class SecurityTokenHelper {
                 }
 
                 data = p.getEncoded(false);
-                data = Arrays.concatenate(
-                        Hex.decode("86"),
-                        new byte[]{(byte) data.length},
-                        data);
-                data = Arrays.concatenate(
-                        Hex.decode("7F49"),
-                        new byte[]{(byte) data.length},
-                        data);
-                data = Arrays.concatenate(
-                        Hex.decode("A6"),
-                        new byte[]{(byte) data.length},
-                        data);
+
+                if (data.length < 128)
+                    dataLen = new byte[]{(byte) data.length};
+                else
+                    dataLen = new byte[]{(byte)0x81, (byte) data.length};
+                data = Arrays.concatenate(Hex.decode("86"), dataLen, data);
+
+                if (data.length < 128)
+                    dataLen = new byte[]{(byte) data.length};
+                else
+                    dataLen = new byte[]{(byte)0x81, (byte) data.length};
+                data = Arrays.concatenate(Hex.decode("7F49"), dataLen, data);
+
+                if (data.length < 128)
+                    dataLen = new byte[]{(byte) data.length};
+                else
+                    dataLen = new byte[]{(byte)0x81, (byte) data.length};
+                data = Arrays.concatenate(Hex.decode("A6"), dataLen, data);
                 break;
 
             default:

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenHelper.java
@@ -326,22 +326,25 @@ public class SecurityTokenHelper {
 
                 data = p.getEncoded(false);
 
-                if (data.length < 128)
+                if (data.length < 128) {
                     dataLen = new byte[]{(byte) data.length};
-                else
+                } else {
                     dataLen = new byte[]{(byte)0x81, (byte) data.length};
+		}
                 data = Arrays.concatenate(Hex.decode("86"), dataLen, data);
 
-                if (data.length < 128)
+                if (data.length < 128) {
                     dataLen = new byte[]{(byte) data.length};
-                else
+                } else {
                     dataLen = new byte[]{(byte)0x81, (byte) data.length};
+		}
                 data = Arrays.concatenate(Hex.decode("7F49"), dataLen, data);
 
-                if (data.length < 128)
+                if (data.length < 128) {
                     dataLen = new byte[]{(byte) data.length};
-                else
+                } else {
                     dataLen = new byte[]{(byte)0x81, (byte) data.length};
+		}
                 data = Arrays.concatenate(Hex.decode("A6"), dataLen, data);
                 break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This commit reflects a [recent commit](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commitdiff;h=ff7ccd284c327a5b1c89603f157089177dac9d13) in GnuPG to fix incorrect encoding of data sent to a security token for the deciphering using ECC with large parameters (Brainpool 512 or NIST p521).

## Description
<!--- Describe your changes in detail -->
For large EC parameters (Brainpool 512 or NIST p521) the length of TLV encoded data for the decipher command is encoded on two bytes instead of one. It is actually systematically encoded on one byte in the existing code, which is wrong. This wrong encoding scheme, also present in GnuPG, as been [recently fixed](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commitdiff;h=ff7ccd284c327a5b1c89603f157089177dac9d13).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With large EC parameters (Brainpool 512 or NIST p521) the length of TLV encoded data for the decipher command sent to a security token is above 127 bytes so it must be encoded on two bytes and not just one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested with SmartPGP applet (version 1.9).
This change breaks compatibility with previous versions of the SmartPGP applet, and possibly other applet/tokens, but only when a deciphering key on Brainpool 512 or NIST p521 is used.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)

