### PR TITLE
Disable unsupported USB tokens

### DIFF
--- a/OpenKeychain/src/main/res/xml/usb_device_filter.xml
+++ b/OpenKeychain/src/main/res/xml/usb_device_filter.xml
@@ -8,35 +8,35 @@
     Note that values are decimal.
 -->
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Yubikey NEO OTP + CCID-->
+    <!-- Yubikey NEO OTP + CCID -->
     <usb-device class="11" vendor-id="4176" product-id="273"/>
-    <!-- Yubikey NEO CCID-->
+    <!-- Yubikey NEO CCID -->
     <usb-device class="11" vendor-id="4176" product-id="274"/>
-    <!-- Yubikey NEO U2F + CCID-->
+    <!-- Yubikey NEO U2F + CCID -->
     <usb-device class="11" vendor-id="4176" product-id="277"/>
-    <!-- Yubikey NEO OTP + U2F + CCID-->
+    <!-- Yubikey NEO OTP + U2F + CCID -->
     <usb-device class="11" vendor-id="4176" product-id="278"/>
 
-
-    <!-- Yubikey 4 CCID-->
-    <usb-device class="11" vendor-id="4176" product-id="1028"/>
-    <!-- Yubikey 4 OTP + CCID-->
-    <usb-device class="11" vendor-id="4176" product-id="1029"/>
-    <!-- Yubikey 4 U2F + CCID-->
-    <usb-device class="11" vendor-id="4176" product-id="1030"/>
-    <!-- Yubikey 4 OTP + U2F + CCID-->
-    <usb-device class="11" vendor-id="4176" product-id="1031"/>
-
-
-    <!-- Nitrokey Pro-->
+    <!-- Nitrokey Pro -->
     <usb-device class="11" vendor-id="8352" product-id="16648"/>
-    <!-- Nitrokey Storage-->
-    <usb-device class="11" vendor-id="8352" product-id="16649"/>
 
-    <!--GNUK based device are not supported right now-->
-    
-    <!-- Nitrokey Start-->
+    <!-- Yubikey 4 CCID -->
+    <!--<usb-device class="11" vendor-id="4176" product-id="1028"/>-->
+    <!-- Yubikey 4 OTP + CCID -->
+    <!--<usb-device class="11" vendor-id="4176" product-id="1029"/>-->
+    <!-- Yubikey 4 U2F + CCID -->
+    <!--<usb-device class="11" vendor-id="4176" product-id="1030"/>-->
+    <!-- Yubikey 4 OTP + U2F + CCID -->
+    <!--<usb-device class="11" vendor-id="4176" product-id="1031"/>-->
+
+    <!-- Nitrokey Storage -->
+    <!--<usb-device class="11" vendor-id="8352" product-id="16649"/>-->
+
+    <!-- Nitrokey Start -->
     <!--<usb-device class="11" vendor-id="8352" product-id="16913"/>-->
-    <!-- Default GNUK vid/pid-->
+    <!-- Default GNUK vid/pid -->
     <!--<usb-device class="11" vendor-id="9035" product-id="0"/>-->
+
+    <!-- Ledger Nano S -->
+    <!--<usb-device class="11" vendor-id="11415" product-id="1"/>-->
 </resources>


### PR DESCRIPTION
I propose we disable unsupported USB devices for now until we properly support them.

I also worked on the [wiki page about supported tokens](https://github.com/open-keychain/open-keychain/wiki/Security-Tokens) which is now linked from our FAQ page: https://github.com/open-keychain/open-keychain.github.io/commit/53ee5c718af59897dec992ac606e1bd2de932416