### PR TITLE
Accept dash character (-) in GitHub user names when checking for Gist URL

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/linked/resources/GithubResource.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/linked/resources/GithubResource.java
@@ -192,7 +192,7 @@ public class GithubResource extends LinkedTokenResource {
             return null;
         }
 
-        Pattern p = Pattern.compile("https://gist\\.github\\.com/([a-zA-Z0-9_]+)/([0-9a-f]+)");
+        Pattern p = Pattern.compile("https://gist\\.github\\.com/([a-zA-Z0-9_-]+)/([0-9a-f]+)");
         Matcher match = p.matcher(uri.toString());
         if (!match.matches()) {
             return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
GitHub allows dash / minus characters in usernames (e.g. "wiktor-k" or
"open-keychain"). This change extends the regular expression to capture
this missing character.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It allows displaying Github Linked Identity resources that contain dash character.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has not been tested at all. I imagine one character change will not break anything but if it's required I can setup the project and build it to see if it really works :)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
