### PR TITLE
Remove colorization of fingerprints

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyFingerprintFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyFingerprintFragment.java
@@ -185,12 +185,10 @@ public class CertifyFingerprintFragment extends LoaderFragment implements
 
     private void displayHexConfirm(byte[] fingerprintBlob) {
         String fingerprint = KeyFormattingUtils.convertFingerprintToHex(fingerprintBlob);
-        mFingerprint.setText(KeyFormattingUtils.colorizeFingerprint(fingerprint));
+        mFingerprint.setText(KeyFormattingUtils.formatFingerprint(fingerprint));
     }
 
     private void displayWordConfirm(byte[] fingerprintBlob) {
-//        String fingerprint = ExperimentalWordConfirm.getWords(getActivity(), fingerprintBlob);
-
         String fingerprint;
         try {
             fingerprint = new SentenceConfirm(getActivity()).fromBytes(fingerprintBlob, 20);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvShareFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvShareFragment.java
@@ -398,7 +398,7 @@ public class ViewKeyAdvShareFragment extends LoaderFragment implements
         mFingerprint = fingerprintBlob;
 
         final String fingerprint = KeyFormattingUtils.convertFingerprintToHex(fingerprintBlob);
-        mFingerprintView.setText(KeyFormattingUtils.colorizeFingerprint(fingerprint));
+        mFingerprintView.setText(KeyFormattingUtils.formatFingerprint(fingerprint));
 
         if (mQrCodeBitmapCache != null) {
             return;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/KeyFormattingUtils.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/KeyFormattingUtils.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2012-2014 Dominik Schürmann <dominik@dominikschuermann.de>
- * Copyright (C) 2010-2014 Thialfihar <thi@thialfihar.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -393,7 +392,7 @@ public class KeyFormattingUtils {
         return beautifyKeyIdWithPrefix(convertKeyIdToHex(keyId));
     }
 
-    public static SpannableStringBuilder colorizeFingerprint(String fingerprint) {
+    public static String formatFingerprint(String fingerprint) {
         // split by 4 characters
         fingerprint = fingerprint.replaceAll("(.{4})(?!$)", "$1 ");
 
@@ -402,78 +401,7 @@ public class KeyFormattingUtils {
         chars[24] = '\n';
         fingerprint = String.valueOf(chars);
 
-        SpannableStringBuilder sb = new SpannableStringBuilder(fingerprint);
-        try {
-            // for each 4 characters of the fingerprint + 1 space
-            for (int i = 0; i < fingerprint.length(); i += 5) {
-                int spanEnd = Math.min(i + 4, fingerprint.length());
-                String fourChars = fingerprint.substring(i, spanEnd);
-
-                int raw = Integer.parseInt(fourChars, 16);
-                byte[] bytes = {(byte) ((raw >> 8) & 0xff - 128), (byte) (raw & 0xff - 128)};
-                int[] color = getRgbForData(bytes);
-                int r = color[0];
-                int g = color[1];
-                int b = color[2];
-
-                // we cannot change black by multiplication, so adjust it to an almost-black grey,
-                // which will then be brightened to the minimal brightness level
-                if (r == 0 && g == 0 && b == 0) {
-                    r = 1;
-                    g = 1;
-                    b = 1;
-                }
-
-                // Convert rgb to brightness
-                double brightness = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-
-                // If a color is too dark to be seen on black,
-                // then brighten it up to a minimal brightness.
-                if (brightness < 80) {
-                    double factor = 80.0 / brightness;
-                    r = Math.min(255, (int) (r * factor));
-                    g = Math.min(255, (int) (g * factor));
-                    b = Math.min(255, (int) (b * factor));
-
-                    // If it is too light, then darken it to a respective maximal brightness.
-                } else if (brightness > 180) {
-                    double factor = 180.0 / brightness;
-                    r = (int) (r * factor);
-                    g = (int) (g * factor);
-                    b = (int) (b * factor);
-                }
-
-                // Create a foreground color with the 3 digest integers as RGB
-                // and then converting that int to hex to use as a color
-                sb.setSpan(new ForegroundColorSpan(Color.rgb(r, g, b)),
-                        i, spanEnd, Spannable.SPAN_INCLUSIVE_INCLUSIVE);
-            }
-        } catch (Exception e) {
-            Log.e(Constants.TAG, "Colorization failed", e);
-            // if anything goes wrong, then just display the fingerprint without colour,
-            // instead of partially correct colour or wrong colours
-            return new SpannableStringBuilder(fingerprint);
-        }
-
-        return sb;
-    }
-
-    /**
-     * Converts the given bytes to a unique RGB color using SHA1 algorithm
-     *
-     * @return an integer array containing 3 numeric color representations (Red, Green, Black)
-     * @throws java.security.NoSuchAlgorithmException
-     * @throws java.security.DigestException
-     */
-    private static int[] getRgbForData(byte[] bytes) throws NoSuchAlgorithmException, DigestException {
-        MessageDigest md = MessageDigest.getInstance("SHA1");
-
-        md.update(bytes);
-        byte[] digest = md.digest();
-
-        return new int[]{((int) digest[0] + 256) % 256,
-                ((int) digest[1] + 256) % 256,
-                ((int) digest[2] + 256) % 256};
+        return fingerprint;
     }
 
     public static final int DEFAULT_COLOR = -1;


### PR DESCRIPTION
The colorization of fingerprints never really provided a lot of benefits as only OpenKeychain implements this method and there exist better methods such as QR Code and SafeSlinger between two OpenKeychain apps.
In addition, the security of such a scheme is not easy to evaluate. An attacker may generate a partial pre-image considering similar looking colors.

## Types of changes
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
