### PR TITLE
Fix NPE upon dialog dismissal in RemoteDeduplicatePresenter

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
@@ -101,7 +101,9 @@ class RemoteDeduplicatePresenter implements LoaderCallbacks<List<KeyInfo>> {
 
     @Override
     public void onLoaderReset(Loader loader) {
-        view.setKeyListData(null);
+        if (view != null) {
+            view.setKeyListData(null);
+        }
     }
 
     void onClickSelect() {


### PR DESCRIPTION
## Description
Upon dialog dismissal the view is set to null, consequently there is no view when the loader is reset as result of the activity being destroyed.
I found this since I based RemoteSelectAuthenticationKeyPresenter on RemoteDeduplicatePresenter.

## How Has This Been Tested?
Not tested in RemoteDeduplicatePresenter, but works in RemoteSelectAuthenticationKeyPresenter.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)