### PR TITLE
Enable multidex for release build

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -195,6 +195,8 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules-release.pro'
 
+            multiDexEnabled true
+
             // Reference them in the java files with e.g. BuildConfig.ACCOUNT_TYPE.
             buildConfigField "String", "ACCOUNT_TYPE", "\"org.sufficientlysecure.keychain.account\""
             buildConfigField "String", "PROVIDER_CONTENT_AUTHORITY", "\"org.sufficientlysecure.keychain.provider\""


### PR DESCRIPTION
## Description
Due to [Add sshauthentication-api v1 support](https://github.com/open-keychain/open-keychain/commit/2619cb1db38f2b9c21a49e2c928cb48d4bc16c8a) multidex is now needed for release build

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)