### PR TITLE
Fix error handling in case of an unsupported algorithm parameter in

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/SshAuthenticationService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/SshAuthenticationService.java
@@ -273,8 +273,8 @@ public class SshAuthenticationService extends Service {
                 return createExceptionErrorResult(SshAuthenticationApiError.NO_AUTH_KEY,
                         "Authentication key for master key id not found in keychain", e);
             } catch (NoSuchAlgorithmException e) {
-                return createExceptionErrorResult(SshAuthenticationApi.RESULT_CODE_ERROR,
-                        "", e);
+                return createExceptionErrorResult(SshAuthenticationApiError.INVALID_ALGORITHM,
+                        "Algorithm not supported", e);
             }
         } else {
             return createErrorResult(SshAuthenticationApiError.NO_KEY_ID,


### PR DESCRIPTION
SshAuthenticationService

## Description
Use the specific error code for invalid algorithm instead of a generic error.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)