### PR TITLE
WIP: Improve decryption from clipboard

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/FacebookKeyserverClient.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/FacebookKeyserverClient.java
@@ -36,7 +36,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.network.OkHttpClientFactory;
-import org.sufficientlysecure.keychain.pgp.PgpHelper;
+import org.sufficientlysecure.keychain.pgp.PgpAsciiArmorReformatter;
 import org.sufficientlysecure.keychain.pgp.UncachedKeyRing;
 import org.sufficientlysecure.keychain.pgp.UncachedPublicKey;
 import org.sufficientlysecure.keychain.pgp.exception.PgpGeneralException;
@@ -90,7 +90,7 @@ public class FacebookKeyserverClient implements KeyserverClient {
             throw new QueryFailedException("data is null");
         }
 
-        Matcher matcher = PgpHelper.PGP_PUBLIC_KEY.matcher(data);
+        Matcher matcher = PgpAsciiArmorReformatter.PGP_PUBLIC_KEY.matcher(data);
         if (matcher.find()) {
             return matcher.group(1);
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/HkpKeyserverClient.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/HkpKeyserverClient.java
@@ -44,7 +44,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.network.OkHttpClientFactory;
-import org.sufficientlysecure.keychain.pgp.PgpHelper;
+import org.sufficientlysecure.keychain.pgp.PgpAsciiArmorReformatter;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.ParcelableProxy;
@@ -295,7 +295,7 @@ public class HkpKeyserverClient implements KeyserverClient {
             throw new KeyserverClient.QueryFailedException("data is null");
         }
 
-        Matcher matcher = PgpHelper.PGP_PUBLIC_KEY.matcher(data);
+        Matcher matcher = PgpAsciiArmorReformatter.PGP_PUBLIC_KEY.matcher(data);
         if (matcher.find()) {
             return matcher.group(1);
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptActivity.java
@@ -36,7 +36,7 @@ import android.widget.Toast;
 
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
-import org.sufficientlysecure.keychain.pgp.PgpHelper;
+import org.sufficientlysecure.keychain.pgp.PgpAsciiArmorReformatter;
 import org.sufficientlysecure.keychain.provider.TemporaryFileProvider;
 import org.sufficientlysecure.keychain.ui.base.BaseActivity;
 
@@ -200,7 +200,7 @@ public class DecryptActivity extends BaseActivity {
         }
 
         // clean up ascii armored message, fixing newlines and stuff
-        String cleanedText = PgpHelper.getPgpMessageContent(text);
+        String cleanedText = PgpAsciiArmorReformatter.getPgpMessageContent(text);
         if (cleanedText == null) {
             return null;
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptDecryptFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptDecryptFragment.java
@@ -35,7 +35,7 @@ import android.view.ViewGroup;
 
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.compatibility.ClipboardReflection;
-import org.sufficientlysecure.keychain.pgp.PgpHelper;
+import org.sufficientlysecure.keychain.pgp.PgpAsciiArmorReformatter;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.Notify.Style;
 import org.sufficientlysecure.keychain.ui.util.SubtleAttentionSeeker;
@@ -131,12 +131,12 @@ public class EncryptDecryptFragment extends Fragment {
             protected Boolean doInBackground(String... clipboardText) {
 
                 // see if it looks like a pgp thing
-                Matcher matcher = PgpHelper.PGP_MESSAGE.matcher(clipboardText[0]);
+                Matcher matcher = PgpAsciiArmorReformatter.PGP_MESSAGE.matcher(clipboardText[0]);
                 boolean animate = matcher.matches();
 
                 // see if it looks like another pgp thing
                 if (!animate) {
-                    matcher = PgpHelper.PGP_CLEARTEXT_SIGNATURE.matcher(clipboardText[0]);
+                    matcher = PgpAsciiArmorReformatter.PGP_CLEARTEXT_SIGNATURE.matcher(clipboardText[0]);
                     animate = matcher.matches();
                 }
                 return animate;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysFileFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysFileFragment.java
@@ -37,7 +37,7 @@ import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.compatibility.ClipboardReflection;
 import org.sufficientlysecure.keychain.keyimport.processing.BytesLoaderState;
 import org.sufficientlysecure.keychain.keyimport.processing.ImportKeysListener;
-import org.sufficientlysecure.keychain.pgp.PgpHelper;
+import org.sufficientlysecure.keychain.pgp.PgpAsciiArmorReformatter;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.Notify.Style;
 import org.sufficientlysecure.keychain.ui.util.PermissionsUtil;
@@ -120,7 +120,7 @@ public class ImportKeysFileFragment extends Fragment {
             return;
         }
 
-        String keyText = PgpHelper.getPgpPublicKeyContent(clipboardText);
+        String keyText = PgpAsciiArmorReformatter.getPgpPublicKeyContent(clipboardText);
         if (keyText == null) {
             Notify.create(mActivity, R.string.error_clipboard_bad, Style.ERROR).show();
             return;


### PR DESCRIPTION
## Motivation and Context
We receive a significant amount of complaints about decryption from clipboard not working. This happens if the ascii armor is broken in some way, e.g. squeezed whitespace. For parsing keys from clipboard, this was fixed in #2162 and was very well received in review comments.

## Description
Unfortunately, for general messages the hacks from #2162 can't be reused, since these relied on a bunch of fixed bits at the beginning of the base64 encoded text. I used some different hacks to achieve a similar result, picking headers apart. This whole thing is a heuristic, and may break some genuine messages that worked before, but I think it improves our handling of messages.

Missing so far is handling for clearsigned messages. I will probably just handle these as before.

## How Has This Been Tested?
Unit test included

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
