### PR TITLE
Use different approach for whitelisting usb security tokens

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -143,6 +143,7 @@ public final class Constants {
         public static final String EXPERIMENTAL_ENABLE_WORD_CONFIRM = "experimentalEnableWordConfirm";
         public static final String EXPERIMENTAL_ENABLE_LINKED_IDENTITIES = "experimentalEnableLinkedIdentities";
         public static final String EXPERIMENTAL_ENABLE_KEYBASE = "experimentalEnableKeybase";
+        public static final String EXPERIMENTAL_USB_ALLOW_UNTESTED = "experimentalUsbAllowUntested";
         public static final String EXPERIMENTAL_SMARTPGP_VERIFY_AUTHORITY = "smartpgp_authorities_pref";
         public static final String EXPERIMENTAL_SMARTPGP_AUTHORITIES = "smartpgp_authorities";
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
@@ -189,9 +189,10 @@ public class SecurityTokenConnection {
     @VisibleForTesting
     void connectToDevice(Context context) throws IOException {
         // Connect on transport layer
-        mCardCapabilities = new CardCapabilities();
-
         mTransport.connect();
+
+        // dummy instance for initial communicate() calls
+        mCardCapabilities = new CardCapabilities();
 
         determineTokenType();
 
@@ -546,7 +547,7 @@ public class SecurityTokenConnection {
         }
 
         // Now we're ready to communicate with the token.
-        byte[] keyBytes = null;
+        byte[] keyBytes;
 
         try {
             secretKey.unlock(passphrase);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
@@ -1016,10 +1016,9 @@ public class SecurityTokenConnection {
 
         TransportType transportType = mTransport.getTransportType();
 
-        SecurityTokenInfo info = SecurityTokenInfo
-                .create(transportType, tokenType, fingerprints, aid, userId, url, pwInfo[4], pwInfo[6], hasLifeCycleManagement);
-
-        return info;
+        return SecurityTokenInfo
+                .create(transportType, tokenType, fingerprints, aid, userId, url, pwInfo[4], pwInfo[6],
+                        hasLifeCycleManagement);
     }
 
     public static double parseOpenPgpVersion(final byte[] aid) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
@@ -3,8 +3,10 @@ package org.sufficientlysecure.keychain.securitytoken;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -100,7 +102,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
         NITROKEY_START_1_25_AND_NEWER, GNUK_OLD, GNUK_1_25_AND_NEWER, LEDGER_NANO_S, UNKNOWN
     }
 
-    private static final HashSet<TokenType> SUPPORTED_USB_TOKENS = new HashSet<>(Arrays.asList(
+    public static final Set<TokenType> SUPPORTED_USB_TOKENS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             TokenType.YUBIKEY_NEO,
             TokenType.YUBIKEY_4,
             TokenType.NITROKEY_PRO,
@@ -109,23 +111,16 @@ public abstract class SecurityTokenInfo implements Parcelable {
             TokenType.NITROKEY_START_1_25_AND_NEWER,
             TokenType.GNUK_OLD,
             TokenType.GNUK_1_25_AND_NEWER
-    ));
+    )));
 
-    private static final HashSet<TokenType> SUPPORTED_USB_SETUP = new HashSet<>(Arrays.asList(
+    private static final Set<TokenType> SUPPORTED_USB_SETUP = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             TokenType.YUBIKEY_NEO,
             TokenType.YUBIKEY_4,
             TokenType.NITROKEY_PRO,
             TokenType.NITROKEY_STORAGE,
             TokenType.NITROKEY_START_1_25_AND_NEWER,
             TokenType.GNUK_1_25_AND_NEWER
-    ));
-
-    public boolean isSecurityTokenSupported() {
-        boolean isKnownSupported = SUPPORTED_USB_TOKENS.contains(getTokenType());
-        boolean isNfcTransport = getTransportType() == TransportType.NFC;
-
-        return isKnownSupported || isNfcTransport;
-    }
+    )));
 
     public boolean isPutKeySupported() {
         boolean isKnownSupported = SUPPORTED_USB_SETUP.contains(getTokenType());

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/UsbConnectionDispatcher.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/UsbConnectionDispatcher.java
@@ -26,6 +26,7 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 
 import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.securitytoken.usb.UsbTransport;
 import org.sufficientlysecure.keychain.ui.UsbEventReceiverActivity;
 import org.sufficientlysecure.keychain.util.Log;
 
@@ -50,7 +51,7 @@ public class UsbConnectionDispatcher {
                             false);
                     if (permission) {
                         Log.d(Constants.TAG, "Got permission for " + usbDevice.getDeviceName());
-                        mListener.usbDeviceDiscovered(usbDevice);
+                        sendUsbTransportDiscovered(usbDevice);
                     }
                     break;
                 }
@@ -82,17 +83,24 @@ public class UsbConnectionDispatcher {
         // Note: we don't check devices VID/PID because
         // we check for permission instead.
         // We should have permission only for matching devices
-        for (UsbDevice device : mUsbManager.getDeviceList().values()) {
-            if (mUsbManager.hasPermission(device)) {
-                if (mListener != null) {
-                    mListener.usbDeviceDiscovered(device);
-                }
+        for (UsbDevice usbDevice : mUsbManager.getDeviceList().values()) {
+            if (mUsbManager.hasPermission(usbDevice)) {
+                sendUsbTransportDiscovered(usbDevice);
                 break;
             }
         }
     }
 
+    private void sendUsbTransportDiscovered(UsbDevice usbDevice) {
+        if (mListener == null) {
+            return;
+        }
+
+        UsbTransport usbTransport = UsbTransport.createUsbTransport(mActivity.getBaseContext(), usbDevice);
+        mListener.usbTransportDiscovered(usbTransport);
+    }
+
     public interface OnDiscoveredUsbDeviceListener {
-        void usbDeviceDiscovered(UsbDevice usbDevice);
+        void usbTransportDiscovered(UsbTransport usbTransport);
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/UnsupportedUsbTokenException.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/UnsupportedUsbTokenException.java
@@ -1,0 +1,8 @@
+package org.sufficientlysecure.keychain.securitytoken.usb;
+
+
+public class UnsupportedUsbTokenException extends UsbTransportException {
+    UnsupportedUsbTokenException() {
+        super("This USB token is not supported!");
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/UsbTransport.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/UsbTransport.java
@@ -134,6 +134,13 @@ public class UsbTransport implements Transport {
             throw new UsbTransportException("USB error: failed to connect to device");
         }
 
+        boolean tokenTypeSupported = SecurityTokenInfo.SUPPORTED_USB_TOKENS.contains(getTokenTypeIfAvailable());
+        if (!tokenTypeSupported) {
+            usbConnection.close();
+            usbConnection = null;
+            throw new UnsupportedUsbTokenException();
+        }
+
         if (!usbConnection.claimInterface(usbInterface, true)) {
             throw new UsbTransportException("USB error: failed to claim interface");
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseSecurityTokenActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseSecurityTokenActivity.java
@@ -45,6 +45,7 @@ import org.sufficientlysecure.keychain.securitytoken.SecurityTokenInfo;
 import org.sufficientlysecure.keychain.securitytoken.SecurityTokenInfo.TokenType;
 import org.sufficientlysecure.keychain.securitytoken.Transport;
 import org.sufficientlysecure.keychain.securitytoken.UsbConnectionDispatcher;
+import org.sufficientlysecure.keychain.securitytoken.usb.UnsupportedUsbTokenException;
 import org.sufficientlysecure.keychain.securitytoken.usb.UsbTransport;
 import org.sufficientlysecure.keychain.securitytoken.usb.UsbTransportException;
 import org.sufficientlysecure.keychain.service.PassphraseCacheService;
@@ -231,6 +232,11 @@ public abstract class BaseSecurityTokenActivity extends BaseActivity
 
     private void handleSecurityTokenError(SecurityTokenConnection stConnection, IOException e) {
         Log.d(Constants.TAG, "Exception in handleSecurityTokenError", e);
+
+        if (e instanceof UnsupportedUsbTokenException) {
+            onSecurityTokenError(getString(R.string.security_token_not_supported));
+            return;
+        }
 
         if (e instanceof TagLostException) {
             onSecurityTokenError(getString(R.string.security_token_error_tag_lost));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseSecurityTokenActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseSecurityTokenActivity.java
@@ -25,11 +25,8 @@ package org.sufficientlysecure.keychain.ui.base;
 import java.io.IOException;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.hardware.usb.UsbDevice;
-import android.hardware.usb.UsbManager;
 import android.nfc.NfcAdapter;
 import android.nfc.Tag;
 import android.nfc.TagLostException;
@@ -61,6 +58,7 @@ import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.Notify.Style;
 import org.sufficientlysecure.keychain.util.Log;
 import org.sufficientlysecure.keychain.util.Passphrase;
+
 
 public abstract class BaseSecurityTokenActivity extends BaseActivity
         implements OnDiscoveredTagListener, UsbConnectionDispatcher.OnDiscoveredUsbDeviceListener {
@@ -114,6 +112,7 @@ public abstract class BaseSecurityTokenActivity extends BaseActivity
         onSecurityTokenError(error);
     }
 
+    @Override
     public void tagDiscovered(Tag tag) {
         // Actual NFC operations are executed in doInBackground to not block the UI thread
         if (!mTagHandlingEnabled) {
@@ -124,15 +123,13 @@ public abstract class BaseSecurityTokenActivity extends BaseActivity
         securityTokenDiscovered(nfcTransport);
     }
 
-    public void usbDeviceDiscovered(UsbDevice usbDevice) {
+    @Override
+    public void usbTransportDiscovered(UsbTransport usbTransport) {
         // Actual USB operations are executed in doInBackground to not block the UI thread
         if (!mTagHandlingEnabled) {
             return;
         }
 
-        UsbManager usbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
-
-        UsbTransport usbTransport = new UsbTransport(usbDevice, usbManager);
         securityTokenDiscovered(usbTransport);
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -402,6 +402,10 @@ public class Preferences {
         return mSharedPreferences.getBoolean(Pref.EXPERIMENTAL_ENABLE_KEYBASE, false);
     }
 
+    public boolean getExperimentalUsbAllowUntested() {
+        return mSharedPreferences.getBoolean(Pref.EXPERIMENTAL_USB_ALLOW_UNTESTED, false);
+    }
+
     public boolean getExperimentalSmartPGPAuthoritiesEnable() {
         return mSharedPreferences.getBoolean(Pref.EXPERIMENTAL_SMARTPGP_VERIFY_AUTHORITY, false);
     }

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1982,5 +1982,7 @@
     </plurals>
 
     <string name="button_locate_nfc">"Where is my NFC reader?"</string>
+    <string name="label_usb_untested_summary">If enabled, USB Smartcard readers can be used that have not been properly tested.</string>
+    <string name="label_usb_untested">Allow untested USB Devices</string>
 
 </resources>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1597,6 +1597,7 @@
     <string name="security_token_error_iso_dep_not_supported">"Security Token does not support the required communication standard (ISO-DEP, ISO 14443-4)"</string>
     <string name="security_token_error_generic">"Communication error. Most probably, the Security Token has been taken off too early."</string>
     <string name="security_token_error_try_again">"Try again"</string>
+    <string name="security_token_not_supported">"This Security Token is not yet supported by OpenKeychain"</string>
     <string name="btn_delete_original">Delete original file</string>
 
     <string name="snack_encrypt_filenames_on">"Filenames <b>are</b> encrypted."</string>

--- a/OpenKeychain/src/main/res/xml/experimental_preferences.xml
+++ b/OpenKeychain/src/main/res/xml/experimental_preferences.xml
@@ -35,6 +35,14 @@
         android:persistent="true"
         android:title="@string/label_theme" />
 
+
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="experimentalUsbAllowUntested"
+        android:persistent="true"
+        android:summary="@string/label_usb_untested_summary"
+        android:title="@string/label_usb_untested" />
+
     <SwitchPreference
         android:defaultValue="false"
         android:key="smartpgp_authorities_pref"


### PR DESCRIPTION
The previous approach to usb whitelisting (added in 0920d9757228930ddc44ae802b6a18fb0f4e96a1, removed again in 1f7c7f49d481efd8e59e08b3d23023e2fc92cf75) didn't actually work, since communication errors happened before the check was ever called. This PR adds a similar check, but much earlier in the procedure and in the UsbTransport only.

## How Has This Been Tested?
Not at all, so far :)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
