### PR TITLE
Do not re-enable contacts sync if first time wizard is not finished

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -119,7 +119,10 @@ public final class Constants {
         public static final String LANGUAGE = "language";
         public static final String KEY_SERVERS = "keyServers";
         public static final String PREF_VERSION = "keyServersDefaultVersion";
-        public static final String FIRST_TIME = "firstTime";
+        // false if first time wizard has been finished
+        public static final String FIRST_TIME_WIZARD = "firstTime";
+        // false if app has been started at least once (also from background etc)
+        public static final String FIRST_TIME_APP = "firstTimeApp";
         public static final String CACHED_CONSOLIDATE = "cachedConsolidate";
         public static final String SEARCH_KEYSERVER = "search_keyserver_pref";
         public static final String SEARCH_KEYBASE = "search_keybase_pref";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
@@ -35,7 +35,6 @@ import android.widget.Toast;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.sufficientlysecure.keychain.network.TlsCertificatePinning;
-import org.sufficientlysecure.keychain.provider.KeychainDatabase;
 import org.sufficientlysecure.keychain.provider.TemporaryFileProvider;
 import org.sufficientlysecure.keychain.service.ContactSyncAdapterService;
 import org.sufficientlysecure.keychain.service.KeyserverSyncAdapterService;
@@ -99,19 +98,23 @@ public class KeychainApplication extends Application {
         // Add OpenKeychain account to Android to link contacts with keys and keyserver sync
         createAccountIfNecessary(this);
 
-        if (Preferences.getKeyserverSyncEnabled(this)) {
-            // will update a keyserver sync if the interval has changed
-            KeyserverSyncAdapterService.enableKeyserverSync(this);
-        }
+        Preferences preferences = Preferences.getPreferences(this);
+        if (preferences.isAppExecutedFirstTime()) {
+            preferences.setAppExecutedFirstTime(false);
 
-        // if first time, enable keyserver and contact sync
-        if (Preferences.getPreferences(this).isFirstTime()) {
             KeyserverSyncAdapterService.enableKeyserverSync(this);
             ContactSyncAdapterService.enableContactsSync(this);
+
+            preferences.setPrefVersionToCurrentVersion();
         }
 
-        // Update keyserver list as needed
-        Preferences.getPreferences(this).upgradePreferences(this);
+        if (Preferences.getKeyserverSyncEnabled(this)) {
+            // will update a keyserver sync if the interval has changed
+            KeyserverSyncAdapterService.updateInterval(this);
+        }
+
+        // Upgrade preferences as needed
+        preferences.upgradePreferences(this);
 
         TlsCertificatePinning.addPinnedCertificate("hkps.pool.sks-keyservers.net", getAssets(), "hkps.pool.sks-keyservers.net.CA.cer");
         TlsCertificatePinning.addPinnedCertificate("pgp.mit.edu", getAssets(), "pgp.mit.edu.cer");

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ContactSyncAdapterService.java
@@ -62,7 +62,7 @@ public class ContactSyncAdapterService extends Service {
 
             new ContactHelper(ContactSyncAdapterService.this).writeKeysToContacts();
 
-            importKeys();
+//            importKeys();
         }
 
         @Override
@@ -94,47 +94,6 @@ public class ContactSyncAdapterService extends Service {
             NotificationManagerCompat.from(ContactSyncAdapterService.this)
                     .notify(NOTIFICATION_ID_SYNC_SETTINGS, mBuilder.build());
         }
-    }
-
-    private static void importKeys() {
-        // TODO: Import is currently disabled, until we implement proper origin management
-//            importDone.set(false);
-//            KeychainApplication.setupAccountAsNeeded(ContactSyncAdapterService.this);
-//            EmailKeyHelper.importContacts(getContext(), new Messenger(new Handler(Looper.getMainLooper(),
-//                    new Handler.Callback() {
-//                        @Override
-//                        public boolean handleMessage(Message msg) {
-//                            Bundle data = msg.getInputData();
-//                            switch (msg.arg1) {
-//                                case KeychainIntentServiceHandler.MESSAGE_OKAY:
-//                                    Log.d(Constants.TAG, "Syncing... Done.");
-//                                    synchronized (importDone) {
-//                                        importDone.set(true);
-//                                        importDone.notifyAll();
-//                                    }
-//                                    return true;
-//                                case KeychainIntentServiceHandler.MESSAGE_UPDATE_PROGRESS:
-//                                    if (data.containsKey(KeychainIntentServiceHandler.DATA_PROGRESS) &&
-//                                            data.containsKey(KeychainIntentServiceHandler.DATA_PROGRESS_MAX)) {
-//                                        Log.d(Constants.TAG, "Syncing... Progress: " +
-//                                                data.getInt(KeychainIntentServiceHandler.DATA_PROGRESS) + "/" +
-//                                                data.getInt(KeychainIntentServiceHandler.DATA_PROGRESS_MAX));
-//                                        return false;
-//                                    }
-//                                default:
-//                                    Log.d(Constants.TAG, "Syncing... " + msg.toString());
-//                                    return false;
-//                            }
-//                        }
-//                    })));
-//            synchronized (importDone) {
-//                try {
-//                    if (!importDone.get()) importDone.wait();
-//                } catch (InterruptedException e) {
-//                    Log.w(Constants.TAG, e);
-//                    return;
-//                }
-//            }
     }
 
     @Override
@@ -187,4 +146,46 @@ public class ContactSyncAdapterService extends Service {
             new ContactHelper(context).deleteAllContacts();
         }
     }
+
+// TODO: Import is currently disabled, until we implement proper origin management
+//    private static void importKeys() {
+//            importDone.set(false);
+//            KeychainApplication.setupAccountAsNeeded(ContactSyncAdapterService.this);
+//            EmailKeyHelper.importContacts(getContext(), new Messenger(new Handler(Looper.getMainLooper(),
+//                    new Handler.Callback() {
+//                        @Override
+//                        public boolean handleMessage(Message msg) {
+//                            Bundle data = msg.getInputData();
+//                            switch (msg.arg1) {
+//                                case KeychainIntentServiceHandler.MESSAGE_OKAY:
+//                                    Log.d(Constants.TAG, "Syncing... Done.");
+//                                    synchronized (importDone) {
+//                                        importDone.set(true);
+//                                        importDone.notifyAll();
+//                                    }
+//                                    return true;
+//                                case KeychainIntentServiceHandler.MESSAGE_UPDATE_PROGRESS:
+//                                    if (data.containsKey(KeychainIntentServiceHandler.DATA_PROGRESS) &&
+//                                            data.containsKey(KeychainIntentServiceHandler.DATA_PROGRESS_MAX)) {
+//                                        Log.d(Constants.TAG, "Syncing... Progress: " +
+//                                                data.getInt(KeychainIntentServiceHandler.DATA_PROGRESS) + "/" +
+//                                                data.getInt(KeychainIntentServiceHandler.DATA_PROGRESS_MAX));
+//                                        return false;
+//                                    }
+//                                default:
+//                                    Log.d(Constants.TAG, "Syncing... " + msg.toString());
+//                                    return false;
+//                            }
+//                        }
+//                    })));
+//            synchronized (importDone) {
+//                try {
+//                    if (!importDone.get()) importDone.wait();
+//                } catch (InterruptedException e) {
+//                    Log.w(Constants.TAG, e);
+//                    return;
+//                }
+//            }
+//    }
+
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeyserverSyncAdapterService.java
@@ -528,10 +528,6 @@ public class KeyserverSyncAdapterService extends Service {
         return builder.build();
     }
 
-    /**
-     * creates a new sync if one does not exist, or updates an existing sync if the sync interval
-     * has changed.
-     */
     public static void enableKeyserverSync(Context context) {
         Account account = KeychainApplication.createAccountIfNecessary(context);
 
@@ -542,6 +538,21 @@ public class KeyserverSyncAdapterService extends Service {
 
         ContentResolver.setIsSyncable(account, Constants.PROVIDER_AUTHORITY, 1);
         ContentResolver.setSyncAutomatically(account, Constants.PROVIDER_AUTHORITY, true);
+
+        updateInterval(context);
+    }
+
+    /**
+     * creates a new sync if one does not exist, or updates an existing sync if the sync interval
+     * has changed.
+     */
+    public static void updateInterval(Context context) {
+        Account account = KeychainApplication.createAccountIfNecessary(context);
+
+        if (account == null) {
+            // account failed to be created for some reason, nothing we can do here
+            return;
+        }
 
         boolean intervalChanged = false;
         boolean syncExists = Preferences.getKeyserverSyncEnabled(context);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/Preferences.java
@@ -118,16 +118,22 @@ public class Preferences {
     }
 
     public boolean isFirstTime() {
-        return mSharedPreferences.getBoolean(Constants.Pref.FIRST_TIME, true);
-    }
-
-    public boolean useNumKeypadForSecurityTokenPin() {
-        return mSharedPreferences.getBoolean(Pref.USE_NUMKEYPAD_FOR_SECURITY_TOKEN_PIN, true);
+        return mSharedPreferences.getBoolean(Constants.Pref.FIRST_TIME_WIZARD, true);
     }
 
     public void setFirstTime(boolean value) {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
-        editor.putBoolean(Constants.Pref.FIRST_TIME, value);
+        editor.putBoolean(Constants.Pref.FIRST_TIME_WIZARD, value);
+        editor.commit();
+    }
+
+    public boolean isAppExecutedFirstTime() {
+        return mSharedPreferences.getBoolean(Pref.FIRST_TIME_APP, true);
+    }
+
+    public void setAppExecutedFirstTime(boolean value) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(Constants.Pref.FIRST_TIME_APP, value);
         editor.commit();
     }
 
@@ -213,6 +219,10 @@ public class Preferences {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         editor.putBoolean(Pref.USE_ARMOR, useArmor);
         editor.commit();
+    }
+
+    public boolean useNumKeypadForSecurityTokenPin() {
+        return mSharedPreferences.getBoolean(Pref.USE_NUMKEYPAD_FOR_SECURITY_TOKEN_PIN, true);
     }
 
     public void setUseNumKeypadForSecurityTokenPin(boolean useNumKeypad) {
@@ -404,6 +414,12 @@ public class Preferences {
 
     public boolean getExperimentalSmartPGPAuthoritiesEnable() {
         return mSharedPreferences.getBoolean(Pref.EXPERIMENTAL_SMARTPGP_VERIFY_AUTHORITY, false);
+    }
+
+    public void setPrefVersionToCurrentVersion() {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putInt(Pref.PREF_VERSION, Constants.Defaults.PREF_CURRENT_VERSION);
+        editor.commit();
     }
 
     public void upgradePreferences(Context context) {


### PR DESCRIPTION
Hopefully fixes #1996

## Description
If the first time wizard is not finished or properly finished, the contacts sync notification will pop-up again and again because the service keeps re-enabling on application start.

## Motivation and Context
#1996

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
