### PR TITLE
Avoid localized text clash in create key start fragment

### DIFF
--- a/OpenKeychain/src/main/res/layout/create_key_start_fragment.xml
+++ b/OpenKeychain/src/main/res/layout/create_key_start_fragment.xml
@@ -67,6 +67,7 @@
                 android:paddingLeft="16dp"
                 android:paddingRight="10dp"
                 android:text="@string/first_time_security_token"
+                android:singleLine="true"
                 android:textAllCaps="true"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:layout_alignParentTop="true"


### PR DESCRIPTION
Disallow multiline in "USE SECURITY TOKEN" button title to avoid localized text clash with subtitle.

## Description
Added `android:singleLine="true"` to the TextView in `create_key_start_fragment.xml`

## Motivation and Context
Fixes #2170 

## Screenshots (if appropriate):
Before:
![screenshot from 2017-12-17 16-12-40](https://user-images.githubusercontent.com/1240012/34080365-28903fdc-e345-11e7-92ad-1b154bf49c9b.png)
After:
![screenshot from 2017-12-17 16-10-59](https://user-images.githubusercontent.com/1240012/34080349-ee175ffc-e344-11e7-9fa7-cb21b71109cb.png)

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
