### PR TITLE
Autocrypt 1.0

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/SaveKeyringResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/SaveKeyringResult.java
@@ -24,12 +24,12 @@ import org.sufficientlysecure.keychain.pgp.CanonicalizedKeyRing;
 
 public class SaveKeyringResult extends OperationResult {
 
-    public final long mRingMasterKeyId;
+    public final Long savedMasterKeyId;
 
     public SaveKeyringResult(int result, OperationLog log,
                              CanonicalizedKeyRing ring) {
         super(result, log);
-        mRingMasterKeyId = ring != null ? ring.getMasterKeyId() : Constants.key.none;
+        savedMasterKeyId = ring != null ? ring.getMasterKeyId() : null;
     }
 
     // Some old key was updated
@@ -46,13 +46,13 @@ public class SaveKeyringResult extends OperationResult {
 
     public SaveKeyringResult(Parcel source) {
         super(source);
-        mRingMasterKeyId = source.readLong();
+        savedMasterKeyId = source.readLong();
     }
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         super.writeToParcel(dest, flags);
-        dest.writeLong(mRingMasterKeyId);
+        dest.writeLong(savedMasterKeyId);
     }
 
     public static Creator<SaveKeyringResult> CREATOR = new Creator<SaveKeyringResult>() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/AutocryptPeerDataAccessObject.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/AutocryptPeerDataAccessObject.java
@@ -153,6 +153,23 @@ public class AutocryptPeerDataAccessObject {
         return null;
     }
 
+    public Date getLastSeenGossip(String autocryptId) {
+        Cursor cursor = queryInterface.query(ApiAutocryptPeer.buildByPackageNameAndAutocryptId(packageName, autocryptId),
+                null, null, null, null);
+
+        try {
+            if (cursor != null && cursor.moveToFirst()) {
+                long lastUpdated = cursor.getColumnIndex(ApiAutocryptPeer.GOSSIP_LAST_SEEN_KEY);
+                return new Date(lastUpdated);
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return null;
+    }
+
     public void updateLastSeen(String autocryptId, Date date) {
         ContentValues cv = new ContentValues();
         cv.put(ApiAutocryptPeer.LAST_SEEN, date.getTime());

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/AutocryptPeerDataAccessObject.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/AutocryptPeerDataAccessObject.java
@@ -187,10 +187,23 @@ public class AutocryptPeerDataAccessObject {
                 .update(ApiAutocryptPeer.buildByPackageNameAndAutocryptId(packageName, autocryptId), cv, null, null);
     }
 
-    public void updateKeyGossip(String autocryptId, Date effectiveDate, long masterKeyId) {
+    public void updateKeyGossipFromAutocrypt(String autocryptId, Date effectiveDate, long masterKeyId) {
+        updateKeyGossip(autocryptId, effectiveDate, masterKeyId, ApiAutocryptPeer.GOSSIP_ORIGIN_AUTOCRYPT);
+    }
+
+    public void updateKeyGossipFromSignature(String autocryptId, Date effectiveDate, long masterKeyId) {
+        updateKeyGossip(autocryptId, effectiveDate, masterKeyId, ApiAutocryptPeer.GOSSIP_ORIGIN_SIGNATURE);
+    }
+
+    public void updateKeyGossipFromDedup(String autocryptId, Date effectiveDate, long masterKeyId) {
+        updateKeyGossip(autocryptId, effectiveDate, masterKeyId, ApiAutocryptPeer.GOSSIP_ORIGIN_DEDUP);
+    }
+
+    private void updateKeyGossip(String autocryptId, Date effectiveDate, long masterKeyId, int origin) {
         ContentValues cv = new ContentValues();
         cv.put(ApiAutocryptPeer.GOSSIP_MASTER_KEY_ID, masterKeyId);
         cv.put(ApiAutocryptPeer.GOSSIP_LAST_SEEN_KEY, effectiveDate.getTime());
+        cv.put(ApiAutocryptPeer.GOSSIP_ORIGIN, origin);
         queryInterface
                 .update(ApiAutocryptPeer.buildByPackageNameAndAutocryptId(packageName, autocryptId), cv, null, null);
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -103,9 +103,13 @@ public class KeychainContract {
         String PACKAGE_NAME = "package_name";
         String IDENTIFIER = "identifier";
         String LAST_SEEN = "last_updated";
-        String LAST_SEEN_KEY = "last_seen_key";
-        String STATE = "state";
+
         String MASTER_KEY_ID = "master_key_id";
+        String LAST_SEEN_KEY = "last_seen_key";
+        String IS_MUTUAL = "is_mutual";
+
+        String GOSSIP_MASTER_KEY_ID = "gossip_master_key_id";
+        String GOSSIP_LAST_SEEN_KEY = "gossip_last_seen_key";
     }
 
     public static final String CONTENT_AUTHORITY = Constants.PROVIDER_AUTHORITY;
@@ -371,12 +375,12 @@ public class KeychainContract {
     public static class ApiAutocryptPeer implements ApiAutocryptPeerColumns, BaseColumns {
         public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
                 .appendPath(BASE_AUTOCRYPT_PEERS).build();
-
-        public static final int RESET = 0;
-        public static final int GOSSIP = 1;
-        public static final int SELECTED = 2;
-        public static final int AVAILABLE = 3;
-        public static final int MUTUAL = 4;
+        public static final String KEY_IS_REVOKED = "key_is_revoked";
+        public static final String KEY_IS_EXPIRED = "key_is_expired";
+        public static final String KEY_IS_VERIFIED = "key_is_verified";
+        public static final String GOSSIP_KEY_IS_REVOKED = "gossip_key_is_revoked";
+        public static final String GOSSIP_KEY_IS_EXPIRED = "gossip_key_is_expired";
+        public static final String GOSSIP_KEY_IS_VERIFIED = "gossip_key_is_verified";
 
         public static Uri buildByKeyUri(Uri uri) {
             return CONTENT_URI.buildUpon().appendPath(PATH_BY_KEY_ID).appendPath(uri.getPathSegments().get(1)).build();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -110,6 +110,7 @@ public class KeychainContract {
 
         String GOSSIP_MASTER_KEY_ID = "gossip_master_key_id";
         String GOSSIP_LAST_SEEN_KEY = "gossip_last_seen_key";
+        String GOSSIP_ORIGIN = "gossip_origin";
     }
 
     public static final String CONTENT_AUTHORITY = Constants.PROVIDER_AUTHORITY;
@@ -381,6 +382,10 @@ public class KeychainContract {
         public static final String GOSSIP_KEY_IS_REVOKED = "gossip_key_is_revoked";
         public static final String GOSSIP_KEY_IS_EXPIRED = "gossip_key_is_expired";
         public static final String GOSSIP_KEY_IS_VERIFIED = "gossip_key_is_verified";
+
+        public static final int GOSSIP_ORIGIN_AUTOCRYPT = 0;
+        public static final int GOSSIP_ORIGIN_SIGNATURE = 10;
+        public static final int GOSSIP_ORIGIN_DEDUP = 20;
 
         public static Uri buildByKeyUri(Uri uri) {
             return CONTENT_URI.buildUpon().appendPath(PATH_BY_KEY_ID).appendPath(uri.getPathSegments().get(1)).build();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -386,6 +386,10 @@ public class KeychainContract {
             return CONTENT_URI.buildUpon().appendPath(PATH_BY_KEY_ID).appendPath(uri.getPathSegments().get(1)).build();
         }
 
+        public static Uri buildByPackageName(String packageName) {
+            return CONTENT_URI.buildUpon().appendPath(PATH_BY_PACKAGE_NAME).appendPath(packageName).build();
+        }
+
         public static Uri buildByPackageNameAndAutocryptId(String packageName, String autocryptPeer) {
             return CONTENT_URI.buildUpon().appendPath(PATH_BY_PACKAGE_NAME).appendPath(packageName).appendPath(autocryptPeer).build();
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -102,7 +102,7 @@ public class KeychainContract {
     interface ApiAutocryptPeerColumns {
         String PACKAGE_NAME = "package_name";
         String IDENTIFIER = "identifier";
-        String LAST_SEEN = "last_updated";
+        String LAST_SEEN = "last_seen";
 
         String MASTER_KEY_ID = "master_key_id";
         String LAST_SEEN_KEY = "last_seen_key";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
@@ -54,7 +54,7 @@ import timber.log.Timber;
  */
 public class KeychainDatabase extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "openkeychain.db";
-    private static final int DATABASE_VERSION = 24;
+    private static final int DATABASE_VERSION = 25;
     private Context mContext;
 
     public interface Tables {
@@ -173,10 +173,12 @@ public class KeychainDatabase extends SQLiteOpenHelper {
             "CREATE TABLE IF NOT EXISTS " + Tables.API_AUTOCRYPT_PEERS + " ("
                     + ApiAutocryptPeerColumns.PACKAGE_NAME + " TEXT NOT NULL, "
                     + ApiAutocryptPeerColumns.IDENTIFIER + " TEXT NOT NULL, "
-                    + ApiAutocryptPeerColumns.LAST_SEEN + " INTEGER NOT NULL, "
-                    + ApiAutocryptPeerColumns.LAST_SEEN_KEY + " INTEGER NOT NULL, "
-                    + ApiAutocryptPeerColumns.STATE + " INTEGER NOT NULL, "
+                    + ApiAutocryptPeerColumns.LAST_SEEN + " INTEGER, "
+                    + ApiAutocryptPeerColumns.LAST_SEEN_KEY + " INTEGER NULL, "
+                    + ApiAutocryptPeerColumns.IS_MUTUAL + " INTEGER NULL, "
                     + ApiAutocryptPeerColumns.MASTER_KEY_ID + " INTEGER NULL, "
+                    + ApiAutocryptPeerColumns.GOSSIP_MASTER_KEY_ID + " INTEGER NULL, "
+                    + ApiAutocryptPeerColumns.GOSSIP_LAST_SEEN_KEY + " INTEGER NULL, "
                     + "PRIMARY KEY(" + ApiAutocryptPeerColumns.PACKAGE_NAME + ", "
                         + ApiAutocryptPeerColumns.IDENTIFIER + "), "
                     + "FOREIGN KEY(" + ApiAutocryptPeerColumns.PACKAGE_NAME + ") REFERENCES "
@@ -406,6 +408,10 @@ public class KeychainDatabase extends SQLiteOpenHelper {
                         + "PRIMARY KEY(master_key_id, signer_key_id), "
                         + "FOREIGN KEY(master_key_id) REFERENCES keyrings_public(master_key_id) ON DELETE CASCADE"
                         + ")");
+
+            case 24:
+                db.execSQL("DROP TABLE api_autocrypt_peers");
+                db.execSQL(CREATE_API_AUTOCRYPT_PEERS);
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
@@ -231,7 +231,7 @@ public class KeychainDatabase extends SQLiteOpenHelper {
         db.execSQL(CREATE_OVERRIDDEN_WARNINGS);
         db.execSQL(CREATE_API_AUTOCRYPT_PEERS);
 
-        db.execSQL("CREATE INDEX keys_by_rank ON keys (" + KeysColumns.RANK + ");");
+        db.execSQL("CREATE INDEX keys_by_rank ON keys (" + KeysColumns.RANK + ", " + KeysColumns.MASTER_KEY_ID + ");");
         db.execSQL("CREATE INDEX uids_by_rank ON user_packets (" + UserPacketsColumns.RANK + ", "
                 + UserPacketsColumns.USER_ID + ", " + UserPacketsColumns.MASTER_KEY_ID + ");");
         db.execSQL("CREATE INDEX verified_certs ON certs ("
@@ -415,6 +415,8 @@ public class KeychainDatabase extends SQLiteOpenHelper {
                 db.execSQL("DROP TABLE api_autocrypt_peers");
                 db.execSQL(CREATE_API_AUTOCRYPT_PEERS);
                 db.execSQL("CREATE INDEX uids_by_email ON user_packets (email);");
+                db.execSQL("DROP INDEX keys_by_rank");
+                db.execSQL("CREATE INDEX keys_by_rank ON keys(rank, master_key_id);");
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
@@ -236,6 +236,8 @@ public class KeychainDatabase extends SQLiteOpenHelper {
                 + UserPacketsColumns.USER_ID + ", " + UserPacketsColumns.MASTER_KEY_ID + ");");
         db.execSQL("CREATE INDEX verified_certs ON certs ("
                 + CertsColumns.VERIFIED + ", " + CertsColumns.MASTER_KEY_ID + ");");
+        db.execSQL("CREATE INDEX uids_by_email ON user_packets ("
+                + UserPacketsColumns.EMAIL + ");");
 
         Preferences.getPreferences(mContext).setKeySignaturesTableInitialized();
     }
@@ -412,6 +414,7 @@ public class KeychainDatabase extends SQLiteOpenHelper {
             case 24:
                 db.execSQL("DROP TABLE api_autocrypt_peers");
                 db.execSQL(CREATE_API_AUTOCRYPT_PEERS);
+                db.execSQL("CREATE INDEX uids_by_email ON user_packets (email);");
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainDatabase.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import android.content.Context;
+import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -413,44 +414,47 @@ public class KeychainDatabase extends SQLiteOpenHelper {
                         + ")");
 
             case 24:
-                db.beginTransaction();
-                db.execSQL("ALTER TABLE api_autocrypt_peers RENAME TO tmp");
-                db.execSQL("CREATE TABLE api_autocrypt_peers ("
-                        + "package_name TEXT NOT NULL, "
-                        + "identifier TEXT NOT NULL, "
-                        + "last_seen INTEGER, "
-                        + "last_seen_key INTEGER, "
-                        + "is_mutual INTEGER, "
-                        + "master_key_id INTEGER, "
-                        + "gossip_master_key_id INTEGER, "
-                        + "gossip_last_seen_key INTEGER, "
-                        + "gossip_origin INTEGER, "
-                        + "PRIMARY KEY(package_name, identifier), "
-                        + "FOREIGN KEY(package_name) REFERENCES api_apps (package_name) ON DELETE CASCADE"
-                    + ")");
-                // Note: Keys from Autocrypt 0.X with state == "reset" (0) are dropped
-                db.execSQL("INSERT INTO api_autocrypt_peers " +
-                        "(package_name, identifier, last_seen, gossip_last_seen_key, gossip_master_key_id, gossip_origin) " +
-                        "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 0 " +
-                        "FROM tmp WHERE state = 1"); // Autocrypt 0.X, "gossip" -> now origin=autocrypt
-                db.execSQL("INSERT INTO api_autocrypt_peers " +
-                        "(package_name, identifier, last_seen, gossip_last_seen_key, gossip_master_key_id, gossip_origin) " +
-                        "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 20 " +
-                        "FROM tmp WHERE state = 2"); // "selected" keys -> now origin=dedup
-                db.execSQL("INSERT INTO api_autocrypt_peers " +
-                        "(package_name, identifier, last_seen, last_seen_key, master_key_id, is_mutual) " +
-                        "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 0 " +
+                try {
+                    db.beginTransaction();
+                    db.execSQL("ALTER TABLE api_autocrypt_peers RENAME TO tmp");
+                    db.execSQL("CREATE TABLE api_autocrypt_peers ("
+                            + "package_name TEXT NOT NULL, "
+                            + "identifier TEXT NOT NULL, "
+                            + "last_seen INTEGER, "
+                            + "last_seen_key INTEGER, "
+                            + "is_mutual INTEGER, "
+                            + "master_key_id INTEGER, "
+                            + "gossip_master_key_id INTEGER, "
+                            + "gossip_last_seen_key INTEGER, "
+                            + "gossip_origin INTEGER, "
+                            + "PRIMARY KEY(package_name, identifier), "
+                            + "FOREIGN KEY(package_name) REFERENCES api_apps (package_name) ON DELETE CASCADE"
+                            + ")");
+                    // Note: Keys from Autocrypt 0.X with state == "reset" (0) are dropped
+                    db.execSQL("INSERT INTO api_autocrypt_peers " +
+                            "(package_name, identifier, last_seen, gossip_last_seen_key, gossip_master_key_id, gossip_origin) " +
+                            "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 0 " +
+                            "FROM tmp WHERE state = 1"); // Autocrypt 0.X, "gossip" -> now origin=autocrypt
+                    db.execSQL("INSERT INTO api_autocrypt_peers " +
+                            "(package_name, identifier, last_seen, gossip_last_seen_key, gossip_master_key_id, gossip_origin) " +
+                            "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 20 " +
+                            "FROM tmp WHERE state = 2"); // "selected" keys -> now origin=dedup
+                    db.execSQL("INSERT INTO api_autocrypt_peers " +
+                            "(package_name, identifier, last_seen, last_seen_key, master_key_id, is_mutual) " +
+                            "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 0 " +
                             "FROM tmp WHERE state = 3"); // Autocrypt 0.X, state = "available"
-                db.execSQL("INSERT INTO api_autocrypt_peers " +
-                        "(package_name, identifier, last_seen, last_seen_key, master_key_id, is_mutual) " +
-                        "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 1 " +
+                    db.execSQL("INSERT INTO api_autocrypt_peers " +
+                            "(package_name, identifier, last_seen, last_seen_key, master_key_id, is_mutual) " +
+                            "SELECT package_name, identifier, last_updated, last_seen_key, master_key_id, 1 " +
                             "FROM tmp WHERE state = 4"); // from Autocrypt 0.X, state = "mutual"
-                db.execSQL("DROP TABLE tmp");
-                db.setTransactionSuccessful();
-                db.endTransaction();
+                    db.execSQL("DROP TABLE tmp");
+                    db.setTransactionSuccessful();
+                } finally {
+                    db.endTransaction();
+                }
 
+                db.execSQL("CREATE INDEX IF NOT EXISTS uids_by_email ON user_packets (email);");
                 db.execSQL("DROP INDEX keys_by_rank");
-                db.execSQL("CREATE INDEX uids_by_email ON user_packets (email);");
                 db.execSQL("CREATE INDEX keys_by_rank ON keys(rank, master_key_id);");
         }
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
@@ -63,14 +63,13 @@ public class KeychainExternalContract {
         public static final String AUTOCRYPT_MASTER_KEY_ID = "autocrypt_master_key_id";
         public static final String AUTOCRYPT_KEY_STATUS = "autocrypt_key_status";
         public static final String AUTOCRYPT_PEER_STATE = "autocrypt_peer_state";
-        public static final String AUTOCRYPT_LAST_SEEN = "autocrypt_last_seen";
-        public static final String AUTOCRYPT_LAST_SEEN_KEY = "autocrypt_last_seen_key";
 
-        public static final int AUTOCRYPT_PEER_RESET = ApiAutocryptPeer.RESET;
-        public static final int AUTOCRYPT_PEER_GOSSIP = ApiAutocryptPeer.GOSSIP;
-        public static final int AUTOCRYPT_PEER_SELECTED = ApiAutocryptPeer.SELECTED;
-        public static final int AUTOCRYPT_PEER_AVAILABLE = ApiAutocryptPeer.AVAILABLE;
-        public static final int AUTOCRYPT_PEER_MUTUAL = ApiAutocryptPeer.MUTUAL;
+        public static final int AUTOCRYPT_PEER_DISABLED = 0;
+        public static final int AUTOCRYPT_PEER_DISCOURAGED_OLD = 10;
+        public static final int AUTOCRYPT_PEER_GOSSIP = 20;
+        public static final int AUTOCRYPT_PEER_AVAILABLE_EXTERNAL = 30;
+        public static final int AUTOCRYPT_PEER_AVAILABLE = 40;
+        public static final int AUTOCRYPT_PEER_MUTUAL = 50;
 
         public static final Uri CONTENT_URI = BASE_CONTENT_URI_EXTERNAL.buildUpon()
                 .appendPath(BASE_AUTOCRYPT_STATUS).build();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -366,7 +366,7 @@ public class KeychainProvider extends ContentProvider {
                         "(" + Tables.KEYS + "." + Keys.EXPIRY + " IS NOT NULL AND " + Tables.KEYS + "." + Keys.EXPIRY
                                 + " < " + new Date().getTime() / 1000 + ") AS " + KeyRings.IS_EXPIRED);
                 projectionMap.put(KeyRings.API_KNOWN_TO_PACKAGE_NAMES,
-                        "GROUP_CONCAT(aTI." + ApiAutocryptPeer.PACKAGE_NAME + ") AS "
+                        "GROUP_CONCAT(DISTINCT aTI." + ApiAutocryptPeer.PACKAGE_NAME + ") AS "
                         + KeyRings.API_KNOWN_TO_PACKAGE_NAMES);
                 qb.setProjectionMap(projectionMap);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -754,16 +754,18 @@ public class KeychainProvider extends ContentProvider {
 
                 qb.setTables(Tables.API_AUTOCRYPT_PEERS +
                         " LEFT JOIN " + Tables.KEYS + " AS ac_key" +
-                        " ON (ac_key." + Keys.MASTER_KEY_ID + " = " + Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.MASTER_KEY_ID + ")" +
+                            " ON (ac_key." + Keys.MASTER_KEY_ID + " = " + Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.MASTER_KEY_ID +
+                                " AND ac_key." + Keys.RANK + " = 0)" +
                         " LEFT JOIN " + Tables.KEYS + " AS gossip_key" +
-                        " ON (gossip_key." + Keys.MASTER_KEY_ID + " = " + ApiAutocryptPeer.GOSSIP_MASTER_KEY_ID + ")"
+                            " ON (gossip_key." + Keys.MASTER_KEY_ID + " = " + ApiAutocryptPeer.GOSSIP_MASTER_KEY_ID +
+                                " AND gossip_key." + Keys.RANK + " = 0)"
                 );
 
                 if (match == AUTOCRYPT_PEERS_BY_MASTER_KEY_ID) {
                     long masterKeyId = Long.parseLong(uri.getLastPathSegment());
 
-                    selection = Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.MASTER_KEY_ID + " = ?";
-                    selectionArgs = new String[] { Long.toString(masterKeyId) };
+                    qb.appendWhere(Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.MASTER_KEY_ID + " = ");
+                    qb.appendWhere(Long.toString(masterKeyId));
                 } else if (match == AUTOCRYPT_PEERS_BY_PACKAGE_NAME) {
                     String packageName = uri.getPathSegments().get(2);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -717,14 +717,10 @@ public class KeychainProvider extends ContentProvider {
             case AUTOCRYPT_PEERS_BY_MASTER_KEY_ID:
             case AUTOCRYPT_PEERS_BY_PACKAGE_NAME:
             case AUTOCRYPT_PEERS_BY_PACKAGE_NAME_AND_TRUST_ID: {
-                if (selection != null || selectionArgs != null) {
-                    throw new UnsupportedOperationException();
-                }
-
                 long unixSeconds = new Date().getTime() / 1000;
 
                 HashMap<String, String> projectionMap = new HashMap<>();
-                projectionMap.put(ApiAutocryptPeer._ID, "oid AS " + ApiAutocryptPeer._ID);
+                projectionMap.put(ApiAutocryptPeer._ID, Tables.API_AUTOCRYPT_PEERS + ".oid AS " + ApiAutocryptPeer._ID);
                 projectionMap.put(ApiAutocryptPeer.IDENTIFIER, ApiAutocryptPeer.IDENTIFIER);
                 projectionMap.put(ApiAutocryptPeer.PACKAGE_NAME, ApiAutocryptPeer.PACKAGE_NAME);
                 projectionMap.put(ApiAutocryptPeer.LAST_SEEN, ApiAutocryptPeer.LAST_SEEN);
@@ -771,8 +767,8 @@ public class KeychainProvider extends ContentProvider {
                 } else if (match == AUTOCRYPT_PEERS_BY_PACKAGE_NAME) {
                     String packageName = uri.getPathSegments().get(2);
 
-                    selection = Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.PACKAGE_NAME + " = ?";
-                    selectionArgs = new String[] { packageName };
+                    qb.appendWhere(Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.PACKAGE_NAME + " = ");
+                    qb.appendWhereEscapeString(packageName);
                 } else { // AUTOCRYPT_PEERS_BY_PACKAGE_NAME_AND_TRUST_ID
                     String packageName = uri.getPathSegments().get(2);
                     String autocryptPeer = uri.getPathSegments().get(3);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -729,6 +729,7 @@ public class KeychainProvider extends ContentProvider {
                 projectionMap.put(ApiAutocryptPeer.LAST_SEEN_KEY, ApiAutocryptPeer.LAST_SEEN_KEY);
                 projectionMap.put(ApiAutocryptPeer.GOSSIP_MASTER_KEY_ID, ApiAutocryptPeer.GOSSIP_MASTER_KEY_ID);
                 projectionMap.put(ApiAutocryptPeer.GOSSIP_LAST_SEEN_KEY, ApiAutocryptPeer.GOSSIP_LAST_SEEN_KEY);
+                projectionMap.put(ApiAutocryptPeer.GOSSIP_ORIGIN, ApiAutocryptPeer.GOSSIP_ORIGIN);
                 projectionMap.put(ApiAutocryptPeer.KEY_IS_REVOKED, "ac_key." + Keys.IS_REVOKED + " AS " + ApiAutocryptPeer.KEY_IS_REVOKED);
                 projectionMap.put(ApiAutocryptPeer.KEY_IS_EXPIRED, "(CASE" +
                                 " WHEN ac_key." + Keys.EXPIRY + " IS NULL THEN 0" +

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
@@ -5,15 +5,17 @@ import java.io.IOException;
 import java.util.Date;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 
 import org.openintents.openpgp.AutocryptPeerUpdate;
 import org.openintents.openpgp.AutocryptPeerUpdate.PreferEncrypt;
 import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.operations.results.SaveKeyringResult;
 import org.sufficientlysecure.keychain.pgp.UncachedKeyRing;
 import org.sufficientlysecure.keychain.pgp.exception.PgpGeneralException;
 import org.sufficientlysecure.keychain.provider.AutocryptPeerDataAccessObject;
 import org.sufficientlysecure.keychain.provider.KeyWritableRepository;
-import org.sufficientlysecure.keychain.util.Log;
+import timber.log.Timber;
 
 
 class AutocryptInteractor {
@@ -33,74 +35,100 @@ class AutocryptInteractor {
         this.keyWritableRepository = keyWritableRepository;
     }
 
-    void updateAutocryptPeerState(String autocryptPeerId, AutocryptPeerUpdate autocryptPeerUpdate)
-            throws PgpGeneralException, IOException {
-        if (autocryptPeerUpdate == null) {
-            return;
-        }
-
-        Long newMasterKeyId;
-        if (autocryptPeerUpdate.hasKeyData()) {
-            UncachedKeyRing uncachedKeyRing = UncachedKeyRing.decodeFromData(autocryptPeerUpdate.getKeyData());
-            if (uncachedKeyRing.isSecret()) {
-                Log.e(Constants.TAG, "Found secret key in autocrypt id! - Ignoring");
-                return;
-            }
-            // this will merge if the key already exists - no worries!
-            keyWritableRepository.savePublicKeyRing(uncachedKeyRing);
-            newMasterKeyId = uncachedKeyRing.getMasterKeyId();
-        } else {
-            newMasterKeyId = null;
-        }
-
+    void updateAutocryptPeerState(String autocryptPeerId, AutocryptPeerUpdate autocryptPeerUpdate) {
         Date effectiveDate = autocryptPeerUpdate.getEffectiveDate();
-        autocryptPeerDao.updateLastSeen(autocryptPeerId, effectiveDate);
 
-        if (newMasterKeyId == null) {
+        // 1. If the message’s effective date is older than the peers[from-addr].autocrypt_timestamp value, then no changes are required, and the update process terminates.
+        Date lastSeenAutocrypt = autocryptPeerDao.getLastSeenKey(autocryptPeerId);
+        if (lastSeenAutocrypt != null && lastSeenAutocrypt.after(effectiveDate)) {
             return;
         }
 
-        Date lastSeenKey = autocryptPeerDao.getLastSeenKey(autocryptPeerId);
-        if (lastSeenKey == null || effectiveDate.after(lastSeenKey)) {
-            boolean isMutual = autocryptPeerUpdate.getPreferEncrypt() == PreferEncrypt.MUTUAL;
-            autocryptPeerDao.updateKey(autocryptPeerId, effectiveDate, newMasterKeyId, isMutual);
+        // 2. If the message’s effective date is more recent than peers[from-addr].last_seen then set peers[from-addr].last_seen to the message’s effective date.
+        Date lastSeen = autocryptPeerDao.getLastSeen(autocryptPeerId);
+        if (lastSeen == null || lastSeen.after(effectiveDate)) {
+            autocryptPeerDao.updateLastSeen(autocryptPeerId, effectiveDate);
         }
+
+        // 3. If the Autocrypt header is unavailable, no further changes are required and the update process terminates.
+        if (!autocryptPeerUpdate.hasKeyData()) {
+            return;
+        }
+
+        SaveKeyringResult saveKeyringResult = parseAndImportAutocryptKeyData(autocryptPeerUpdate);
+        if (saveKeyringResult == null) {
+            return;
+        }
+
+        // 4. Set peers[from-addr].autocrypt_timestamp to the message’s effective date.
+        // 5. Set peers[from-addr].public_key to the corresponding keydata value of the Autocrypt header.
+        Long newMasterKeyId = saveKeyringResult.savedMasterKeyId;
+        // 6. Set peers[from-addr].prefer_encrypt to the corresponding prefer-encrypt value of the Autocrypt header.
+        boolean isMutual = autocryptPeerUpdate.getPreferEncrypt() == PreferEncrypt.MUTUAL;
+
+        autocryptPeerDao.updateKey(autocryptPeerId, effectiveDate, newMasterKeyId, isMutual);
     }
 
-
-    void updateAutocryptPeerGossipState(String autocryptPeerId, AutocryptPeerUpdate autocryptPeerUpdate)
-            throws PgpGeneralException, IOException {
-        if (autocryptPeerUpdate == null) {
-            return;
-        }
-
-        Long newMasterKeyId;
-        if (autocryptPeerUpdate.hasKeyData()) {
-            UncachedKeyRing uncachedKeyRing = UncachedKeyRing.decodeFromData(autocryptPeerUpdate.getKeyData());
-            if (uncachedKeyRing.isSecret()) {
-                Log.e(Constants.TAG, "Found secret key in autocrypt id! - Ignoring");
-                return;
-            }
-            // this will merge if the key already exists - no worries!
-            keyWritableRepository.savePublicKeyRing(uncachedKeyRing);
-            newMasterKeyId = uncachedKeyRing.getMasterKeyId();
-        } else {
-            newMasterKeyId = null;
-        }
-
-        Date lastSeen = autocryptPeerDao.getLastSeen(autocryptPeerId);
+    void updateAutocryptPeerGossipState(String autocryptPeerId, AutocryptPeerUpdate autocryptPeerUpdate) {
         Date effectiveDate = autocryptPeerUpdate.getEffectiveDate();
-        if (newMasterKeyId == null) {
+
+        // 1. If gossip-addr does not match any recipient in the mail’s To or Cc header, the update process terminates (i.e., header is ignored).
+        // -> This should be taken care of in the mail client that sends us this data!
+
+        // 2. If peers[gossip-addr].gossip_timestamp is more recent than the message’s effective date, then the update process terminates.
+        Date lastSeenGossip = autocryptPeerDao.getLastSeenGossip(autocryptPeerId);
+        if (lastSeenGossip != null && lastSeenGossip.after(effectiveDate)) {
             return;
         }
 
-        Date lastSeenKey = autocryptPeerDao.getLastSeenKey(autocryptPeerId);
-        if (lastSeenKey != null && effectiveDate.before(lastSeenKey)) {
+        if (!autocryptPeerUpdate.hasKeyData()) {
             return;
         }
 
-        if (lastSeen == null || effectiveDate.after(lastSeen)) {
-            autocryptPeerDao.updateKeyGossip(autocryptPeerId, effectiveDate, newMasterKeyId);
+        SaveKeyringResult saveKeyringResult = parseAndImportAutocryptKeyData(autocryptPeerUpdate);
+        if (saveKeyringResult == null) {
+            return;
         }
+
+        // 3. Set peers[gossip-addr].gossip_timestamp to the message’s effective date.
+        // 4. Set peers[gossip-addr].gossip_key to the value of the keydata attribute.
+        Long newMasterKeyId = saveKeyringResult.savedMasterKeyId;
+
+        autocryptPeerDao.updateKeyGossip(autocryptPeerId, effectiveDate, newMasterKeyId);
+    }
+
+    @Nullable
+    private SaveKeyringResult parseAndImportAutocryptKeyData(AutocryptPeerUpdate autocryptPeerUpdate) {
+        UncachedKeyRing uncachedKeyRing = parseAutocryptKeyData(autocryptPeerUpdate);
+        if (uncachedKeyRing != null) {
+            return importAutocryptKeyData(uncachedKeyRing);
+        }
+        return null;
+    }
+
+    @Nullable
+    private SaveKeyringResult importAutocryptKeyData(UncachedKeyRing uncachedKeyRing) {
+        SaveKeyringResult saveKeyringResult = keyWritableRepository.savePublicKeyRing(uncachedKeyRing);
+        if (!saveKeyringResult.success()) {
+            Timber.e(Constants.TAG, "Error inserting key - ignoring!");
+            return null;
+        }
+        return saveKeyringResult;
+    }
+
+    @Nullable
+    private UncachedKeyRing parseAutocryptKeyData(AutocryptPeerUpdate autocryptPeerUpdate) {
+        UncachedKeyRing uncachedKeyRing;
+        try {
+            uncachedKeyRing = UncachedKeyRing.decodeFromData(autocryptPeerUpdate.getKeyData());
+        } catch (IOException | PgpGeneralException e) {
+            Timber.e(Constants.TAG, "Error parsing public key! - Ignoring");
+            return null;
+        }
+        if (uncachedKeyRing.isSecret()) {
+            Timber.e(Constants.TAG, "Found secret key in autocrypt id! - Ignoring");
+            return null;
+        }
+        return uncachedKeyRing;
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
@@ -94,7 +94,7 @@ class AutocryptInteractor {
         // 4. Set peers[gossip-addr].gossip_key to the value of the keydata attribute.
         Long newMasterKeyId = saveKeyringResult.savedMasterKeyId;
 
-        autocryptPeerDao.updateKeyGossip(autocryptPeerId, effectiveDate, newMasterKeyId);
+        autocryptPeerDao.updateKeyGossipFromAutocrypt(autocryptPeerId, effectiveDate, newMasterKeyId);
     }
 
     @Nullable

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
@@ -1,0 +1,106 @@
+package org.sufficientlysecure.keychain.remote;
+
+
+import java.io.IOException;
+import java.util.Date;
+
+import android.content.Context;
+
+import org.openintents.openpgp.AutocryptPeerUpdate;
+import org.openintents.openpgp.AutocryptPeerUpdate.PreferEncrypt;
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.pgp.UncachedKeyRing;
+import org.sufficientlysecure.keychain.pgp.exception.PgpGeneralException;
+import org.sufficientlysecure.keychain.provider.AutocryptPeerDataAccessObject;
+import org.sufficientlysecure.keychain.provider.KeyWritableRepository;
+import org.sufficientlysecure.keychain.util.Log;
+
+
+class AutocryptInteractor {
+
+    private AutocryptPeerDataAccessObject autocryptPeerDao;
+    private KeyWritableRepository keyWritableRepository;
+
+    public static AutocryptInteractor getInstance(Context context, AutocryptPeerDataAccessObject autocryptPeerentityDao) {
+        KeyWritableRepository keyWritableRepository = KeyWritableRepository.create(context);
+
+        return new AutocryptInteractor(autocryptPeerentityDao, keyWritableRepository);
+    }
+
+    private AutocryptInteractor(AutocryptPeerDataAccessObject autocryptPeerDao,
+            KeyWritableRepository keyWritableRepository) {
+        this.autocryptPeerDao = autocryptPeerDao;
+        this.keyWritableRepository = keyWritableRepository;
+    }
+
+    void updateAutocryptPeerState(String autocryptPeerId, AutocryptPeerUpdate autocryptPeerUpdate)
+            throws PgpGeneralException, IOException {
+        if (autocryptPeerUpdate == null) {
+            return;
+        }
+
+        Long newMasterKeyId;
+        if (autocryptPeerUpdate.hasKeyData()) {
+            UncachedKeyRing uncachedKeyRing = UncachedKeyRing.decodeFromData(autocryptPeerUpdate.getKeyData());
+            if (uncachedKeyRing.isSecret()) {
+                Log.e(Constants.TAG, "Found secret key in autocrypt id! - Ignoring");
+                return;
+            }
+            // this will merge if the key already exists - no worries!
+            keyWritableRepository.savePublicKeyRing(uncachedKeyRing);
+            newMasterKeyId = uncachedKeyRing.getMasterKeyId();
+        } else {
+            newMasterKeyId = null;
+        }
+
+        Date effectiveDate = autocryptPeerUpdate.getEffectiveDate();
+        autocryptPeerDao.updateLastSeen(autocryptPeerId, effectiveDate);
+
+        if (newMasterKeyId == null) {
+            return;
+        }
+
+        Date lastSeenKey = autocryptPeerDao.getLastSeenKey(autocryptPeerId);
+        if (lastSeenKey == null || effectiveDate.after(lastSeenKey)) {
+            boolean isMutual = autocryptPeerUpdate.getPreferEncrypt() == PreferEncrypt.MUTUAL;
+            autocryptPeerDao.updateKey(autocryptPeerId, effectiveDate, newMasterKeyId, isMutual);
+        }
+    }
+
+
+    void updateAutocryptPeerGossipState(String autocryptPeerId, AutocryptPeerUpdate autocryptPeerUpdate)
+            throws PgpGeneralException, IOException {
+        if (autocryptPeerUpdate == null) {
+            return;
+        }
+
+        Long newMasterKeyId;
+        if (autocryptPeerUpdate.hasKeyData()) {
+            UncachedKeyRing uncachedKeyRing = UncachedKeyRing.decodeFromData(autocryptPeerUpdate.getKeyData());
+            if (uncachedKeyRing.isSecret()) {
+                Log.e(Constants.TAG, "Found secret key in autocrypt id! - Ignoring");
+                return;
+            }
+            // this will merge if the key already exists - no worries!
+            keyWritableRepository.savePublicKeyRing(uncachedKeyRing);
+            newMasterKeyId = uncachedKeyRing.getMasterKeyId();
+        } else {
+            newMasterKeyId = null;
+        }
+
+        Date lastSeen = autocryptPeerDao.getLastSeen(autocryptPeerId);
+        Date effectiveDate = autocryptPeerUpdate.getEffectiveDate();
+        if (newMasterKeyId == null) {
+            return;
+        }
+
+        Date lastSeenKey = autocryptPeerDao.getLastSeenKey(autocryptPeerId);
+        if (lastSeenKey != null && effectiveDate.before(lastSeenKey)) {
+            return;
+        }
+
+        if (lastSeen == null || effectiveDate.after(lastSeen)) {
+            autocryptPeerDao.updateKeyGossip(autocryptPeerId, effectiveDate, newMasterKeyId);
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/KeychainExternalProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/KeychainExternalProvider.java
@@ -20,7 +20,6 @@ package org.sufficientlysecure.keychain.remote;
 
 import java.security.AccessControlException;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
@@ -40,9 +39,11 @@ import android.text.TextUtils;
 import org.sufficientlysecure.keychain.BuildConfig;
 import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.provider.ApiDataAccessObject;
+import org.sufficientlysecure.keychain.provider.AutocryptPeerDataAccessObject;
+import org.sufficientlysecure.keychain.provider.AutocryptPeerDataAccessObject.AutocryptPeerStateResult;
+import org.sufficientlysecure.keychain.provider.AutocryptPeerDataAccessObject.AutocryptState;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.provider.KeychainContract.ApiApps;
-import org.sufficientlysecure.keychain.provider.KeychainContract.ApiAutocryptPeer;
 import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.provider.KeychainContract.Keys;
@@ -230,81 +231,70 @@ public class KeychainExternalProvider extends ContentProvider implements SimpleC
                     throw new AccessControlException("An application must register before use of KeychainExternalProvider!");
                 }
 
-                db.execSQL("CREATE TEMPORARY TABLE " + TEMP_TABLE_QUERIED_ADDRESSES + " (" + TEMP_TABLE_COLUMN_ADDRES + " TEXT);");
+                if (projection == null) {
+                    throw new IllegalArgumentException("Please provide a projection!");
+                }
+
+                db.execSQL("CREATE TEMPORARY TABLE " + TEMP_TABLE_QUERIED_ADDRESSES + " (" +
+                        TEMP_TABLE_COLUMN_ADDRES + " TEXT NOT NULL PRIMARY KEY, " +
+                        AutocryptStatus.UID_KEY_STATUS + " INT, " +
+                        AutocryptStatus.UID_ADDRESS + " TEXT, " +
+                        AutocryptStatus.UID_MASTER_KEY_ID + " TEXT, " +
+                        AutocryptStatus.AUTOCRYPT_KEY_STATUS + " INT, " +
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE + " INT, " +
+                        AutocryptStatus.AUTOCRYPT_MASTER_KEY_ID + " INT" +
+                        ");");
                 ContentValues cv = new ContentValues();
                 for (String address : selectionArgs) {
                     cv.put(TEMP_TABLE_COLUMN_ADDRES, address);
                     db.insert(TEMP_TABLE_QUERIED_ADDRESSES, null, cv);
                 }
 
-                HashMap<String, String> projectionMap = new HashMap<>();
-                projectionMap.put(AutocryptStatus._ID, "email AS _id");
-                projectionMap.put(AutocryptStatus.ADDRESS, // this is actually the queried address
-                        TEMP_TABLE_QUERIED_ADDRESSES + "." + TEMP_TABLE_COLUMN_ADDRES + " AS " + AutocryptStatus.ADDRESS);
+                long unixSeconds = System.currentTimeMillis() / 1000;
+                db.execSQL("REPLACE INTO " + TEMP_TABLE_QUERIED_ADDRESSES +
+                        "(" + TEMP_TABLE_COLUMN_ADDRES + ", " + AutocryptStatus.UID_KEY_STATUS + ", " + AutocryptStatus.UID_ADDRESS + ")" +
+                        " SELECT " + TEMP_TABLE_COLUMN_ADDRES + ", " +
+                                "CASE ( MIN (certs_user_id." + Certs.VERIFIED + " ) ) "
+                                // remap to keep this provider contract independent from our internal representation
+                                + " WHEN " + Certs.VERIFIED_SELF + " THEN " + KeychainExternalContract.KEY_STATUS_UNVERIFIED
+                                + " WHEN " + Certs.VERIFIED_SECRET + " THEN " + KeychainExternalContract.KEY_STATUS_VERIFIED
+                                + " WHEN NULL THEN NULL"
+                                + " END AS " + AutocryptStatus.UID_KEY_STATUS +
+                        ", " + Tables.USER_PACKETS + "." + UserPackets.USER_ID +
+                        " FROM " + TEMP_TABLE_QUERIED_ADDRESSES
+                            + " JOIN " + Tables.USER_PACKETS + " ON ("
+                            + Tables.USER_PACKETS + "." + UserPackets.USER_ID + " IS NOT NULL"
+                            + " AND " + Tables.USER_PACKETS + "." + UserPackets.EMAIL + " LIKE " + TEMP_TABLE_QUERIED_ADDRESSES + "." + TEMP_TABLE_COLUMN_ADDRES
+                            + ")"
+                            + " JOIN " + Tables.CERTS + " AS certs_user_id ON ("
+                            + Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID + " = certs_user_id." + Certs.MASTER_KEY_ID
+                            + " AND " + Tables.USER_PACKETS + "." + UserPackets.RANK + " = certs_user_id." + Certs.RANK
+                            + ")"
+                        + " WHERE (EXISTS (SELECT * FROM " + Tables.KEYS + " WHERE "
+                                + Tables.KEYS + "." + Keys.KEY_ID + " = " + Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID
+                                + " AND " + Tables.KEYS + "." + Keys.IS_REVOKED + " = 0"
+                                + " AND NOT " + "(" + Tables.KEYS + "." + Keys.EXPIRY + " IS NOT NULL AND " + Tables.KEYS + "." + Keys.EXPIRY
+                                + " < " + unixSeconds + ")"
+                                + ")) OR " + Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID + " IS NULL"
+                        + " GROUP BY " + TEMP_TABLE_QUERIED_ADDRESSES + "." + TEMP_TABLE_COLUMN_ADDRES
+                );
 
-                projectionMap.put(AutocryptStatus.UID_ADDRESS,
-                        Tables.USER_PACKETS + "." + UserPackets.USER_ID + " AS " + AutocryptStatus.UID_ADDRESS);
-                // we take the minimum (>0) here, where "1" is "verified by known secret key", "2" is "self-certified"
-                projectionMap.put(AutocryptStatus.UID_KEY_STATUS, "CASE ( MIN (certs_user_id." + Certs.VERIFIED + " ) ) "
-                        // remap to keep this provider contract independent from our internal representation
-                        + " WHEN " + Certs.VERIFIED_SELF + " THEN " + KeychainExternalContract.KEY_STATUS_UNVERIFIED
-                        + " WHEN " + Certs.VERIFIED_SECRET + " THEN " + KeychainExternalContract.KEY_STATUS_VERIFIED
-                        + " WHEN NULL THEN NULL"
-                        + " END AS " + AutocryptStatus.UID_KEY_STATUS);
-                projectionMap.put(AutocryptStatus.UID_MASTER_KEY_ID,
-                        Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID + " AS " + AutocryptStatus.UID_MASTER_KEY_ID);
-                projectionMap.put(AutocryptStatus.UID_CANDIDATES,
-                        "COUNT(DISTINCT " + Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID +
-                                ") AS " + AutocryptStatus.UID_CANDIDATES);
-
-                projectionMap.put(AutocryptStatus.AUTOCRYPT_KEY_STATUS, "CASE ( MIN (certs_autocrypt_peer." + Certs.VERIFIED + " ) ) "
-                        // remap to keep this provider contract independent from our internal representation
-                        + " WHEN " + Certs.VERIFIED_SELF + " THEN " + KeychainExternalContract.KEY_STATUS_UNVERIFIED
-                        + " WHEN " + Certs.VERIFIED_SECRET + " THEN " + KeychainExternalContract.KEY_STATUS_VERIFIED
-                        + " WHEN NULL THEN NULL"
-                        + " END AS " + AutocryptStatus.AUTOCRYPT_KEY_STATUS);
-                projectionMap.put(AutocryptStatus.AUTOCRYPT_MASTER_KEY_ID,
-                        Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.MASTER_KEY_ID + " AS " + AutocryptStatus.AUTOCRYPT_MASTER_KEY_ID);
-                projectionMap.put(AutocryptStatus.AUTOCRYPT_PEER_STATE, Tables.API_AUTOCRYPT_PEERS + "." +
-                        ApiAutocryptPeer.STATE + " AS " + AutocryptStatus.AUTOCRYPT_LAST_SEEN_KEY);
-                projectionMap.put(AutocryptStatus.AUTOCRYPT_LAST_SEEN, Tables.API_AUTOCRYPT_PEERS + "." +
-                        ApiAutocryptPeer.LAST_SEEN + " AS " + AutocryptStatus.AUTOCRYPT_LAST_SEEN);
-                projectionMap.put(AutocryptStatus.AUTOCRYPT_LAST_SEEN_KEY, Tables.API_AUTOCRYPT_PEERS + "." +
-                        ApiAutocryptPeer.LAST_SEEN_KEY + " AS " + AutocryptStatus.AUTOCRYPT_LAST_SEEN_KEY);
-                qb.setProjectionMap(projectionMap);
-
-                if (projection == null) {
-                    throw new IllegalArgumentException("Please provide a projection!");
+                AutocryptPeerDataAccessObject autocryptPeerDao =
+                        new AutocryptPeerDataAccessObject(getContext(), callingPackageName);
+                for (String autocryptId : selectionArgs) {
+                    AutocryptPeerStateResult autocryptState = autocryptPeerDao.getAutocryptState(autocryptId);
+                    cv.put(AutocryptStatus.AUTOCRYPT_PEER_STATE, getPeerStateValue(autocryptState.autocryptState));
+                    if (autocryptState.masterKeyId != null) {
+                        cv.put(AutocryptStatus.AUTOCRYPT_MASTER_KEY_ID, autocryptState.masterKeyId);
+                        cv.put(AutocryptStatus.AUTOCRYPT_KEY_STATUS, autocryptState.isVerified ?
+                                KeychainExternalContract.KEY_STATUS_VERIFIED : KeychainExternalContract.KEY_STATUS_UNVERIFIED);
+                    }
+                    System.err.println(cv.toString());
+                    db.update(TEMP_TABLE_QUERIED_ADDRESSES, cv,
+                            TEMP_TABLE_COLUMN_ADDRES + "=?", new String [] { autocryptId });
                 }
 
-                qb.setTables(
-                        TEMP_TABLE_QUERIED_ADDRESSES
-                                + " LEFT JOIN " + Tables.USER_PACKETS + " ON ("
-                                + Tables.USER_PACKETS + "." + UserPackets.USER_ID + " IS NOT NULL"
-                                + " AND " + Tables.USER_PACKETS + "." + UserPackets.EMAIL + " LIKE " + TEMP_TABLE_QUERIED_ADDRESSES + "." + TEMP_TABLE_COLUMN_ADDRES
-                                + ")"
-                                + " LEFT JOIN " + Tables.CERTS + " AS certs_user_id ON ("
-                                + Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID + " = certs_user_id." + Certs.MASTER_KEY_ID
-                                + " AND " + Tables.USER_PACKETS + "." + UserPackets.RANK + " = certs_user_id." + Certs.RANK
-                                + ")"
-                                + " LEFT JOIN " + Tables.API_AUTOCRYPT_PEERS + " ON ("
-                                + Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.IDENTIFIER + " LIKE queried_addresses.address"
-                                + " AND " + Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.PACKAGE_NAME + " = \"" + callingPackageName + "\""
-                                + ")"
-                                + " LEFT JOIN " + Tables.CERTS + " AS certs_autocrypt_peer ON ("
-                                + Tables.API_AUTOCRYPT_PEERS + "." + ApiAutocryptPeer.MASTER_KEY_ID + " = certs_autocrypt_peer." + Certs.MASTER_KEY_ID
-                                + ")"
-                );
-                // in case there are multiple verifying certificates
-                groupBy = TEMP_TABLE_QUERIED_ADDRESSES + "." + TEMP_TABLE_COLUMN_ADDRES;
-
-                // can't have an expired master key for the uid candidate
-                qb.appendWhere("(EXISTS (SELECT * FROM " + Tables.KEYS + " WHERE "
-                        + Tables.KEYS + "." + Keys.KEY_ID + " = " + Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID
-                        + " AND " + Tables.KEYS + "." + Keys.IS_REVOKED + " = 0"
-                        + " AND NOT " + "(" + Tables.KEYS + "." + Keys.EXPIRY + " IS NOT NULL AND " + Tables.KEYS + "." + Keys.EXPIRY
-                        + " < " + new Date().getTime() / 1000 + ")"
-                        + ")) OR " + Tables.USER_PACKETS + "." + UserPackets.MASTER_KEY_ID + " IS NULL");
+                qb.setTables(TEMP_TABLE_QUERIED_ADDRESSES);
 
                 if (TextUtils.isEmpty(sortOrder)) {
                     sortOrder = AutocryptStatus.ADDRESS;
@@ -353,6 +343,17 @@ public class KeychainExternalProvider extends ContentProvider implements SimpleC
         Timber.d("Query: " + qb.buildQuery(projection, selection, groupBy, null, orderBy, null));
 
         return cursor;
+    }
+
+    private int getPeerStateValue(AutocryptState autocryptState) {
+        switch (autocryptState) {
+            case DISABLE: return AutocryptStatus.AUTOCRYPT_PEER_DISABLED;
+            case DISCOURAGED_OLD: return AutocryptStatus.AUTOCRYPT_PEER_DISCOURAGED_OLD;
+            case DISCOURAGED_GOSSIP: return AutocryptStatus.AUTOCRYPT_PEER_GOSSIP;
+            case AVAILABLE: return AutocryptStatus.AUTOCRYPT_PEER_AVAILABLE;
+            case MUTUAL: return AutocryptStatus.AUTOCRYPT_PEER_MUTUAL;
+        }
+        throw new IllegalStateException("Unhandled case!");
     }
 
     private void checkIfPackageBelongsToCaller(Context context, String requestedPackageName) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -577,13 +577,12 @@ public class OpenPgpService extends Service {
 
         long masterKeyId = signatureResult.getKeyId();
         if (autocryptPeerMasterKeyId == null) {
-            // TODO
-//            Date now = new Date();
-//            Date effectiveTime = signatureResult.getSignatureTimestamp();
-//            if (effectiveTime.after(now)) {
-//                effectiveTime = now;
-//            }
-//            autocryptPeerentityDao.updateKeyGossip(autocryptPeerId, effectiveTime, masterKeyId);
+            Date now = new Date();
+            Date effectiveTime = signatureResult.getSignatureTimestamp();
+            if (effectiveTime.after(now)) {
+                effectiveTime = now;
+            }
+            autocryptPeerentityDao.updateKeyGossipFromSignature(autocryptPeerId, effectiveTime, masterKeyId);
             return signatureResult.withAutocryptPeerResult(AutocryptPeerResult.NEW);
         } else  if (masterKeyId == autocryptPeerMasterKeyId) {
             return signatureResult.withAutocryptPeerResult(AutocryptPeerResult.OK);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -762,7 +762,9 @@ public class OpenPgpService extends Service {
                 String autocryptPeerId = data.getStringExtra(OpenPgpApi.EXTRA_AUTOCRYPT_PEER_ID);
                 AutocryptPeerUpdate autocryptPeerUpdate = data.getParcelableExtra(OpenPgpApi.EXTRA_AUTOCRYPT_PEER_UPDATE);
 
-                autocryptInteractor.updateAutocryptPeerState(autocryptPeerId, autocryptPeerUpdate);
+                if (autocryptPeerUpdate != null) {
+                    autocryptInteractor.updateAutocryptPeerState(autocryptPeerId, autocryptPeerUpdate);
+                }
             }
 
             if (data.hasExtra(OpenPgpApi.EXTRA_AUTOCRYPT_PEER_GOSSIP_UPDATES)) {
@@ -770,7 +772,9 @@ public class OpenPgpService extends Service {
                 for (String address : updates.keySet()) {
                     Timber.d(Constants.TAG, "Updating gossip state: " + address);
                     AutocryptPeerUpdate update = updates.getParcelable(address);
-                    autocryptInteractor.updateAutocryptPeerGossipState(address, update);
+                    if (update != null) {
+                        autocryptInteractor.updateAutocryptPeerGossipState(address, update);
+                    }
                 }
             }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpServiceKeyIdExtractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpServiceKeyIdExtractor.java
@@ -102,7 +102,7 @@ class OpenPgpServiceKeyIdExtractor {
         return result;
     }
 
-    private KeyIdResult returnKeyIdsFromEmails(Intent data, String[] encryptionAddresses, String callingPackageName) {
+    KeyIdResult returnKeyIdsFromEmails(Intent data, String[] encryptionAddresses, String callingPackageName) {
         boolean hasAddresses = (encryptionAddresses != null && encryptionAddresses.length > 0);
 
         boolean allKeysConfirmed = false;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
@@ -122,7 +122,7 @@ class RemoteDeduplicatePresenter implements LoaderCallbacks<List<KeyInfo>> {
         }
 
          long masterKeyId = keyInfoData.get(selectedItem).getMasterKeyId();
-         autocryptPeerDao.updateKeyGossip(duplicateAddress, new Date(), masterKeyId);
+         autocryptPeerDao.updateKeyGossipFromDedup(duplicateAddress, new Date(), masterKeyId);
 
         view.finish();
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
@@ -120,8 +120,8 @@ class RemoteDeduplicatePresenter implements LoaderCallbacks<List<KeyInfo>> {
             return;
         }
 
-        long masterKeyId = keyInfoData.get(selectedItem).getMasterKeyId();
-        autocryptPeerDao.updateToSelectedState(duplicateAddress, masterKeyId);
+        // long masterKeyId = keyInfoData.get(selectedItem).getMasterKeyId();
+        // autocryptPeerDao.updateToSelectedState(duplicateAddress, masterKeyId);
 
         view.finish();
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
@@ -18,6 +18,7 @@
 package org.sufficientlysecure.keychain.remote.ui.dialog;
 
 
+import java.util.Date;
 import java.util.List;
 
 import android.content.Context;
@@ -120,8 +121,8 @@ class RemoteDeduplicatePresenter implements LoaderCallbacks<List<KeyInfo>> {
             return;
         }
 
-        // long masterKeyId = keyInfoData.get(selectedItem).getMasterKeyId();
-        // autocryptPeerDao.updateToSelectedState(duplicateAddress, masterKeyId);
+         long masterKeyId = keyInfoData.get(selectedItem).getMasterKeyId();
+         autocryptPeerDao.updateKeyGossip(duplicateAddress, new Date(), masterKeyId);
 
         view.finish();
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/IdentityAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/IdentityAdapter.java
@@ -39,7 +39,7 @@ import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
 import org.sufficientlysecure.keychain.ui.adapter.IdentityAdapter.ViewHolder;
 import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.IdentityInfo;
 import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.LinkedIdInfo;
-import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.TrustIdInfo;
+import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.AutocryptPeerInfo;
 import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.UserIdInfo;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils.State;
@@ -79,8 +79,8 @@ public class IdentityAdapter extends RecyclerView.Adapter<ViewHolder> {
 
         int viewType = getItemViewType(position);
         if (viewType == VIEW_TYPE_USER_ID) {
-            if (info instanceof TrustIdInfo) {
-                ((UserIdViewHolder) holder).bind((TrustIdInfo) info);
+            if (info instanceof AutocryptPeerInfo) {
+                ((UserIdViewHolder) holder).bind((AutocryptPeerInfo) info);
             } else {
                 ((UserIdViewHolder) holder).bind((UserIdInfo) info);
             }
@@ -107,7 +107,7 @@ public class IdentityAdapter extends RecyclerView.Adapter<ViewHolder> {
     @Override
     public int getItemViewType(int position) {
         IdentityInfo info = data.get(position);
-        if (info instanceof UserIdInfo || info instanceof TrustIdInfo) {
+        if (info instanceof UserIdInfo || info instanceof AutocryptPeerInfo) {
             return VIEW_TYPE_USER_ID;
         } else if (info instanceof LinkedIdInfo) {
             return VIEW_TYPE_LINKED_ID;
@@ -236,21 +236,21 @@ public class IdentityAdapter extends RecyclerView.Adapter<ViewHolder> {
             });
         }
 
-        public void bind(TrustIdInfo info) {
+        public void bind(AutocryptPeerInfo info) {
             if (info.getUserIdInfo() != null) {
                 bindUserIdInfo(info.getUserIdInfo());
             } else {
                 vName.setVisibility(View.GONE);
                 vComment.setVisibility(View.GONE);
 
-                vAddress.setText(info.getTrustId());
+                vAddress.setText(info.getIdentity());
                 vAddress.setTypeface(null, Typeface.NORMAL);
             }
 
             vIcon.setImageDrawable(info.getAppIcon());
             vMore.setVisibility(View.VISIBLE);
 
-            itemView.setClickable(info.getTrustIdIntent() != null);
+            itemView.setClickable(info.getAutocryptPeerIntent() != null);
         }
 
         public void bind(UserIdInfo info) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
@@ -494,7 +494,7 @@ public class KeySectionedListAdapter extends SectionCursorAdapter<KeySectionedLi
             }
 
             { // set icons
-                List<String> packageNames = keyItem.getTrustIdPackages();
+                List<String> packageNames = keyItem.getAutocryptPeerIdPackages();
 
                 if (!keyItem.isSecret() && !packageNames.isEmpty()) {
                     String packageName = packageNames.get(0);
@@ -627,7 +627,7 @@ public class KeySectionedListAdapter extends SectionCursorAdapter<KeySectionedLi
             return getInt(index) > 0;
         }
 
-        public List<String> getTrustIdPackages() {
+        public List<String> getAutocryptPeerIdPackages() {
             int index = getColumnIndexOrThrow(KeyRings.API_KNOWN_TO_PACKAGE_NAMES);
             String packageNames = getString(index);
             if (packageNames == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/presenter/IdentitiesPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/presenter/IdentitiesPresenter.java
@@ -42,7 +42,7 @@ import org.sufficientlysecure.keychain.ui.keyview.LinkedIdViewFragment;
 import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader;
 import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.IdentityInfo;
 import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.LinkedIdInfo;
-import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.TrustIdInfo;
+import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.AutocryptPeerInfo;
 import org.sufficientlysecure.keychain.ui.keyview.loader.IdentityLoader.UserIdInfo;
 import org.sufficientlysecure.keychain.ui.linked.LinkedIdWizard;
 import org.sufficientlysecure.keychain.util.Preferences;
@@ -129,8 +129,8 @@ public class IdentitiesPresenter implements LoaderCallbacks<List<IdentityInfo>> 
             showLinkedId((LinkedIdInfo) info);
         } else if (info instanceof UserIdInfo) {
             showUserIdInfo((UserIdInfo) info);
-        } else if (info instanceof TrustIdInfo) {
-            Intent autocryptPeerIntent = ((TrustIdInfo) info).getTrustIdIntent();
+        } else if (info instanceof AutocryptPeerInfo) {
+            Intent autocryptPeerIntent = ((AutocryptPeerInfo) info).getAutocryptPeerIntent();
             if (autocryptPeerIntent != null) {
                 viewKeyMvpView.startActivity(autocryptPeerIntent);
             }
@@ -176,7 +176,7 @@ public class IdentitiesPresenter implements LoaderCallbacks<List<IdentityInfo>> 
     }
 
     public void onClickForgetIdentity(int position) {
-        TrustIdInfo info = (TrustIdInfo) identitiesAdapter.getInfo(position);
+        AutocryptPeerInfo info = (AutocryptPeerInfo) identitiesAdapter.getInfo(position);
         if (info == null) {
             Timber.e("got a 'forget' click on a bad trust id");
             return;
@@ -184,7 +184,7 @@ public class IdentitiesPresenter implements LoaderCallbacks<List<IdentityInfo>> 
 
         AutocryptPeerDataAccessObject autocryptPeerDao =
                 new AutocryptPeerDataAccessObject(context, info.getPackageName());
-        autocryptPeerDao.delete(info.getTrustId());
+        autocryptPeerDao.delete(info.getIdentity());
     }
 
     public interface IdentitiesMvpView {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/adapter/CursorAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/adapter/CursorAdapter.java
@@ -392,8 +392,7 @@ public abstract class CursorAdapter<C extends SimpleCursor, VH extends RecyclerV
                     KeychainContract.KeyRings.CREATION,
                     KeychainContract.KeyRings.NAME,
                     KeychainContract.KeyRings.EMAIL,
-                    KeychainContract.KeyRings.COMMENT,
-                    KeychainContract.KeyRings.API_KNOWN_TO_PACKAGE_NAMES
+                    KeychainContract.KeyRings.COMMENT
             ));
 
             PROJECTION = arr.toArray(new String[arr.size()]);

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
@@ -207,13 +207,13 @@ public class KeychainExternalProviderTest {
         insertSecretKeyringFrom("/test-keys/testring.sec");
         insertPublicKeyringFrom("/test-keys/testring.pub");
 
-        autocryptPeerDao.updateToAvailableState("tid", new Date(), KEY_ID_PUBLIC);
+        autocryptPeerDao.updateKey(AUTOCRYPT_PEER, new Date(), KEY_ID_PUBLIC, false);
 
         Cursor cursor = contentResolver.query(
                 AutocryptStatus.CONTENT_URI, new String[] {
                         AutocryptStatus.ADDRESS, AutocryptStatus.UID_KEY_STATUS, AutocryptStatus.UID_ADDRESS,
-                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_MASTER_KEY_ID,
-                        AutocryptStatus.AUTOCRYPT_PEER_STATE
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE,
+                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_MASTER_KEY_ID
                 },
                 null, new String [] { AUTOCRYPT_PEER }, null
             );
@@ -223,9 +223,36 @@ public class KeychainExternalProviderTest {
         assertEquals("tid", cursor.getString(0));
         assertTrue(cursor.isNull(1));
         assertEquals(null, cursor.getString(2));
-        assertEquals(KeychainExternalContract.KEY_STATUS_UNVERIFIED, cursor.getInt(3));
-        assertEquals(KEY_ID_PUBLIC, cursor.getLong(4));
-        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_AVAILABLE, cursor.getInt(5));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_AVAILABLE, cursor.getInt(3));
+        assertEquals(KeychainExternalContract.KEY_STATUS_UNVERIFIED, cursor.getInt(4));
+        assertEquals(KEY_ID_PUBLIC, cursor.getLong(5));
+        assertFalse(cursor.moveToNext());
+    }
+
+    @Test
+    public void testAutocryptStatus_autocryptPeer_withMutualKey() throws Exception {
+        insertSecretKeyringFrom("/test-keys/testring.sec");
+        insertPublicKeyringFrom("/test-keys/testring.pub");
+
+        autocryptPeerDao.updateKey(AUTOCRYPT_PEER, new Date(), KEY_ID_PUBLIC, true);
+
+        Cursor cursor = contentResolver.query(
+                AutocryptStatus.CONTENT_URI, new String[] {
+                        AutocryptStatus.ADDRESS, AutocryptStatus.UID_KEY_STATUS, AutocryptStatus.UID_ADDRESS,
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE,
+                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_MASTER_KEY_ID
+                },
+                null, new String [] { AUTOCRYPT_PEER }, null
+        );
+
+        assertNotNull(cursor);
+        assertTrue(cursor.moveToFirst());
+        assertEquals("tid", cursor.getString(0));
+        assertTrue(cursor.isNull(1));
+        assertEquals(null, cursor.getString(2));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_MUTUAL, cursor.getInt(3));
+        assertEquals(KeychainExternalContract.KEY_STATUS_UNVERIFIED, cursor.getInt(4));
+        assertEquals(KEY_ID_PUBLIC, cursor.getLong(5));
         assertFalse(cursor.moveToNext());
     }
 
@@ -234,13 +261,13 @@ public class KeychainExternalProviderTest {
         insertSecretKeyringFrom("/test-keys/testring.sec");
         insertPublicKeyringFrom("/test-keys/testring.pub");
 
-        autocryptPeerDao.updateToAvailableState("tid", new Date(), KEY_ID_PUBLIC);
+        autocryptPeerDao.updateKey("tid", new Date(), KEY_ID_PUBLIC, false);
         certifyKey(KEY_ID_SECRET, KEY_ID_PUBLIC, USER_ID_1);
 
         Cursor cursor = contentResolver.query(
                 AutocryptStatus.CONTENT_URI, new String[] {
                         AutocryptStatus.ADDRESS, AutocryptStatus.UID_KEY_STATUS, AutocryptStatus.UID_ADDRESS,
-                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_PEER_STATE },
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE, AutocryptStatus.AUTOCRYPT_KEY_STATUS },
                 null, new String [] { AUTOCRYPT_PEER }, null
         );
 
@@ -249,8 +276,8 @@ public class KeychainExternalProviderTest {
         assertEquals("tid", cursor.getString(0));
         assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(1));
         assertEquals(null, cursor.getString(2));
-        assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(3));
-        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_AVAILABLE, cursor.getInt(4));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_AVAILABLE, cursor.getInt(3));
+        assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(4));
         assertFalse(cursor.moveToNext());
     }
 
@@ -259,7 +286,7 @@ public class KeychainExternalProviderTest {
         Cursor cursor = contentResolver.query(
                 AutocryptStatus.CONTENT_URI, new String[] {
                         AutocryptStatus.ADDRESS, AutocryptStatus.UID_KEY_STATUS, AutocryptStatus.UID_ADDRESS,
-                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_PEER_STATE },
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE, AutocryptStatus.AUTOCRYPT_KEY_STATUS },
                 null, new String [] { AUTOCRYPT_PEER }, null
         );
 
@@ -268,8 +295,8 @@ public class KeychainExternalProviderTest {
         assertEquals("tid", cursor.getString(0));
         assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(1));
         assertEquals(null, cursor.getString(2));
-        assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(3));
-        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_RESET, cursor.getInt(4));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_DISABLED, cursor.getInt(3));
+        assertTrue(cursor.isNull(4));
         assertFalse(cursor.moveToNext());
     }
 
@@ -278,13 +305,13 @@ public class KeychainExternalProviderTest {
         insertSecretKeyringFrom("/test-keys/testring.sec");
         insertPublicKeyringFrom("/test-keys/testring.pub");
 
-        autocryptPeerDao.updateToGossipState("tid", new Date(), KEY_ID_PUBLIC);
+        autocryptPeerDao.updateKeyGossip("tid", new Date(), KEY_ID_PUBLIC);
         autocryptPeerDao.delete("tid");
 
         Cursor cursor = contentResolver.query(
                 AutocryptStatus.CONTENT_URI, new String[] {
                         AutocryptStatus.ADDRESS, AutocryptStatus.UID_KEY_STATUS, AutocryptStatus.UID_ADDRESS,
-                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_PEER_STATE },
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE, AutocryptStatus.AUTOCRYPT_KEY_STATUS },
                 null, new String [] { AUTOCRYPT_PEER }, null
         );
 
@@ -293,8 +320,8 @@ public class KeychainExternalProviderTest {
         assertEquals("tid", cursor.getString(0));
         assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(1));
         assertEquals(null, cursor.getString(2));
-        assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(3));
-        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_RESET, cursor.getInt(4));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_DISABLED, cursor.getInt(3));
+        assertTrue(cursor.isNull(4));
         assertFalse(cursor.moveToNext());
     }
 
@@ -303,13 +330,13 @@ public class KeychainExternalProviderTest {
         insertSecretKeyringFrom("/test-keys/testring.sec");
         insertPublicKeyringFrom("/test-keys/testring.pub");
 
-        autocryptPeerDao.updateToGossipState("tid", new Date(), KEY_ID_PUBLIC);
+        autocryptPeerDao.updateKeyGossip(AUTOCRYPT_PEER, new Date(), KEY_ID_PUBLIC);
         certifyKey(KEY_ID_SECRET, KEY_ID_PUBLIC, USER_ID_1);
 
         Cursor cursor = contentResolver.query(
                 AutocryptStatus.CONTENT_URI, new String[] {
                         AutocryptStatus.ADDRESS, AutocryptStatus.UID_KEY_STATUS, AutocryptStatus.UID_ADDRESS,
-                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_PEER_STATE },
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE, AutocryptStatus.AUTOCRYPT_KEY_STATUS },
                 null, new String [] { AUTOCRYPT_PEER }, null
         );
 
@@ -318,11 +345,12 @@ public class KeychainExternalProviderTest {
         assertEquals("tid", cursor.getString(0));
         assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(1));
         assertEquals(null, cursor.getString(2));
-        assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(3));
-        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_GOSSIP, cursor.getInt(4));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_GOSSIP, cursor.getInt(3));
+        assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(4));
         assertFalse(cursor.moveToNext());
     }
 
+/*
     @Test
     public void testAutocryptStatus_stateSelected() throws Exception {
         insertSecretKeyringFrom("/test-keys/testring.sec");
@@ -334,7 +362,7 @@ public class KeychainExternalProviderTest {
         Cursor cursor = contentResolver.query(
                 AutocryptStatus.CONTENT_URI, new String[] {
                         AutocryptStatus.ADDRESS, AutocryptStatus.UID_KEY_STATUS, AutocryptStatus.UID_ADDRESS,
-                        AutocryptStatus.AUTOCRYPT_KEY_STATUS, AutocryptStatus.AUTOCRYPT_PEER_STATE },
+                        AutocryptStatus.AUTOCRYPT_PEER_STATE, AutocryptStatus.AUTOCRYPT_KEY_STATUS },
                 null, new String [] { AUTOCRYPT_PEER }, null
         );
 
@@ -343,10 +371,11 @@ public class KeychainExternalProviderTest {
         assertEquals("tid", cursor.getString(0));
         assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(1));
         assertEquals(null, cursor.getString(2));
-        assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(3));
-        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_SELECTED, cursor.getInt(4));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_SELECTED, cursor.getInt(3));
+        assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(4));
         assertFalse(cursor.moveToNext());
     }
+*/
 
     @Test
     public void testAutocryptStatus_withConfirmedKey() throws Exception {
@@ -367,7 +396,7 @@ public class KeychainExternalProviderTest {
         assertEquals(MAIL_ADDRESS_1, cursor.getString(0));
         assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(1));
         assertEquals(USER_ID_1, cursor.getString(2));
-        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_RESET, cursor.getInt(3));
+        assertEquals(AutocryptStatus.AUTOCRYPT_PEER_DISABLED, cursor.getInt(3));
         assertFalse(cursor.moveToNext());
     }
 

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
@@ -305,7 +305,7 @@ public class KeychainExternalProviderTest {
         insertSecretKeyringFrom("/test-keys/testring.sec");
         insertPublicKeyringFrom("/test-keys/testring.pub");
 
-        autocryptPeerDao.updateKeyGossip("tid", new Date(), KEY_ID_PUBLIC);
+        autocryptPeerDao.updateKeyGossipFromAutocrypt("tid", new Date(), KEY_ID_PUBLIC);
         autocryptPeerDao.delete("tid");
 
         Cursor cursor = contentResolver.query(
@@ -330,7 +330,7 @@ public class KeychainExternalProviderTest {
         insertSecretKeyringFrom("/test-keys/testring.sec");
         insertPublicKeyringFrom("/test-keys/testring.pub");
 
-        autocryptPeerDao.updateKeyGossip(AUTOCRYPT_PEER, new Date(), KEY_ID_PUBLIC);
+        autocryptPeerDao.updateKeyGossipFromAutocrypt(AUTOCRYPT_PEER, new Date(), KEY_ID_PUBLIC);
         certifyKey(KEY_ID_SECRET, KEY_ID_PUBLIC, USER_ID_1);
 
         Cursor cursor = contentResolver.query(


### PR DESCRIPTION
This PR changes the logic from behavior Autocrypt-circa-July to the shiny new Autocrypt 1.0. These changes should be compatible with current K-9, but I havn't done a lot of testing yet.

Still missing is a way to deal with "external" keys. I don't have a good plan for that yet. It might make sense to save a state similar to having received an autocrypt header when we see a signature by some key from an email address (careful with mailing lists though). There are a lot of variations to this concept, and it's actually not terribly important for now to get this 100% right. It does need to handle deduplication of keys though, that's broken right now and needs to be fixed.