### PR TITLE
Make predicate names in KeychainProvider consistent and allow export of SSH public keys without associated private key in keyring

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
@@ -217,8 +217,23 @@ public class CachedPublicKeyRing extends KeyRing {
         }
     }
 
-    public boolean hasAuthentication() throws PgpKeyNotFoundException {
+    public boolean hasSecretAuthentication() throws PgpKeyNotFoundException {
         return getSecretAuthenticationId() != 0;
+    }
+
+    public long getAuthenticationId() throws PgpKeyNotFoundException {
+        try {
+            Object data = mKeyRepository.getGenericData(mUri,
+                    KeyRings.HAS_AUTHENTICATE,
+                    KeyRepository.FIELD_TYPE_INTEGER);
+            return (Long) data;
+        } catch(KeyWritableRepository.NotFoundException e) {
+            throw new PgpKeyNotFoundException(e);
+        }
+    }
+
+    public boolean hasAuthentication() throws PgpKeyNotFoundException {
+        return getAuthenticationId() != 0;
     }
 
     @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
@@ -158,7 +158,7 @@ public class CachedPublicKeyRing extends KeyRing {
     public boolean canCertify() throws PgpKeyNotFoundException {
         try {
             Object data = mKeyRepository.getGenericData(mUri,
-                    KeychainContract.KeyRings.HAS_CERTIFY,
+                    KeychainContract.KeyRings.HAS_CERTIFY_SECRET,
                     KeyRepository.FIELD_TYPE_NULL);
             return !((Boolean) data);
         } catch(KeyWritableRepository.NotFoundException e) {
@@ -192,7 +192,7 @@ public class CachedPublicKeyRing extends KeyRing {
     public long getSecretSignId() throws PgpKeyNotFoundException {
         try {
             Object data = mKeyRepository.getGenericData(mUri,
-                    KeyRings.HAS_SIGN,
+                    KeyRings.HAS_SIGN_SECRET,
                     KeyRepository.FIELD_TYPE_INTEGER);
             return (Long) data;
         } catch(KeyWritableRepository.NotFoundException e) {
@@ -209,7 +209,7 @@ public class CachedPublicKeyRing extends KeyRing {
     public long getSecretAuthenticationId() throws PgpKeyNotFoundException {
         try {
             Object data = mKeyRepository.getGenericData(mUri,
-                    KeyRings.HAS_AUTHENTICATE,
+                    KeyRings.HAS_AUTHENTICATE_SECRET,
                     KeyRepository.FIELD_TYPE_INTEGER);
             return (Long) data;
         } catch(KeyWritableRepository.NotFoundException e) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -154,6 +154,7 @@ public class KeychainContract {
         public static final String HAS_ENCRYPT = "has_encrypt";
         public static final String HAS_SIGN_SECRET = "has_sign_secret";
         public static final String HAS_CERTIFY_SECRET = "has_certify_secret";
+        public static final String HAS_AUTHENTICATE = "has_authenticate";
         public static final String HAS_AUTHENTICATE_SECRET = "has_authenticate_secret";
         public static final String HAS_DUPLICATE_USER_ID = "has_duplicate_user_id";
         public static final String API_KNOWN_TO_PACKAGE_NAMES = "known_to_apps";

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -152,9 +152,9 @@ public class KeychainContract {
         public static final String IS_EXPIRED = "is_expired";
         public static final String HAS_ANY_SECRET = "has_any_secret";
         public static final String HAS_ENCRYPT = "has_encrypt";
-        public static final String HAS_SIGN = "has_sign";
-        public static final String HAS_CERTIFY = "has_certify";
-        public static final String HAS_AUTHENTICATE = "has_authenticate";
+        public static final String HAS_SIGN_SECRET = "has_sign_secret";
+        public static final String HAS_CERTIFY_SECRET = "has_certify_secret";
+        public static final String HAS_AUTHENTICATE_SECRET = "has_authenticate_secret";
         public static final String HAS_DUPLICATE_USER_ID = "has_duplicate_user_id";
         public static final String API_KNOWN_TO_PACKAGE_NAMES = "known_to_apps";
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -353,6 +353,8 @@ public class KeychainProvider extends ContentProvider {
                         "kE." + Keys.KEY_ID + " AS " + KeyRings.HAS_ENCRYPT);
                 projectionMap.put(KeyRings.HAS_SIGN_SECRET,
                         "kS." + Keys.KEY_ID + " AS " + KeyRings.HAS_SIGN_SECRET);
+                projectionMap.put(KeyRings.HAS_AUTHENTICATE,
+                        "kA." + Keys.KEY_ID + " AS " + KeyRings.HAS_AUTHENTICATE);
                 projectionMap.put(KeyRings.HAS_AUTHENTICATE_SECRET,
                         "kA." + Keys.KEY_ID + " AS " + KeyRings.HAS_AUTHENTICATE_SECRET);
                 projectionMap.put(KeyRings.HAS_CERTIFY_SECRET,
@@ -409,6 +411,16 @@ public class KeychainProvider extends ContentProvider {
                                 + " AND ( kS." + Keys.EXPIRY + " IS NULL OR kS." + Keys.EXPIRY
                                     + " >= " + new Date().getTime() / 1000 + " )"
                             + ")" : "")
+                        + (plist.contains(KeyRings.HAS_AUTHENTICATE) ?
+                            " LEFT JOIN " + Tables.KEYS + " AS kA ON ("
+                                    +"kA." + Keys.MASTER_KEY_ID
+                                    + " = " + Tables.KEYS + "." + Keys.MASTER_KEY_ID
+                                    + " AND kA." + Keys.IS_REVOKED + " = 0"
+                                    + " AND kA." + Keys.IS_SECURE + " = 1"
+                                    + " AND kA." + Keys.CAN_AUTHENTICATE + " = 1"
+                                    + " AND ( kA." + Keys.EXPIRY + " IS NULL OR kA." + Keys.EXPIRY
+                                    + " >= " + new Date().getTime() / 1000 + " )"
+                                    + ")" : "")
                         + (plist.contains(KeyRings.HAS_AUTHENTICATE_SECRET) ?
                             " LEFT JOIN " + Tables.KEYS + " AS kA ON ("
                                     +"kA." + Keys.MASTER_KEY_ID

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -351,12 +351,12 @@ public class KeychainProvider extends ContentProvider {
                                 + ")) AS " + KeyRings.HAS_ANY_SECRET);
                 projectionMap.put(KeyRings.HAS_ENCRYPT,
                         "kE." + Keys.KEY_ID + " AS " + KeyRings.HAS_ENCRYPT);
-                projectionMap.put(KeyRings.HAS_SIGN,
-                        "kS." + Keys.KEY_ID + " AS " + KeyRings.HAS_SIGN);
-                projectionMap.put(KeyRings.HAS_AUTHENTICATE,
-                        "kA." + Keys.KEY_ID + " AS " + KeyRings.HAS_AUTHENTICATE);
-                projectionMap.put(KeyRings.HAS_CERTIFY,
-                        "kC." + Keys.KEY_ID + " AS " + KeyRings.HAS_CERTIFY);
+                projectionMap.put(KeyRings.HAS_SIGN_SECRET,
+                        "kS." + Keys.KEY_ID + " AS " + KeyRings.HAS_SIGN_SECRET);
+                projectionMap.put(KeyRings.HAS_AUTHENTICATE_SECRET,
+                        "kA." + Keys.KEY_ID + " AS " + KeyRings.HAS_AUTHENTICATE_SECRET);
+                projectionMap.put(KeyRings.HAS_CERTIFY_SECRET,
+                        "kC." + Keys.KEY_ID + " AS " + KeyRings.HAS_CERTIFY_SECRET);
                 projectionMap.put(KeyRings.IS_EXPIRED,
                         "(" + Tables.KEYS + "." + Keys.EXPIRY + " IS NOT NULL AND " + Tables.KEYS + "." + Keys.EXPIRY
                                 + " < " + new Date().getTime() / 1000 + ") AS " + KeyRings.IS_EXPIRED);
@@ -398,7 +398,7 @@ public class KeychainProvider extends ContentProvider {
                                 + " AND ( kE." + Keys.EXPIRY + " IS NULL OR kE." + Keys.EXPIRY
                                     + " >= " + new Date().getTime() / 1000 + " )"
                             + ")" : "")
-                        + (plist.contains(KeyRings.HAS_SIGN) ?
+                        + (plist.contains(KeyRings.HAS_SIGN_SECRET) ?
                             " LEFT JOIN " + Tables.KEYS + " AS kS ON ("
                                 +"kS." + Keys.MASTER_KEY_ID
                                     + " = " + Tables.KEYS + "." + Keys.MASTER_KEY_ID
@@ -409,7 +409,7 @@ public class KeychainProvider extends ContentProvider {
                                 + " AND ( kS." + Keys.EXPIRY + " IS NULL OR kS." + Keys.EXPIRY
                                     + " >= " + new Date().getTime() / 1000 + " )"
                             + ")" : "")
-                        + (plist.contains(KeyRings.HAS_AUTHENTICATE) ?
+                        + (plist.contains(KeyRings.HAS_AUTHENTICATE_SECRET) ?
                             " LEFT JOIN " + Tables.KEYS + " AS kA ON ("
                                     +"kA." + Keys.MASTER_KEY_ID
                                     + " = " + Tables.KEYS + "." + Keys.MASTER_KEY_ID
@@ -420,7 +420,7 @@ public class KeychainProvider extends ContentProvider {
                                     + " AND ( kA." + Keys.EXPIRY + " IS NULL OR kA." + Keys.EXPIRY
                                     + " >= " + new Date().getTime() / 1000 + " )"
                                     + ")" : "")
-                        + (plist.contains(KeyRings.HAS_CERTIFY) ?
+                        + (plist.contains(KeyRings.HAS_CERTIFY_SECRET) ?
                             " LEFT JOIN " + Tables.KEYS + " AS kC ON ("
                                 +"kC." + Keys.MASTER_KEY_ID
                                 + " = " + Tables.KEYS + "." + Keys.MASTER_KEY_ID

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/SshAuthenticationService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/SshAuthenticationService.java
@@ -363,7 +363,7 @@ public class SshAuthenticationService extends Service {
             throws PgpKeyNotFoundException, KeyRepository.NotFoundException {
         KeyRepository keyRepository = KeyRepository.create(getApplicationContext());
         long authSubKeyId = keyRepository.getCachedPublicKeyRing(masterKeyId)
-                .getSecretAuthenticationId();
+                .getAuthenticationId();
         return keyRepository.getCanonicalizedPublicKeyRing(masterKeyId)
                 .getPublicKey(authSubKeyId);
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/KeyLoader.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/KeyLoader.java
@@ -42,7 +42,7 @@ public class KeyLoader extends AsyncTaskLoader<List<KeyInfo>> {
             KeyRings.MASTER_KEY_ID,
             KeyRings.CREATION,
             KeyRings.HAS_ENCRYPT,
-            KeyRings.HAS_AUTHENTICATE,
+            KeyRings.HAS_AUTHENTICATE_SECRET,
             KeyRings.HAS_ANY_SECRET,
             KeyRings.VERIFIED,
             KeyRings.NAME,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyPresenter.java
@@ -82,7 +82,7 @@ class RemoteSelectAuthenticationKeyPresenter implements LoaderCallbacks<List<Key
 
     @Override
     public Loader<List<KeyInfo>> onCreateLoader(int id, Bundle args) {
-        String selection = KeyRings.HAS_ANY_SECRET + " != 0 AND " + KeyRings.HAS_AUTHENTICATE_SECRET + " != 0";
+        String selection = KeyRings.HAS_AUTHENTICATE_SECRET + " != 0";
         KeySelector keySelector = KeySelector.create(
                 KeyRings.buildUnifiedKeyRingsUri(), selection);
         return new KeyLoader(context, context.getContentResolver(), keySelector);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyPresenter.java
@@ -82,7 +82,7 @@ class RemoteSelectAuthenticationKeyPresenter implements LoaderCallbacks<List<Key
 
     @Override
     public Loader<List<KeyInfo>> onCreateLoader(int id, Bundle args) {
-        String selection = KeyRings.HAS_ANY_SECRET + " != 0 AND " + KeyRings.HAS_AUTHENTICATE + " != 0";
+        String selection = KeyRings.HAS_ANY_SECRET + " != 0 AND " + KeyRings.HAS_AUTHENTICATE_SECRET + " != 0";
         KeySelector keySelector = KeySelector.create(
                 KeyRings.buildUnifiedKeyRingsUri(), selection);
         return new KeyLoader(context, context.getContentResolver(), keySelector);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvShareFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvShareFragment.java
@@ -216,7 +216,7 @@ public class ViewKeyAdvShareFragment extends LoaderFragment implements
         try {
             masterKeyId = keyRepository.getCachedPublicKeyRing(mDataUri).extractOrGetMasterKeyId();
             CachedPublicKeyRing cachedPublicKeyRing = keyRepository.getCachedPublicKeyRing(masterKeyId);
-            authSubKeyId = cachedPublicKeyRing.getSecretAuthenticationId();
+            authSubKeyId = cachedPublicKeyRing.getAuthenticationId();
         } catch (PgpKeyNotFoundException e) {
             Log.e(Constants.TAG, "key not found!", e);
         }
@@ -232,7 +232,7 @@ public class ViewKeyAdvShareFragment extends LoaderFragment implements
         String content;
         long masterKeyId = keyRepository.getCachedPublicKeyRing(mDataUri).extractOrGetMasterKeyId();
         if (asSshKey) {
-            long authSubKeyId = keyRepository.getCachedPublicKeyRing(masterKeyId).getSecretAuthenticationId();
+            long authSubKeyId = keyRepository.getCachedPublicKeyRing(masterKeyId).getAuthenticationId();
             CanonicalizedPublicKey publicKey = keyRepository.getCanonicalizedPublicKeyRing(masterKeyId)
                                                             .getPublicKey(authSubKeyId);
             SshPublicKey sshPublicKey = new SshPublicKey(publicKey);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertifyKeySpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertifyKeySpinner.java
@@ -60,7 +60,7 @@ public class CertifyKeySpinner extends KeySpinner {
         Uri baseUri = KeychainContract.KeyRings.buildUnifiedKeyRingsUri();
 
         String[] projection = KeyAdapter.getProjectionWith(new String[] {
-                KeychainContract.KeyRings.HAS_CERTIFY,
+                KeychainContract.KeyRings.HAS_CERTIFY_SECRET,
         });
 
         String where = KeychainContract.KeyRings.HAS_ANY_SECRET + " = 1 AND "
@@ -79,7 +79,7 @@ public class CertifyKeySpinner extends KeySpinner {
         super.onLoadFinished(loader, data);
 
         if (loader.getId() == LOADER_ID) {
-            mIndexHasCertify = data.getColumnIndex(KeychainContract.KeyRings.HAS_CERTIFY);
+            mIndexHasCertify = data.getColumnIndex(KeychainContract.KeyRings.HAS_CERTIFY_SECRET);
 
             // If:
             // - no key has been pre-selected (e.g. by SageSlinger)

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/SignKeySpinner.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/SignKeySpinner.java
@@ -49,7 +49,7 @@ public class SignKeySpinner extends KeySpinner {
         Uri baseUri = KeychainContract.KeyRings.buildUnifiedKeyRingsUri();
 
         String[] projection = KeyAdapter.getProjectionWith(new String[] {
-                KeychainContract.KeyRings.HAS_SIGN,
+                KeychainContract.KeyRings.HAS_SIGN_SECRET,
         });
 
         String where = KeychainContract.KeyRings.HAS_ANY_SECRET + " = 1";
@@ -66,7 +66,7 @@ public class SignKeySpinner extends KeySpinner {
         super.onLoadFinished(loader, data);
 
         if (loader.getId() == LOADER_ID) {
-            mIndexHasSign = data.getColumnIndex(KeychainContract.KeyRings.HAS_SIGN);
+            mIndexHasSign = data.getColumnIndex(KeychainContract.KeyRings.HAS_SIGN_SECRET);
         }
     }
 


### PR DESCRIPTION
## Description
Make predicate names in KeychainProvider consistent and allow export of SSH public keys from keyrings with authentication subkey but without associated private key.

## Motivation and Context
This allows for use cases where the user needs to copy the SSH public key blob of someone else (or of a keyring with secret key material on another device) manually into an app not using the sshauthentication-api (of which the implementation in OpenKeychain also supports export of SSH public keys for keyrings without private key with this PR) or a browser.

## How Has This Been Tested?
Works for me.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)