### PR TITLE
Gradle 4.4.1 + build sdk 27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ before_install:
 android:
   components:
     - tools
-    - android-25
+    - android-27
     - platform-tools
-    - build-tools-25.0.2
+    - build-tools-27.0.3
     - extra-android-support
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-25
+    - sys-img-armeabi-v7a-android-27
   licenses:
     - 'android-sdk-preview-license-52d11cd2'
     - 'android-sdk-license-.+'

--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     // http://robolectric.org/getting-started/
     // http://www.vogella.com/tutorials/Robolectric/article.html
     testCompile 'junit:junit:4.12'
-    testCompile ('org.robolectric:robolectric:3.2.2') {
+    testCompile ('org.robolectric:robolectric:3.6.1') {
         exclude group: 'org.bouncycastle', module: 'bcprov-jdk16'
     }
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -167,8 +167,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     testOptions.unitTests.all {

--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'witness'
 apply plugin: 'jacoco'
 // apply plugin: 'com.github.kt3k.coveralls'
-apply plugin: 'com.neenbedankt.android-apt'
 
 dependencies {
     // NOTE: Always use fixed version codes not dynamic ones, e.g. 0.7.3 instead of 0.7.+, see README for more information
@@ -52,15 +51,15 @@ dependencies {
     compile 'com.fidesmo:nordpol-android:0.1.22'
 
     // libs as submodules
-    compile project(':libkeychain')
-    compile project(':openpgp-api-lib')
-    compile project(':sshauthentication-api')
-    compile project(':extern:bouncycastle:core')
-    compile project(':extern:bouncycastle:pg')
-    compile project(':extern:bouncycastle:prov')
-    compile project(':extern:minidns')
-    compile project(':KeybaseLib')
-    compile project(':safeslinger-exchange')
+    implementation project(':libkeychain')
+    implementation project(':openpgp-api-lib')
+    implementation project(':sshauthentication-api')
+    implementation project(':extern:bouncycastle:core')
+    implementation project(':extern:bouncycastle:pg')
+    implementation project(':extern:bouncycastle:prov')
+    implementation project(':extern:minidns')
+    implementation project(':KeybaseLib')
+    implementation project(':safeslinger-exchange')
 
     // Unit tests in the local JVM with Robolectric
     // https://developer.android.com/training/testing/unit-testing/local-unit-tests.html
@@ -91,72 +90,61 @@ dependencies {
     compile "com.jakewharton.timber:timber:4.5.1"
 
     compile 'org.glassfish:javax.annotation:10.0-b28'
-    provided    "com.google.auto.value:auto-value:1.4.1"
-    apt         "com.google.auto.value:auto-value:1.4.1"
-    apt         "com.ryanharter.auto.value:auto-value-parcel:0.2.5"
+    provided    "com.google.auto.value:auto-value:1.5"
+    annotationProcessor "com.google.auto.value:auto-value:1.5"
+    annotationProcessor "com.ryanharter.auto.value:auto-value-parcel:0.2.5"
     compile 'com.ryanharter.auto.value:auto-value-parcel-adapter:0.2.5'
+
 }
 
 // Output of ./gradlew -q calculateChecksums
 // Comment out the libs referenced as git submodules!
 dependencyVerification {
     verify = [
-            'com.android.support:support-v4:07d389154bcf73b47e514964df1578136b26cba78257b8a577a3ccb54beff0ae',
-            'com.android.support:appcompat-v7:ac1ebbc46589195dda3e0b1becfe410bafd75bdf3edd1cd9acf04850f3895830',
-            'com.android.support:design:a3e83064fe99d0a4369f9b46d8bfbe77d0c3022fffdee4be3ac3857b87cc89e3',
-            'com.android.support:recyclerview-v7:375974a8724e359d97d77fa8522c614f813a3ac4583c1807f154a3f9a054b0a1',
-            'com.android.support:cardview-v7:defc17032ffa600a82e1c7d96bb574aa5ed64e2b57e28414a245da7d6db0c666',
-            'com.android.support:support-annotations:aedf76962584adfaed2bd3fcaa22406461c4310237fc27e301128edaa2dba2fa',
-            'com.journeyapps:zxing-android-embedded:2422d83c2c09a7b645f516c8458ececba6a7da47b94e40778d876facf495c660',
-            'com.google.zxing:core:bba7724e02a997cec38213af77133ee8e24b0d5cf5fa7ecbc16a4fa93f11ee0d',
-            'org.commonjava.googlecode.markdown4j:markdown4j:28eb991f702c6d85d6cafd68c24d1ce841d1f5c995c943f25aedb433c0c13f60',
-            'org.ocpsoft.prettytime:prettytime:ef7098d973ae78b57d1a22dc37d3b8a771bf030301300e24055d676b6cdc5e75',
-            'org.sufficientlysecure:donations:2be4183afa5e35263e37346344cfea48681f3c987e6832dd4acde227c13ccad6',
-            'com.squareup.okhttp3:okhttp:a0d01017a42bba26e507fc6d448bb36e536f4b6e612f7c42de30bbdac2b7785e',
-            'com.squareup.okhttp3:okhttp-urlconnection:16a410e5c4457ab381759486df6f840fdc7cc426d67433d4da1b7d65ed2b3b33',
-            'org.apache.james:apache-mime4j-core:561987f604911e1870b2b4eabf0b0658d666c66cb1e65fba3e9e4bffe63acab9',
-            'org.apache.james:apache-mime4j-dom:e18717fe6d36f32e5c5f7cbeea1a9bf04645fdabc84e7e8374d9da10fd52e78d',
-            'org.sufficientlysecure:html-textview:ed740adf05cae2373999c7a3047c803183d9807b2cf66162902090d7c112a832',
-            'com.splitwise:tokenautocomplete:f921f83ee26b5265f719b312c30452ef8e219557826c5ce5bf02e29647967939',
-            'com.jpardogo.materialtabstrip:library:4ee2f1211c302b45fb8c627cc5b240dc6b38b7aaaab1b8bffc81663e1b108013',
-            'com.getbase:floatingactionbutton:3edefa511aac4d90794c7b0496aca59cff2eee1e32679247b4f85acbeee05240',
-            'com.nispok:snackbar:46b5eb9d630d329e13c2ce00ee9fb115ffb66c23c72cff32ee97eedd76824c6f',
-            'com.cocosw:bottomsheet:4af6112a7f4cad4e2b70e5fdf1edc39f51275523a0f53011a012837dc103e597',
-            'com.tonicartos:superslim:ca89b5c674660cc6918a8f8fd385065bffeee27983e0d33c7c2f0ad7b34d2d49',
-            'com.futuremind.recyclerfastscroll:fastscroll:ae655201885a9dbb5fabecb4adfefbb23ffdbca26a2b4ea255ec1bf6f214c606',
-            'com.mikepenz:materialdrawer:8bba1428dcef5ad7c2decf49c612ad980b38e2f1031cbd66c152a8a104793929',
-            'com.mikepenz:fastadapter:21d4ecb5c128bcda37b14e7998d799ed52cfc768b72cdf3d5578bb6775769ebd',
-            'com.mikepenz:materialize:942ccf5e2aa1a46803aa884e8dc7bbaf2a9e8e9996a0cf92e3fe2f44a8592ba4',
-            'com.mikepenz:iconics-core:478d7e245098f7c28b5b20a0e6b1e5cb108ef3eaf595af7190bc60f91063aa3d',
-            'com.mikepenz:google-material-typeface:f27c629ba5d2a90ecfbd7f221ff98cd363e1ee6be06b099b82bae490766e14a5',
-            'com.mikepenz:fontawesome-typeface:ee47b7fe97b90412f01f2fcdd78f65a4edb0ab00006f5ef59ed00516baca9309',
-            'com.mikepenz:community-material-typeface:d6035d261c5eba880cd7fe5dcb8cc00b09bfe6d41063b881b759e9897dc7b7c9',
-            'com.fidesmo:nordpol-android:9a992eca347ff7af6e99ff48078954b44b26f26fdc5463139e340234757a24f7',
-//            'OpenKeychain:libkeychain:9f79dd8d5d4d58d1e2f4eb7429da1898c7fcff723fedb54399de4aba699f4860',
-//            'OpenKeychain:openpgp-api-lib:489480bf51458809edda5a659192a02e133bc391bdbcc7e6c3048e881a9c6c41',
-//            'OpenKeychain:sshauthentication-api:e041d730bab7992ce20e712e49d56d7e3a27e9f77bccc4d4de16328a3e1df596',
-//            'OpenKeychain.extern.bouncycastle:core:60340e082e8928cdeaaf152a10bae572a5f717d561d4aeee3652bd6113b784ef',
-//            'OpenKeychain.extern.bouncycastle:pg:3ba6b317b3334c2b56aefc9ccf9a5160d24dbde54b87303b970345a5c52b5135',
-//            'OpenKeychain.extern.bouncycastle:prov:38a2da6ffba840430d7c9c448d34d06510618603d500336e0add7ef1d99309b4',
-//            'OpenKeychain.extern:minidns:10c500247ec50e317e56e1e9ae0fb9d6b117c34a41dbe4dbeec58f726b0df8a8',
-//            'OpenKeychain:KeybaseLib:d246be4fbeb56eab1f0912a2a1fd4250644d666019dd91444bcf668c63a8d2b4',
-//            'OpenKeychain:safeslinger-exchange:a83cf41872b2778e7802e7c835ac0ef127eb296bd59c47731457c5b92a3f06e4',
-            'org.glassfish:javax.annotation:339c876b928766329cc0657920366e75beb25f932b80bb3b26df6c0e687a9582',
-            'com.ryanharter.auto.value:auto-value-parcel-adapter:f730534497f7de81f62f1165df65e750522fdaedabd56031ee1c2d9da2544e17',
-            'com.android.databinding:library:def2976cb30dd5abf9f3a35d70c70cfb5485af4fb4ae022f5b9a6e2f8cff6386',
-            'com.android.databinding:baseLibrary:51343eec95ee9bfddc89cc34a3006de7c68e2571565cc220d4f37065807e64eb',
-            'com.android.databinding:adapters:0dd06349dad760f3cb56769f8e9f46451634be6a8a1bfdb2e88a5ca10afcebd6',
-            'com.android.support:support-compat:e02d781268dc60aab6638d8dc20156ea11ca20b962d294b85e6f1e8418cabfa7',
-            'com.android.support:support-media-compat:cbed07d07e0e84fdb4b75712f5fd946229a8af155933c9a92e41db64d00791e0',
-            'com.android.support:support-core-utils:32fac02eb2c20a77fa3e3bc3ede62392a19613f72b8f8e10f5dfa84bb4c89ea1',
-            'com.android.support:support-core-ui:6182278a6653e6c111c888963626cbb16f2d0022571cb239760475119e0b92a8',
-            'com.android.support:support-fragment:541d6393c1e024453aca2a14f31bea0c7270ff4e2a02783f3528aa426367444d',
-            'com.android.support:support-vector-drawable:13728f337f36d1c02d52198a6c20724edb447a0875454d829f95cb9eb4aa293b',
-            'com.android.support:animated-vector-drawable:4bc46edf1946b32d518b41416d1734e915e0cbb28021de3b340527419b070691',
-            'com.android.support:transition:36c688825a8c0e6e879e18886de83dc90673322822d5b606ee302f70fb558e16',
-            'com.squareup.okio:okio:734269c3ebc5090e3b23566db558f421f0b4027277c79ad5d176b8ec168bb850',
-            'com.fidesmo:nordpol-core:296e71b12884a9cd28cf00ab908973bbf776a90be1f23ac897380d91604e614d',
-            'com.jakewharton.timber:timber:d553d3d3e883ce7d061f1b21b95d6ee0840f3bfbf6d3bd51c5671f0b0f0b0091',
+        'com.android.support:design:a3e83064fe99d0a4369f9b46d8bfbe77d0c3022fffdee4be3ac3857b87cc89e3',
+        'com.journeyapps:zxing-android-embedded:2422d83c2c09a7b645f516c8458ececba6a7da47b94e40778d876facf495c660',
+        'org.sufficientlysecure:donations:2be4183afa5e35263e37346344cfea48681f3c987e6832dd4acde227c13ccad6',
+        'com.android.support:transition:36c688825a8c0e6e879e18886de83dc90673322822d5b606ee302f70fb558e16',
+        'com.futuremind.recyclerfastscroll:fastscroll:ae655201885a9dbb5fabecb4adfefbb23ffdbca26a2b4ea255ec1bf6f214c606',
+        'com.mikepenz:fastadapter:21d4ecb5c128bcda37b14e7998d799ed52cfc768b72cdf3d5578bb6775769ebd',
+        'com.mikepenz:materialize:942ccf5e2aa1a46803aa884e8dc7bbaf2a9e8e9996a0cf92e3fe2f44a8592ba4',
+        'com.android.support:appcompat-v7:ac1ebbc46589195dda3e0b1becfe410bafd75bdf3edd1cd9acf04850f3895830',
+        'com.android.support:support-v4:07d389154bcf73b47e514964df1578136b26cba78257b8a577a3ccb54beff0ae',
+        'com.nispok:snackbar:46b5eb9d630d329e13c2ce00ee9fb115ffb66c23c72cff32ee97eedd76824c6f',
+        'com.tonicartos:superslim:ca89b5c674660cc6918a8f8fd385065bffeee27983e0d33c7c2f0ad7b34d2d49',
+        'com.android.support:recyclerview-v7:375974a8724e359d97d77fa8522c614f813a3ac4583c1807f154a3f9a054b0a1',
+        'com.android.support:cardview-v7:defc17032ffa600a82e1c7d96bb574aa5ed64e2b57e28414a245da7d6db0c666',
+        'org.sufficientlysecure:html-textview:ed740adf05cae2373999c7a3047c803183d9807b2cf66162902090d7c112a832',
+        'com.getbase:floatingactionbutton:3edefa511aac4d90794c7b0496aca59cff2eee1e32679247b4f85acbeee05240',
+        'com.android.support:support-fragment:541d6393c1e024453aca2a14f31bea0c7270ff4e2a02783f3528aa426367444d',
+        'com.android.support:support-media-compat:cbed07d07e0e84fdb4b75712f5fd946229a8af155933c9a92e41db64d00791e0',
+        'com.android.support:support-core-utils:32fac02eb2c20a77fa3e3bc3ede62392a19613f72b8f8e10f5dfa84bb4c89ea1',
+        'com.jpardogo.materialtabstrip:library:4ee2f1211c302b45fb8c627cc5b240dc6b38b7aaaab1b8bffc81663e1b108013',
+        'com.android.support:support-core-ui:6182278a6653e6c111c888963626cbb16f2d0022571cb239760475119e0b92a8',
+        'com.android.support:animated-vector-drawable:4bc46edf1946b32d518b41416d1734e915e0cbb28021de3b340527419b070691',
+        'com.android.support:support-vector-drawable:13728f337f36d1c02d52198a6c20724edb447a0875454d829f95cb9eb4aa293b',
+        'com.android.support:support-compat:e02d781268dc60aab6638d8dc20156ea11ca20b962d294b85e6f1e8418cabfa7',
+        'com.android.support:support-annotations:aedf76962584adfaed2bd3fcaa22406461c4310237fc27e301128edaa2dba2fa',
+        'com.google.zxing:core:bba7724e02a997cec38213af77133ee8e24b0d5cf5fa7ecbc16a4fa93f11ee0d',
+        'org.commonjava.googlecode.markdown4j:markdown4j:28eb991f702c6d85d6cafd68c24d1ce841d1f5c995c943f25aedb433c0c13f60',
+        'org.ocpsoft.prettytime:prettytime:ef7098d973ae78b57d1a22dc37d3b8a771bf030301300e24055d676b6cdc5e75',
+        'com.squareup.okhttp3:okhttp-urlconnection:16a410e5c4457ab381759486df6f840fdc7cc426d67433d4da1b7d65ed2b3b33',
+        'com.squareup.okhttp3:okhttp:a0d01017a42bba26e507fc6d448bb36e536f4b6e612f7c42de30bbdac2b7785e',
+        'org.apache.james:apache-mime4j-dom:e18717fe6d36f32e5c5f7cbeea1a9bf04645fdabc84e7e8374d9da10fd52e78d',
+        'org.apache.james:apache-mime4j-core:561987f604911e1870b2b4eabf0b0658d666c66cb1e65fba3e9e4bffe63acab9',
+        'com.splitwise:tokenautocomplete:f921f83ee26b5265f719b312c30452ef8e219557826c5ce5bf02e29647967939',
+        'com.cocosw:bottomsheet:4af6112a7f4cad4e2b70e5fdf1edc39f51275523a0f53011a012837dc103e597',
+        'com.mikepenz:materialdrawer:8bba1428dcef5ad7c2decf49c612ad980b38e2f1031cbd66c152a8a104793929',
+        'com.mikepenz:iconics-core:478d7e245098f7c28b5b20a0e6b1e5cb108ef3eaf595af7190bc60f91063aa3d',
+        'com.mikepenz:google-material-typeface:f27c629ba5d2a90ecfbd7f221ff98cd363e1ee6be06b099b82bae490766e14a5',
+        'com.mikepenz:fontawesome-typeface:ee47b7fe97b90412f01f2fcdd78f65a4edb0ab00006f5ef59ed00516baca9309',
+        'com.mikepenz:community-material-typeface:d6035d261c5eba880cd7fe5dcb8cc00b09bfe6d41063b881b759e9897dc7b7c9',
+        'com.fidesmo:nordpol-android:9a992eca347ff7af6e99ff48078954b44b26f26fdc5463139e340234757a24f7',
+        'org.glassfish:javax.annotation:339c876b928766329cc0657920366e75beb25f932b80bb3b26df6c0e687a9582',
+        'com.ryanharter.auto.value:auto-value-parcel-adapter:f730534497f7de81f62f1165df65e750522fdaedabd56031ee1c2d9da2544e17',
+        'com.squareup.okio:okio:734269c3ebc5090e3b23566db558f421f0b4027277c79ad5d176b8ec168bb850',
+        'com.fidesmo:nordpol-core:296e71b12884a9cd28cf00ab908973bbf776a90be1f23ac897380d91604e614d',
+        'com.jakewharton.timber:timber:d553d3d3e883ce7d061f1b21b95d6ee0840f3bfbf6d3bd51c5671f0b0f0b0091',
     ]
 }
 
@@ -243,11 +231,15 @@ android {
         debugWithTestCoverage {
             // Enable code coverage (Jacoco)
             testCoverageEnabled true
+            matchingFallbacks = ['debug']    // instead use this
         }
     }
 
+    flavorDimensions("freedom")
+
     productFlavors {
         google {
+            dimension "freedom"
             buildConfigField "boolean", "DONATIONS_GOOGLE", "true"
             buildConfigField "String", "GOOGLE_PLAY_PUBKEY", "\"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwX9SOQ/EL4u5pvbYmYMagN5DDenuSaMaVs2cVPzqxMaIHp6/9/nGuzj2/CpcB4ASd2vvfLlE9tZRkPmFTULWc4Sp4OR+JenQufZZr7Y8WGPkFyqd+dOxhIqKKLtH1QuqSyhby3gEMlWzydJY3rHXlH2Bpu65Uroawq76nynnELXNlzsCM231XWgj4HA87qxv9hSWLCpu16wKxZIX3d6mwZLZmGF+xYJAzVr291oDYYl+h6BDoIcAfmQFsv5MexNwBFO+TLVrvL0e5qdGHZxwwD1/68VSY8FxAEfM+yq7jovdVSdcXlJQjZrV5TRDdFWrtEB6njGA3YZWXP6B6MMMoQIDAQAB\""
             buildConfigField "String", "PAYPAL_USER", "null"
@@ -257,6 +249,7 @@ android {
             buildConfigField "String", "FLATTR_URL", "null"
         }
         fdroid {
+            dimension "freedom"
             buildConfigField "boolean", "DONATIONS_GOOGLE", "false"
             buildConfigField "String", "GOOGLE_PLAY_PUBKEY", "null"
             buildConfigField "String", "PAYPAL_USER", "\"android@schuermann.eu\""

--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -261,7 +261,7 @@ android {
 
     variantFilter { variant ->
         if(variant.buildType.name.equals('debug') && variant.getFlavors().get(0).name.equals('google')) {
-            variant.setIgnore(true);
+            variant.setIgnore(true)
         }
     }
 

--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -8,12 +8,12 @@ dependencies {
     // NOTE: libraries are pinned to a specific build, see below
 
     // from local Android SDK
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'com.android.support:cardview-v7:25.3.1'
-    compile 'com.android.support:support-annotations:25.3.1'
+    compile 'com.android.support:support-v4:27.0.2'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:design:27.0.2'
+    compile 'com.android.support:recyclerview-v7:27.0.2'
+    compile 'com.android.support:cardview-v7:27.0.2'
+    compile 'com.android.support:support-annotations:27.0.2'
 
     // JCenter etc.
     compile 'com.journeyapps:zxing-android-embedded:3.4.0'
@@ -74,9 +74,9 @@ dependencies {
     // UI testing with Espresso
     // Force usage of support libs in the test app, since they are internally used by the runner module.
     // https://github.com/googlesamples/android-testing/blob/master/ui/espresso/BasicSample/app/build.gradle#L28
-    androidTestCompile 'com.android.support:support-annotations:25.3.1'
-    androidTestCompile 'com.android.support:appcompat-v7:25.3.1'
-    androidTestCompile 'com.android.support:design:25.3.1'
+    androidTestCompile 'com.android.support:support-annotations:27.0.2'
+    androidTestCompile 'com.android.support:appcompat-v7:27.0.2'
+    androidTestCompile 'com.android.support:design:27.0.2'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
@@ -94,37 +94,36 @@ dependencies {
     annotationProcessor "com.google.auto.value:auto-value:1.5"
     annotationProcessor "com.ryanharter.auto.value:auto-value-parcel:0.2.5"
     compile 'com.ryanharter.auto.value:auto-value-parcel-adapter:0.2.5'
-
 }
 
 // Output of ./gradlew -q calculateChecksums
 // Comment out the libs referenced as git submodules!
 dependencyVerification {
     verify = [
-        'com.android.support:design:a3e83064fe99d0a4369f9b46d8bfbe77d0c3022fffdee4be3ac3857b87cc89e3',
+        'com.android.support:design:fa5c27a705310e95a8f4099c98777132ed901a0d69178942306bb34cd76f0d57',
         'com.journeyapps:zxing-android-embedded:2422d83c2c09a7b645f516c8458ececba6a7da47b94e40778d876facf495c660',
         'org.sufficientlysecure:donations:2be4183afa5e35263e37346344cfea48681f3c987e6832dd4acde227c13ccad6',
-        'com.android.support:transition:36c688825a8c0e6e879e18886de83dc90673322822d5b606ee302f70fb558e16',
+        'com.android.support:support-v4:1b2b37169fcccfef5e563d273749e3792decdce9818bc17932403a2363f537b4',
         'com.futuremind.recyclerfastscroll:fastscroll:ae655201885a9dbb5fabecb4adfefbb23ffdbca26a2b4ea255ec1bf6f214c606',
         'com.mikepenz:fastadapter:21d4ecb5c128bcda37b14e7998d799ed52cfc768b72cdf3d5578bb6775769ebd',
         'com.mikepenz:materialize:942ccf5e2aa1a46803aa884e8dc7bbaf2a9e8e9996a0cf92e3fe2f44a8592ba4',
-        'com.android.support:appcompat-v7:ac1ebbc46589195dda3e0b1becfe410bafd75bdf3edd1cd9acf04850f3895830',
-        'com.android.support:support-v4:07d389154bcf73b47e514964df1578136b26cba78257b8a577a3ccb54beff0ae',
+        'com.android.support:appcompat-v7:b2825e8b47f665d3362d8481c8d147d1af9230d16f23a2b94f6ccbc53c68cec1',
         'com.nispok:snackbar:46b5eb9d630d329e13c2ce00ee9fb115ffb66c23c72cff32ee97eedd76824c6f',
         'com.tonicartos:superslim:ca89b5c674660cc6918a8f8fd385065bffeee27983e0d33c7c2f0ad7b34d2d49',
-        'com.android.support:recyclerview-v7:375974a8724e359d97d77fa8522c614f813a3ac4583c1807f154a3f9a054b0a1',
-        'com.android.support:cardview-v7:defc17032ffa600a82e1c7d96bb574aa5ed64e2b57e28414a245da7d6db0c666',
+        'com.android.support:recyclerview-v7:3eb953930f10941f2b0447ec123a9b03d2746a42a99c523e82c3ece3308ca70b',
+        'com.android.support:cardview-v7:57f867a3c8f33e2d4dc0a03e2dfa03cad6267a908179f04a725a68ea9f0b8ccf',
         'org.sufficientlysecure:html-textview:ed740adf05cae2373999c7a3047c803183d9807b2cf66162902090d7c112a832',
         'com.getbase:floatingactionbutton:3edefa511aac4d90794c7b0496aca59cff2eee1e32679247b4f85acbeee05240',
-        'com.android.support:support-fragment:541d6393c1e024453aca2a14f31bea0c7270ff4e2a02783f3528aa426367444d',
-        'com.android.support:support-media-compat:cbed07d07e0e84fdb4b75712f5fd946229a8af155933c9a92e41db64d00791e0',
-        'com.android.support:support-core-utils:32fac02eb2c20a77fa3e3bc3ede62392a19613f72b8f8e10f5dfa84bb4c89ea1',
+        'com.android.support:transition:1a7db0453c1467fc8fd815e6d50ca6bb475a7a9ba6b5f3b307329688a7c62a68',
+        'com.android.support:support-media-compat:6dd9327ee9aa467cab479aad97df375072b2b6ba61eadffdaa5a88de3843c457',
+        'com.android.support:support-fragment:e4358388022a2205777575a7251fe357334658e4123d5d6e3b082f5899d9b011',
+        'com.android.support:support-core-utils:b69c6e1e7731b876b910fc7100bcadf40a57f27b32ca26b91400995542112c96',
         'com.jpardogo.materialtabstrip:library:4ee2f1211c302b45fb8c627cc5b240dc6b38b7aaaab1b8bffc81663e1b108013',
-        'com.android.support:support-core-ui:6182278a6653e6c111c888963626cbb16f2d0022571cb239760475119e0b92a8',
-        'com.android.support:animated-vector-drawable:4bc46edf1946b32d518b41416d1734e915e0cbb28021de3b340527419b070691',
-        'com.android.support:support-vector-drawable:13728f337f36d1c02d52198a6c20724edb447a0875454d829f95cb9eb4aa293b',
-        'com.android.support:support-compat:e02d781268dc60aab6638d8dc20156ea11ca20b962d294b85e6f1e8418cabfa7',
-        'com.android.support:support-annotations:aedf76962584adfaed2bd3fcaa22406461c4310237fc27e301128edaa2dba2fa',
+        'com.android.support:animated-vector-drawable:5b117a2c13a898c2a3c84c480d64edcfac2ef720aa9b742c29249fac774ffc48',
+        'com.android.support:support-core-ui:2284072511a95d504c074de80c82cd33724c6d2754117833b98ba3a09994163e',
+        'com.android.support:support-vector-drawable:bf4f4fcbf58b1380616581224e6487c230bfdb3434ec353d4adaa4b1f4865cfa',
+        'com.android.support:support-compat:ed4d25d91a0b13d8b9def1c0de69ed03d7fb89d50fb37eb0e9b63b0cf7a42357',
+        'com.android.support:support-annotations:af05330d997eb92a066534dbe0a3ea24347d26d7001221092113ae02a8f233da',
         'com.google.zxing:core:bba7724e02a997cec38213af77133ee8e24b0d5cf5fa7ecbc16a4fa93f11ee0d',
         'org.commonjava.googlecode.markdown4j:markdown4j:28eb991f702c6d85d6cafd68c24d1ce841d1f5c995c943f25aedb433c0c13f60',
         'org.ocpsoft.prettytime:prettytime:ef7098d973ae78b57d1a22dc37d3b8a771bf030301300e24055d676b6cdc5e75',

--- a/OpenKeychain/src/main/java/android/support/v4/widget/FlingNestedScrollView.java
+++ b/OpenKeychain/src/main/java/android/support/v4/widget/FlingNestedScrollView.java
@@ -94,7 +94,7 @@ public class FlingNestedScrollView extends FrameLayout implements NestedScrollin
     private float mVerticalScrollFactor;
 
     public FlingNestedScrollView(Context context) {
-        this(context, (AttributeSet)null);
+        this(context, null);
     }
 
     public FlingNestedScrollView(Context context, AttributeSet attrs) {
@@ -176,7 +176,7 @@ public class FlingNestedScrollView extends FrameLayout implements NestedScrollin
         this.scrollBy(0, dyUnconsumed);
         int myConsumed = this.getScrollY() - oldScrollY;
         int myUnconsumed = dyUnconsumed - myConsumed;
-        this.dispatchNestedScroll(0, myConsumed, 0, myUnconsumed, (int[])null);
+        this.dispatchNestedScroll(0, myConsumed, 0, myUnconsumed, null);
     }
 
     public void onNestedPreScroll(View target, int dx, int dy, int[] consumed) {
@@ -1061,8 +1061,9 @@ public class FlingNestedScrollView extends FrameLayout implements NestedScrollin
             direction = 33;
         }
 
-        View nextFocus = previouslyFocusedRect == null?FocusFinder.getInstance().findNextFocus(this, (View)null, direction):FocusFinder.getInstance().findNextFocusFromRect(this, previouslyFocusedRect, direction);
-        return nextFocus == null?false:(this.isOffScreen(nextFocus)?false:nextFocus.requestFocus(direction, previouslyFocusedRect));
+        View nextFocus = previouslyFocusedRect == null?FocusFinder.getInstance().findNextFocus(this, null, direction):FocusFinder.getInstance().findNextFocusFromRect(this, previouslyFocusedRect, direction);
+        return nextFocus != null && (!this.isOffScreen(nextFocus) &&
+                nextFocus.requestFocus(direction, previouslyFocusedRect));
     }
 
     public boolean requestChildRectangleOnScreen(View child, Rect rectangle, boolean immediate) {

--- a/OpenKeychain/src/main/java/android/support/v4/widget/NoScrollableSwipeRefreshLayout.java
+++ b/OpenKeychain/src/main/java/android/support/v4/widget/NoScrollableSwipeRefreshLayout.java
@@ -450,7 +450,7 @@ public class NoScrollableSwipeRefreshLayout extends ViewGroup {
      * triggers a refresh should implement this interface.
      */
     public interface OnRefreshListener {
-        public void onRefresh();
+        void onRefresh();
     }
 
     /**

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/network/TlsPskCompat.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/network/TlsPskCompat.java
@@ -1,0 +1,77 @@
+package org.sufficientlysecure.keychain.network;
+
+
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import android.os.Build.VERSION_CODES;
+import android.support.annotation.RequiresApi;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+
+
+@RequiresApi(api = VERSION_CODES.LOLLIPOP)
+class TlsPskCompat {
+
+    static SSLContext createTlsPskSslContext(byte[] presharedKey) {
+        try {
+            PresharedKeyManager pskKeyManager = new PresharedKeyManager(presharedKey);
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(new KeyManager[] { pskKeyManager }, new TrustManager[0], null);
+
+            return sslContext;
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    /* This class is a KeyManager that is compatible to TlsPskManager.
+     *
+     * Due to the way conscrypt works internally, this class will be internally duck typed to
+     * PSKKeyManager. This is quite a hack, and relies on conscrypt internals to work - but it
+     * works.
+     *
+     * see also:
+     * https://github.com/google/conscrypt/blob/b23e9353ed4e3256379d660cb09491a69b21affb/common/src/main/java/org/conscrypt/SSLParametersImpl.java#L494
+     * https://github.com/google/conscrypt/blob/29916ef38dc9cb4e4c6e3fdb87d4e921546d3ef4/common/src/main/java/org/conscrypt/DuckTypedPSKKeyManager.java#L51
+     *
+     */
+    private static class PresharedKeyManager implements KeyManager {
+        byte[] presharedKey;
+
+        private PresharedKeyManager(byte[] presharedKey) {
+            this.presharedKey = presharedKey;
+        }
+
+        public String chooseServerKeyIdentityHint(Socket socket) {
+            return null;
+        }
+
+        public String chooseServerKeyIdentityHint(SSLEngine engine) {
+            return null;
+        }
+
+        public String chooseClientKeyIdentity(String identityHint, Socket socket) {
+            return identityHint;
+        }
+
+        public String chooseClientKeyIdentity(String identityHint, SSLEngine engine) {
+            return identityHint;
+        }
+
+        public SecretKey getKey(String identityHint, String identity, Socket socket) {
+            return new SecretKeySpec(presharedKey, "AES");
+        }
+
+        public SecretKey getKey(String identityHint, String identity, SSLEngine engine) {
+            return new SecretKeySpec(presharedKey, "AES");
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
@@ -926,7 +926,6 @@ public abstract class OperationResult implements Parcelable {
         MSG_TRUST_INITIALIZE (LogLevel.INFO, R.string.msg_trust_initialize),
         MSG_TRUST_COUNT_NONE (LogLevel.DEBUG, R.string.msg_trust_count_none),
         MSG_TRUST_COUNT (LogLevel.DEBUG, R.plurals.msg_trust_count);
-        ;
 
         public final int mMsgId;
         public final LogLevel mLevel;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PassphraseCacheInterface.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PassphraseCacheInterface.java
@@ -20,13 +20,13 @@ package org.sufficientlysecure.keychain.pgp;
 import org.sufficientlysecure.keychain.util.Passphrase;
 
 public interface PassphraseCacheInterface {
-    public static class NoSecretKeyException extends Exception {
+    class NoSecretKeyException extends Exception {
         public NoSecretKeyException() {
         }
     }
 
-    public Passphrase getCachedPassphrase(long subKeyId) throws NoSecretKeyException;
+    Passphrase getCachedPassphrase(long subKeyId) throws NoSecretKeyException;
 
-    public Passphrase getCachedPassphrase(long masterKeyId, long subKeyId) throws NoSecretKeyException;
+    Passphrase getCachedPassphrase(long masterKeyId, long subKeyId) throws NoSecretKeyException;
 
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpDecryptVerifyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpDecryptVerifyOperation.java
@@ -579,7 +579,6 @@ public class PgpDecryptVerifyOperation extends BaseOperation<PgpDecryptVerifyInp
         CanonicalizedSecretKey decryptionKey = null;
         CachingDataDecryptorFactory cachedKeyDecryptorFactory = new CachingDataDecryptorFactory(
                 Constants.BOUNCY_CASTLE_PROVIDER_NAME, cryptoInput.getCryptoData());
-        ;
 
         Passphrase passphrase = null;
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/UncachedKeyRing.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/UncachedKeyRing.java
@@ -255,8 +255,8 @@ public class UncachedKeyRing {
     }
 
     public interface IteratorWithIOThrow<E> {
-        public boolean hasNext() throws IOException;
-        public E next() throws IOException;
+        boolean hasNext() throws IOException;
+        E next() throws IOException;
     }
     public void encodeArmored(OutputStream out, String version) throws IOException {
         ArmoredOutputStream aos = new ArmoredOutputStream(out);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppSettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppSettingsActivity.java
@@ -61,8 +61,8 @@ public class AppSettingsActivity extends BaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mAppNameView = (TextView) findViewById(R.id.api_app_settings_app_name);
-        mAppIconView = (ImageView) findViewById(R.id.api_app_settings_app_icon);
+        mAppNameView = findViewById(R.id.api_app_settings_app_name);
+        mAppIconView = findViewById(R.id.api_app_settings_app_icon);
 
         findViewById(R.id.fab).setOnClickListener(new View.OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppSettingsAllowedKeysListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppSettingsAllowedKeysListFragment.java
@@ -76,7 +76,7 @@ public class AppSettingsAllowedKeysListFragment extends ListFragmentWorkaround i
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View layout = super.onCreateView(inflater, container, savedInstanceState);
-        ListView lv = (ListView) layout.findViewById(android.R.id.list);
+        ListView lv = layout.findViewById(android.R.id.list);
         ViewGroup parent = (ViewGroup) lv.getParent();
 
         /*

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppSettingsHeaderFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppSettingsHeaderFragment.java
@@ -63,10 +63,10 @@ public class AppSettingsHeaderFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.api_app_settings_fragment, container, false);
-        mAppNameView = (TextView) view.findViewById(R.id.api_app_settings_app_name);
-        mAppIconView = (ImageView) view.findViewById(R.id.api_app_settings_app_icon);
-        mPackageName = (TextView) view.findViewById(R.id.api_app_settings_package_name);
-        mPackageCertificate = (TextView) view.findViewById(R.id.api_app_settings_package_certificate);
+        mAppNameView = view.findViewById(R.id.api_app_settings_app_name);
+        mAppIconView = view.findViewById(R.id.api_app_settings_app_icon);
+        mPackageName = view.findViewById(R.id.api_app_settings_package_name);
+        mPackageCertificate = view.findViewById(R.id.api_app_settings_package_certificate);
         return view;
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppsListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/AppsListFragment.java
@@ -321,9 +321,9 @@ public class AppsListFragment extends ListFragment implements
 
         @Override
         public void bindView(View view, Context context, Cursor cursor) {
-            TextView text = (TextView) view.findViewById(R.id.api_apps_adapter_item_name);
-            ImageView icon = (ImageView) view.findViewById(R.id.api_apps_adapter_item_icon);
-            ImageView installIcon = (ImageView) view.findViewById(R.id.api_apps_adapter_install_icon);
+            TextView text = view.findViewById(R.id.api_apps_adapter_item_name);
+            ImageView icon = view.findViewById(R.id.api_apps_adapter_item_icon);
+            ImageView installIcon = view.findViewById(R.id.api_apps_adapter_install_icon);
 
             String packageName = cursor.getString(INDEX_PACKAGE_NAME);
             Timber.d("packageName: " + packageName);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteErrorActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteErrorActivity.java
@@ -63,7 +63,7 @@ public class RemoteErrorActivity extends BaseActivity {
         );
 
         // set text on view
-        TextView textView = (TextView) findViewById(R.id.api_app_error_message_text);
+        TextView textView = findViewById(R.id.api_app_error_message_text);
         textView.setText(redErrorMessage);
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteRegisterActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteRegisterActivity.java
@@ -94,8 +94,8 @@ public class RemoteRegisterActivity extends FragmentActivity {
             View view = LayoutInflater.from(theme).inflate(R.layout.api_remote_register_app, null, false);
             alert.setView(view);
 
-            buttonAllow = (Button) view.findViewById(R.id.button_allow);
-            buttonCancel = (Button) view.findViewById(R.id.button_cancel);
+            buttonAllow = view.findViewById(R.id.button_allow);
+            buttonCancel = view.findViewById(R.id.button_cancel);
 
             setupListenersForPresenter();
             mvpView = createMvpView(view);
@@ -132,8 +132,8 @@ public class RemoteRegisterActivity extends FragmentActivity {
 
         @NonNull
         private RemoteRegisterView createMvpView(View view) {
-            final TextView titleText = (TextView) view.findViewById(R.id.api_register_text);
-            final ImageView iconClientApp = (ImageView) view.findViewById(R.id.icon_client_app);
+            final TextView titleText = view.findViewById(R.id.api_register_text);
+            final ImageView iconClientApp = view.findViewById(R.id.icon_client_app);
 
             return new RemoteRegisterView() {
                 @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteSecurityProblemDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteSecurityProblemDialogActivity.java
@@ -110,12 +110,12 @@ public class RemoteSecurityProblemDialogActivity extends FragmentActivity {
             View view = LayoutInflater.from(theme).inflate(R.layout.remote_security_issue_dialog, null, false);
             alert.setView(view);
 
-            buttonGotIt = (Button) view.findViewById(R.id.button_allow);
-            buttonViewKey = (Button) view.findViewById(R.id.button_view_key);
-            buttonOverride = (Button) view.findViewById(R.id.button_override);
-            buttonOverrideUndo = (Button) view.findViewById(R.id.button_override_undo);
-            buttonOverrideBack = (Button) view.findViewById(R.id.button_override_back);
-            buttonOverrideConfirm = (Button) view.findViewById(R.id.button_override_confirm);
+            buttonGotIt = view.findViewById(R.id.button_allow);
+            buttonViewKey = view.findViewById(R.id.button_view_key);
+            buttonOverride = view.findViewById(R.id.button_override);
+            buttonOverrideUndo = view.findViewById(R.id.button_override_undo);
+            buttonOverrideBack = view.findViewById(R.id.button_override_back);
+            buttonOverrideConfirm = view.findViewById(R.id.button_override_confirm);
 
             setupListenersForPresenter();
             mvpView = createMvpView(view);
@@ -152,17 +152,17 @@ public class RemoteSecurityProblemDialogActivity extends FragmentActivity {
 
         @NonNull
         private RemoteSecurityProblemView createMvpView(View view) {
-            final LinearLayout insecureWarningLayout = (LinearLayout) view.findViewById(R.id.insecure_warning_layout);
-            final ImageView iconClientApp = (ImageView) view.findViewById(R.id.icon_client_app);
-            final TextView explanationText = (TextView) insecureWarningLayout.findViewById(R.id.dialog_insecure_text);
+            final LinearLayout insecureWarningLayout = view.findViewById(R.id.insecure_warning_layout);
+            final ImageView iconClientApp = view.findViewById(R.id.icon_client_app);
+            final TextView explanationText = insecureWarningLayout.findViewById(R.id.dialog_insecure_text);
             final TextView recommendText =
-                    (TextView) insecureWarningLayout.findViewById(R.id.dialog_insecure_recommend_text);
+                    insecureWarningLayout.findViewById(R.id.dialog_insecure_recommend_text);
             final TextView overrideText =
-                    (TextView) insecureWarningLayout.findViewById(R.id.dialog_insecure_override_text);
+                    insecureWarningLayout.findViewById(R.id.dialog_insecure_override_text);
             final ToolableViewAnimator secondaryLayoutAnimator =
-                    (ToolableViewAnimator) insecureWarningLayout.findViewById(R.id.dialog_insecure_secondary_layout);
+                    insecureWarningLayout.findViewById(R.id.dialog_insecure_secondary_layout);
             final ToolableViewAnimator buttonBarAnimator =
-                    (ToolableViewAnimator) view.findViewById(R.id.dialog_insecure_button_bar);
+                    view.findViewById(R.id.dialog_insecure_button_bar);
 
             return new RemoteSecurityProblemView() {
                 private boolean layoutInitialized = false;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteSelectPubKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RemoteSelectPubKeyActivity.java
@@ -120,7 +120,7 @@ public class RemoteSelectPubKeyActivity extends BaseActivity {
                 });
 
         // set text on view
-        TextView textView = (TextView) findViewById(R.id.api_select_pub_keys_text);
+        TextView textView = findViewById(R.id.api_select_pub_keys_text);
         textView.setText(ssb, TextView.BufferType.SPANNABLE);
 
         // Load select pub keys fragment

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RequestKeyPermissionActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/RequestKeyPermissionActivity.java
@@ -92,8 +92,8 @@ public class RequestKeyPermissionActivity extends FragmentActivity {
             View view = LayoutInflater.from(theme).inflate(R.layout.api_remote_request_key_permission, null, false);
             alert.setView(view);
 
-            buttonAllow = (Button) view.findViewById(R.id.button_allow);
-            buttonCancel = (Button) view.findViewById(R.id.button_cancel);
+            buttonAllow = view.findViewById(R.id.button_allow);
+            buttonCancel = view.findViewById(R.id.button_cancel);
 
             setupListenersForPresenter();
             mvpView = createMvpView(view);
@@ -130,9 +130,9 @@ public class RequestKeyPermissionActivity extends FragmentActivity {
 
         @NonNull
         private RequestKeyPermissionMvpView createMvpView(View view) {
-            final TextView titleText = (TextView) view.findViewById(R.id.select_identity_key_title);
-            final TextView keyUserIdView = (TextView) view.findViewById(R.id.select_key_item_name);
-            final ImageView iconClientApp = (ImageView) view.findViewById(R.id.icon_client_app);
+            final TextView titleText = view.findViewById(R.id.select_identity_key_title);
+            final TextView keyUserIdView = view.findViewById(R.id.select_key_item_name);
+            final ImageView iconClientApp = view.findViewById(R.id.icon_client_app);
             final View keyUnavailableWarning = view.findViewById(R.id.requested_key_unavailable_warning);
             final View keyInfoLayout = view.findViewById(R.id.key_info_layout);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/SelectSignKeyIdActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/SelectSignKeyIdActivity.java
@@ -56,7 +56,7 @@ public class SelectSignKeyIdActivity extends BaseActivity {
                     }
                 });
 
-        TextView noneButton = (TextView) findViewById(R.id.api_select_sign_key_none);
+        TextView noneButton = findViewById(R.id.api_select_sign_key_none);
         noneButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectEncryptKeyAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectEncryptKeyAdapter.java
@@ -139,11 +139,11 @@ public class SelectEncryptKeyAdapter extends KeyCursorAdapter<SelectEncryptKeyAd
             super(itemView);
             itemView.setOnClickListener(this);
 
-            mUserIdText = (TextView) itemView.findViewById(R.id.select_key_item_name);
-            mUserIdRestText = (TextView) itemView.findViewById(R.id.select_key_item_email);
-            mCreationText = (TextView) itemView.findViewById(R.id.select_key_item_creation);
-            mStatusIcon = (ImageView) itemView.findViewById(R.id.select_key_item_status_icon);
-            mChecked = (CheckBox) itemView.findViewById(R.id.selected);
+            mUserIdText = itemView.findViewById(R.id.select_key_item_name);
+            mUserIdRestText = itemView.findViewById(R.id.select_key_item_email);
+            mCreationText = itemView.findViewById(R.id.select_key_item_creation);
+            mStatusIcon = itemView.findViewById(R.id.select_key_item_status_icon);
+            mChecked = itemView.findViewById(R.id.selected);
         }
 
         public void bind(PublicKeyCursor cursor, String query, boolean selected) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectSignKeyAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectSignKeyAdapter.java
@@ -129,10 +129,10 @@ public class SelectSignKeyAdapter extends KeyCursorAdapter<CursorAdapter.KeyCurs
             itemView.setClickable(true);
             itemView.setOnClickListener(this);
 
-            mUserIdText = (TextView) itemView.findViewById(R.id.select_key_item_name);
-            mUserIdRestText = (TextView) itemView.findViewById(R.id.select_key_item_email);
-            mCreationText = (TextView) itemView.findViewById(R.id.select_key_item_creation);
-            mStatusIcon = (ImageView) itemView.findViewById(R.id.select_key_item_status_icon);
+            mUserIdText = itemView.findViewById(R.id.select_key_item_name);
+            mUserIdRestText = itemView.findViewById(R.id.select_key_item_email);
+            mCreationText = itemView.findViewById(R.id.select_key_item_creation);
+            mStatusIcon = itemView.findViewById(R.id.select_key_item_status_icon);
         }
 
         public void bind(KeyCursor cursor, String query) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicateActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicateActivity.java
@@ -117,10 +117,10 @@ public class RemoteDeduplicateActivity extends FragmentActivity {
             View view = layoutInflater.inflate(R.layout.api_remote_deduplicate, null, false);
             alert.setView(view);
 
-            buttonSelect = (Button) view.findViewById(R.id.button_select);
-            buttonCancel = (Button) view.findViewById(R.id.button_cancel);
+            buttonSelect = view.findViewById(R.id.button_select);
+            buttonCancel = view.findViewById(R.id.button_cancel);
 
-            keyChoiceList = (RecyclerView) view.findViewById(R.id.duplicate_key_list);
+            keyChoiceList = view.findViewById(R.id.duplicate_key_list);
             keyChoiceList.setLayoutManager(new LinearLayoutManager(activity));
             keyChoiceList.addItemDecoration(
                     new DividerItemDecoration(activity, DividerItemDecoration.VERTICAL_LIST, true));
@@ -160,9 +160,9 @@ public class RemoteDeduplicateActivity extends FragmentActivity {
 
         @NonNull
         private RemoteDeduplicateView createMvpView(View view, LayoutInflater layoutInflater) {
-            final ImageView iconClientApp = (ImageView) view.findViewById(R.id.icon_client_app);
+            final ImageView iconClientApp = view.findViewById(R.id.icon_client_app);
             final KeyChoiceAdapter keyChoiceAdapter = new KeyChoiceAdapter(layoutInflater, getResources());
-            final TextView addressText = (TextView) view.findViewById(R.id.select_key_item_name);
+            final TextView addressText = view.findViewById(R.id.select_key_item_name);
             keyChoiceList.setAdapter(keyChoiceAdapter);
 
             return new RemoteDeduplicateView() {
@@ -314,9 +314,9 @@ public class RemoteDeduplicateActivity extends FragmentActivity {
         KeyChoiceViewHolder(View itemView) {
             super(itemView);
 
-            vName = (TextView) itemView.findViewById(R.id.key_list_item_name);
-            vCreation = (TextView) itemView.findViewById(R.id.key_list_item_creation);
-            vIcon = (ImageView) itemView.findViewById(R.id.key_list_item_icon);
+            vName = itemView.findViewById(R.id.key_list_item_name);
+            vCreation = itemView.findViewById(R.id.key_list_item_creation);
+            vIcon = itemView.findViewById(R.id.key_list_item_icon);
         }
 
         void bind(KeyInfo keyInfo, Drawable selectionIcon) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyActivity.java
@@ -140,10 +140,10 @@ public class RemoteSelectAuthenticationKeyActivity extends FragmentActivity {
             View view = layoutInflater.inflate(R.layout.api_remote_select_authentication_key, null, false);
             alert.setView(view);
 
-            buttonSelect = (Button) view.findViewById(R.id.button_select);
-            buttonCancel = (Button) view.findViewById(R.id.button_cancel);
+            buttonSelect = view.findViewById(R.id.button_select);
+            buttonCancel = view.findViewById(R.id.button_cancel);
 
-            keyChoiceList = (RecyclerView) view.findViewById(R.id.authentication_key_list);
+            keyChoiceList = view.findViewById(R.id.authentication_key_list);
             keyChoiceList.setLayoutManager(new LinearLayoutManager(activity));
             keyChoiceList.addItemDecoration(
                     new DividerItemDecoration(activity, DividerItemDecoration.VERTICAL_LIST, true));
@@ -183,7 +183,7 @@ public class RemoteSelectAuthenticationKeyActivity extends FragmentActivity {
 
         @NonNull
         private RemoteSelectAuthenticationKeyView createMvpView(View view, LayoutInflater layoutInflater) {
-            final ImageView iconClientApp = (ImageView) view.findViewById(R.id.icon_client_app);
+            final ImageView iconClientApp = view.findViewById(R.id.icon_client_app);
             final KeyChoiceAdapter keyChoiceAdapter = new KeyChoiceAdapter(layoutInflater, getResources());
             keyChoiceList.setAdapter(keyChoiceAdapter);
 
@@ -328,9 +328,9 @@ public class RemoteSelectAuthenticationKeyActivity extends FragmentActivity {
         KeyChoiceViewHolder(View itemView) {
             super(itemView);
 
-            vName = (TextView) itemView.findViewById(R.id.key_list_item_name);
-            vCreation = (TextView) itemView.findViewById(R.id.key_list_item_creation);
-            vIcon = (ImageView) itemView.findViewById(R.id.key_list_item_icon);
+            vName = itemView.findViewById(R.id.key_list_item_name);
+            vCreation = itemView.findViewById(R.id.key_list_item_creation);
+            vIcon = itemView.findViewById(R.id.key_list_item_icon);
         }
 
         void bind(KeyInfo keyInfo, Drawable selectionIcon) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/OpenPgpCapabilities.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/OpenPgpCapabilities.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
-import org.jetbrains.annotations.Nullable;
 
 
 @SuppressWarnings("unused") // just expose all included data

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeychainService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeychainService.java
@@ -99,7 +99,7 @@ public class KeychainService extends Service implements Progressable {
                 Bundle extras = intent.getExtras();
 
                 // Set messenger for communication (for this particular thread)
-                mMessenger.set(extras.<Messenger>getParcelable(EXTRA_MESSENGER));
+                mMessenger.set(extras.getParcelable(EXTRA_MESSENGER));
 
                 // Input
                 Parcelable inputParcel = extras.getParcelable(EXTRA_OPERATION_INPUT);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/input/CryptoInputParcel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/input/CryptoInputParcel.java
@@ -65,7 +65,7 @@ public abstract class CryptoInputParcel implements Parcelable {
 
 
     public static CryptoInputParcel createCryptoInputParcel() {
-        return new AutoValue_CryptoInputParcel(null, null, null, true, null, Collections.<ByteBuffer,byte[]>emptyMap());
+        return new AutoValue_CryptoInputParcel(null, null, null, true, null, Collections.emptyMap());
     }
 
     public static CryptoInputParcel createCryptoInputParcel(Date signatureTime, Passphrase passphrase) {
@@ -73,11 +73,11 @@ public abstract class CryptoInputParcel implements Parcelable {
             signatureTime = new Date();
         }
         return new AutoValue_CryptoInputParcel(signatureTime, passphrase, null, true, null,
-                Collections.<ByteBuffer,byte[]>emptyMap());
+                Collections.emptyMap());
     }
 
     public static CryptoInputParcel createCryptoInputParcel(Passphrase passphrase) {
-        return new AutoValue_CryptoInputParcel(null, passphrase, null, true, null, Collections.<ByteBuffer,byte[]>emptyMap());
+        return new AutoValue_CryptoInputParcel(null, passphrase, null, true, null, Collections.emptyMap());
     }
 
     public static CryptoInputParcel createCryptoInputParcel(Date signatureTime) {
@@ -85,7 +85,7 @@ public abstract class CryptoInputParcel implements Parcelable {
             signatureTime = new Date();
         }
         return new AutoValue_CryptoInputParcel(signatureTime, null, null, true, null,
-                Collections.<ByteBuffer,byte[]>emptyMap());
+                Collections.emptyMap());
     }
 
     public static CryptoInputParcel createCryptoInputParcel(ParcelableProxy parcelableProxy) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/BackupCodeFragment.java
@@ -261,21 +261,21 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
         mExecuteBackupOperation = args.getBoolean(ARG_EXECUTE_BACKUP_OPERATION, true);
 
         mCodeEditText = new EditText[6];
-        mCodeEditText[0] = (EditText) view.findViewById(R.id.backup_code_1);
-        mCodeEditText[1] = (EditText) view.findViewById(R.id.backup_code_2);
-        mCodeEditText[2] = (EditText) view.findViewById(R.id.backup_code_3);
-        mCodeEditText[3] = (EditText) view.findViewById(R.id.backup_code_4);
-        mCodeEditText[4] = (EditText) view.findViewById(R.id.backup_code_5);
-        mCodeEditText[5] = (EditText) view.findViewById(R.id.backup_code_6);
+        mCodeEditText[0] = view.findViewById(R.id.backup_code_1);
+        mCodeEditText[1] = view.findViewById(R.id.backup_code_2);
+        mCodeEditText[2] = view.findViewById(R.id.backup_code_3);
+        mCodeEditText[3] = view.findViewById(R.id.backup_code_4);
+        mCodeEditText[4] = view.findViewById(R.id.backup_code_5);
+        mCodeEditText[5] = view.findViewById(R.id.backup_code_6);
 
         {
             TextView[] codeDisplayText = new TextView[6];
-            codeDisplayText[0] = (TextView) view.findViewById(R.id.backup_code_display_1);
-            codeDisplayText[1] = (TextView) view.findViewById(R.id.backup_code_display_2);
-            codeDisplayText[2] = (TextView) view.findViewById(R.id.backup_code_display_3);
-            codeDisplayText[3] = (TextView) view.findViewById(R.id.backup_code_display_4);
-            codeDisplayText[4] = (TextView) view.findViewById(R.id.backup_code_display_5);
-            codeDisplayText[5] = (TextView) view.findViewById(R.id.backup_code_display_6);
+            codeDisplayText[0] = view.findViewById(R.id.backup_code_display_1);
+            codeDisplayText[1] = view.findViewById(R.id.backup_code_display_2);
+            codeDisplayText[2] = view.findViewById(R.id.backup_code_display_3);
+            codeDisplayText[3] = view.findViewById(R.id.backup_code_display_4);
+            codeDisplayText[4] = view.findViewById(R.id.backup_code_display_5);
+            codeDisplayText[5] = view.findViewById(R.id.backup_code_display_6);
 
             // set backup code in code TextViews
             char[] backupCode = mBackupCode.toCharArray();
@@ -293,9 +293,9 @@ public class BackupCodeFragment extends CryptoOperationFragment<BackupKeyringPar
         setupEditTextFocusNext(mCodeEditText);
         setupEditTextSuccessListener(mCodeEditText);
 
-        mStatusAnimator = (ToolableViewAnimator) view.findViewById(R.id.button_bar_animator);
-        mTitleAnimator = (ToolableViewAnimator) view.findViewById(R.id.title_animator);
-        mCodeFieldsAnimator = (ToolableViewAnimator) view.findViewById(R.id.code_animator);
+        mStatusAnimator = view.findViewById(R.id.button_bar_animator);
+        mTitleAnimator = view.findViewById(R.id.title_animator);
+        mCodeFieldsAnimator = view.findViewById(R.id.code_animator);
 
         View backupInput = view.findViewById(R.id.button_backup_input);
         backupInput.setOnClickListener(new OnClickListener() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyFingerprintFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyFingerprintFragment.java
@@ -73,12 +73,12 @@ public class CertifyFingerprintFragment extends LoaderFragment implements
         View root = super.onCreateView(inflater, superContainer, savedInstanceState);
         View view = inflater.inflate(R.layout.certify_fingerprint_fragment, getContainer());
 
-        TextView actionNo = (TextView) view.findViewById(R.id.certify_fingerprint_button_no);
-        mActionYes = (TextView) view.findViewById(R.id.certify_fingerprint_button_yes);
+        TextView actionNo = view.findViewById(R.id.certify_fingerprint_button_no);
+        mActionYes = view.findViewById(R.id.certify_fingerprint_button_yes);
 
-        mFingerprint = (TextView) view.findViewById(R.id.certify_fingerprint_fingerprint);
-        mIntro = (TextView) view.findViewById(R.id.certify_fingerprint_intro);
-        mHeader = (TextView) view.findViewById(R.id.certify_fingerprint_fingerprint_header);
+        mFingerprint = view.findViewById(R.id.certify_fingerprint_fingerprint);
+        mIntro = view.findViewById(R.id.certify_fingerprint_intro);
+        mHeader = view.findViewById(R.id.certify_fingerprint_fingerprint_header);
 
         actionNo.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyKeyFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CertifyKeyFragment.java
@@ -92,14 +92,14 @@ public class CertifyKeyFragment
     public View onCreateView(LayoutInflater inflater, ViewGroup superContainer, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.certify_key_fragment, null);
 
-        mCertifyKeySpinner = (CertifyKeySpinner) view.findViewById(R.id.certify_key_spinner);
-        mUploadKeyCheckbox = (CheckBox) view.findViewById(R.id.sign_key_upload_checkbox);
+        mCertifyKeySpinner = view.findViewById(R.id.certify_key_spinner);
+        mUploadKeyCheckbox = view.findViewById(R.id.sign_key_upload_checkbox);
         mMultiUserIdsFragment = (MultiUserIdsFragment)
                 getChildFragmentManager().findFragmentById(R.id.multi_user_ids_fragment);
 
         // make certify image gray, like action icons
         ImageView vActionCertifyImage =
-                (ImageView) view.findViewById(R.id.certify_key_action_certify_image);
+                view.findViewById(R.id.certify_key_action_certify_image);
         vActionCertifyImage.setColorFilter(FormattingUtils.getColorFromAttr(getActivity(), R.attr.colorTertiaryText),
                 PorterDuff.Mode.SRC_IN);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyEmailFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyEmailFragment.java
@@ -86,10 +86,10 @@ public class CreateKeyEmailFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.create_key_email_fragment, container, false);
 
-        mEmailEdit = (EmailEditText) view.findViewById(R.id.create_key_email);
+        mEmailEdit = view.findViewById(R.id.create_key_email);
         View backButton = view.findViewById(R.id.create_key_back_button);
         View nextButton = view.findViewById(R.id.create_key_next_button);
-        RecyclerView emailsRecyclerView = (RecyclerView) view.findViewById(R.id.create_key_emails);
+        RecyclerView emailsRecyclerView = view.findViewById(R.id.create_key_emails);
 
         // initial values
         mEmailEdit.setText(mCreateKeyActivity.mEmail);
@@ -286,8 +286,8 @@ public class CreateKeyEmailFragment extends Fragment {
 
             public ViewHolder(View itemView) {
                 super(itemView);
-                mTextView = (TextView) itemView.findViewById(R.id.create_key_email_item_email);
-                mDeleteButton = (ImageButton) itemView.findViewById(R.id.create_key_email_item_delete_button);
+                mTextView = itemView.findViewById(R.id.create_key_email_item_email);
+                mDeleteButton = itemView.findViewById(R.id.create_key_email_item_delete_button);
             }
         }
 
@@ -296,7 +296,7 @@ public class CreateKeyEmailFragment extends Fragment {
 
             public FooterHolder(View itemView) {
                 super(itemView);
-                mAddButton = (Button) itemView.findViewById(R.id.create_key_add_email);
+                mAddButton = itemView.findViewById(R.id.create_key_add_email);
             }
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyFinalFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyFinalFragment.java
@@ -104,13 +104,13 @@ public class CreateKeyFinalFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.create_key_final_fragment, container, false);
 
-        mNameEdit = (TextView) view.findViewById(R.id.name);
-        mEmailEdit = (TextView) view.findViewById(R.id.email);
-        mUploadCheckbox = (CheckBox) view.findViewById(R.id.create_key_upload);
+        mNameEdit = view.findViewById(R.id.name);
+        mEmailEdit = view.findViewById(R.id.email);
+        mUploadCheckbox = view.findViewById(R.id.create_key_upload);
         mBackButton = view.findViewById(R.id.create_key_back_button);
         mCreateButton = view.findViewById(R.id.create_key_next_button);
         mCustomKeyLayout = view.findViewById(R.id.custom_key_layout);
-        mCustomKeyRevertButton = (Button) view.findViewById(R.id.revert_key_configuration);
+        mCustomKeyRevertButton = view.findViewById(R.id.revert_key_configuration);
 
         CreateKeyActivity createKeyActivity = (CreateKeyActivity) getActivity();
 
@@ -261,7 +261,7 @@ public class CreateKeyFinalFragment extends Fragment {
         setHasOptionsMenu(true);
 
         if (savedInstanceState != null && savedInstanceState.containsKey(STATE_CUSTOM_CONFIGURATION)) {
-            keyConfigUseCustom(savedInstanceState.<SaveKeyringParcel>getParcelable(STATE_CUSTOM_CONFIGURATION));
+            keyConfigUseCustom(savedInstanceState.getParcelable(STATE_CUSTOM_CONFIGURATION));
         } else {
             keyConfigRevertToDefault();
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyNameFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyNameFragment.java
@@ -53,7 +53,7 @@ public class CreateKeyNameFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.create_key_name_fragment, container, false);
 
-        mNameEdit = (NameEditText) view.findViewById(R.id.create_key_name);
+        mNameEdit = view.findViewById(R.id.create_key_name);
         mBackButton = view.findViewById(R.id.create_key_back_button);
         mNextButton = view.findViewById(R.id.create_key_next_button);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyPassphraseFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyPassphraseFragment.java
@@ -91,9 +91,9 @@ public class CreateKeyPassphraseFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.create_key_passphrase_fragment, container, false);
 
-        mPassphraseEdit = (PassphraseEditText) view.findViewById(R.id.create_key_passphrase);
-        mPassphraseEditAgain = (EditText) view.findViewById(R.id.create_key_passphrase_again);
-        mShowPassphrase = (CheckBox) view.findViewById(R.id.create_key_show_passphrase);
+        mPassphraseEdit = view.findViewById(R.id.create_key_passphrase);
+        mPassphraseEditAgain = view.findViewById(R.id.create_key_passphrase_again);
+        mShowPassphrase = view.findViewById(R.id.create_key_show_passphrase);
         mBackButton = view.findViewById(R.id.create_key_back_button);
         mNextButton = view.findViewById(R.id.create_key_next_button);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyStartFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateKeyStartFragment.java
@@ -72,7 +72,7 @@ public class CreateKeyStartFragment extends Fragment {
         mCreateKey = view.findViewById(R.id.create_key_create_key_button);
         mImportKey = view.findViewById(R.id.create_key_import_button);
         mSecurityToken = view.findViewById(R.id.create_key_security_token_button);
-        mSkipOrCancel = (TextView) view.findViewById(R.id.create_key_cancel);
+        mSkipOrCancel = view.findViewById(R.id.create_key_cancel);
         mSecureDeviceSetup = view.findViewById(R.id.create_key_secure_device_setup);
 
         if (mCreateKeyActivity.mFirstTime) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateSecurityTokenAlgorithmFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateSecurityTokenAlgorithmFragment.java
@@ -87,9 +87,9 @@ public class CreateSecurityTokenAlgorithmFragment extends Fragment {
             }
         });
 
-        mSignKeySpinner = (Spinner) view.findViewById(R.id.create_key_yubi_key_algorithm_sign);
-        mDecKeySpinner = (Spinner) view.findViewById(R.id.create_key_yubi_key_algorithm_dec);
-        mAuthKeySpinner = (Spinner) view.findViewById(R.id.create_key_yubi_key_algorithm_auth);
+        mSignKeySpinner = view.findViewById(R.id.create_key_yubi_key_algorithm_sign);
+        mDecKeySpinner = view.findViewById(R.id.create_key_yubi_key_algorithm_dec);
+        mAuthKeySpinner = view.findViewById(R.id.create_key_yubi_key_algorithm_auth);
 
         ArrayList<Choice<SupportedKeyType>> choices = new ArrayList<>();
 
@@ -175,8 +175,8 @@ public class CreateSecurityTokenAlgorithmFragment extends Fragment {
 
             Choice c = this.getItem(position);
 
-            TextView text1 = (TextView) convertView.findViewById(android.R.id.text1);
-            TextView text2 = (TextView) convertView.findViewById(android.R.id.text2);
+            TextView text1 = convertView.findViewById(android.R.id.text1);
+            TextView text2 = convertView.findViewById(android.R.id.text2);
 
             text1.setText(c.getName());
             text2.setText(Html.fromHtml(c.getDescription()));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateSecurityTokenPinFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateSecurityTokenPinFragment.java
@@ -115,9 +115,9 @@ public class CreateSecurityTokenPinFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.create_yubi_key_pin_fragment, container, false);
 
-        mPin = (EditText) view.findViewById(R.id.create_yubi_key_pin);
-        mPinRepeat = (EditText) view.findViewById(R.id.create_yubi_key_pin_repeat);
-        mAdminPin = (TextView) view.findViewById(R.id.create_yubi_key_admin_pin);
+        mPin = view.findViewById(R.id.create_yubi_key_pin);
+        mPinRepeat = view.findViewById(R.id.create_yubi_key_pin_repeat);
+        mAdminPin = view.findViewById(R.id.create_yubi_key_admin_pin);
         mBackButton = view.findViewById(R.id.create_key_back_button);
         mNextButton = view.findViewById(R.id.create_key_next_button);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptActivity.java
@@ -93,7 +93,7 @@ public class DecryptActivity extends BaseActivity {
                     // Binary via content provider (could also be files)
                     // override uri to get stream from send
                     if (intent.hasExtra(Intent.EXTRA_STREAM)) {
-                        uris.add(intent.<Uri>getParcelableExtra(Intent.EXTRA_STREAM));
+                        uris.add(intent.getParcelableExtra(Intent.EXTRA_STREAM));
                     } else if (intent.hasExtra(Intent.EXTRA_TEXT)) {
                         String text = intent.getStringExtra(Intent.EXTRA_TEXT);
                         Uri uri = readToTempFile(text);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptFragment.java
@@ -89,20 +89,20 @@ public abstract class DecryptFragment extends Fragment implements LoaderManager.
         super.onViewCreated(view, savedInstanceState);
 
         // NOTE: These views are inside the activity!
-        mResultLayout = (LinearLayout) getActivity().findViewById(R.id.result_main_layout);
+        mResultLayout = getActivity().findViewById(R.id.result_main_layout);
         mResultLayout.setVisibility(View.GONE);
-        mEncryptionIcon = (ImageView) getActivity().findViewById(R.id.result_encryption_icon);
-        mEncryptionText = (TextView) getActivity().findViewById(R.id.result_encryption_text);
-        mSignatureIcon = (ImageView) getActivity().findViewById(R.id.result_signature_icon);
-        mSignatureText = (TextView) getActivity().findViewById(R.id.result_signature_text);
+        mEncryptionIcon = getActivity().findViewById(R.id.result_encryption_icon);
+        mEncryptionText = getActivity().findViewById(R.id.result_encryption_text);
+        mSignatureIcon = getActivity().findViewById(R.id.result_signature_icon);
+        mSignatureText = getActivity().findViewById(R.id.result_signature_text);
         mSignatureLayout = getActivity().findViewById(R.id.result_signature_layout);
-        mSignatureName = (TextView) getActivity().findViewById(R.id.result_signature_name);
-        mSignatureEmail = (TextView) getActivity().findViewById(R.id.result_signature_email);
-        mSignatureAction = (TextView) getActivity().findViewById(R.id.result_signature_action);
+        mSignatureName = getActivity().findViewById(R.id.result_signature_name);
+        mSignatureEmail = getActivity().findViewById(R.id.result_signature_email);
+        mSignatureAction = getActivity().findViewById(R.id.result_signature_action);
 
         // Overlay
         mOverlayAnimator = (ViewAnimator) view;
-        Button vErrorOverlayButton = (Button) view.findViewById(R.id.decrypt_error_overlay_button);
+        Button vErrorOverlayButton = view.findViewById(R.id.decrypt_error_overlay_button);
         vErrorOverlayButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptListFragment.java
@@ -165,7 +165,7 @@ public class DecryptListFragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.decrypt_files_list_fragment, container, false);
 
-        RecyclerView vFilesList = (RecyclerView) view.findViewById(R.id.decrypted_files_list);
+        RecyclerView vFilesList = view.findViewById(R.id.decrypted_files_list);
 
         vFilesList.addItemDecoration(new SpacesItemDecoration(
                 FormattingUtils.dpToPx(getActivity(), 4)));
@@ -1203,9 +1203,9 @@ public class DecryptListFragment
 
             public SubViewHolder(View itemView) {
                 vFile = itemView.findViewById(R.id.file);
-                vFilename = (TextView) itemView.findViewById(R.id.filename);
-                vFilesize = (TextView) itemView.findViewById(R.id.filesize);
-                vThumbnail = (ImageView) itemView.findViewById(R.id.thumbnail);
+                vFilename = itemView.findViewById(R.id.filename);
+                vFilesize = itemView.findViewById(R.id.filesize);
+                vThumbnail = itemView.findViewById(R.id.thumbnail);
             }
         }
 
@@ -1215,22 +1215,22 @@ public class DecryptListFragment
         public ViewHolder(View itemView) {
             super(itemView);
 
-            vAnimator = (ViewAnimator) itemView.findViewById(R.id.view_animator);
+            vAnimator = itemView.findViewById(R.id.view_animator);
 
-            vProgress = (ProgressBar) itemView.findViewById(R.id.progress);
-            vProgressMsg = (TextView) itemView.findViewById(R.id.progress_msg);
+            vProgress = itemView.findViewById(R.id.progress);
+            vProgressMsg = itemView.findViewById(R.id.progress_msg);
 
-            vEncStatusIcon = (ImageView) itemView.findViewById(R.id.result_encryption_icon);
-            vEncStatusText = (TextView) itemView.findViewById(R.id.result_encryption_text);
+            vEncStatusIcon = itemView.findViewById(R.id.result_encryption_icon);
+            vEncStatusText = itemView.findViewById(R.id.result_encryption_text);
 
-            vSigStatusIcon = (ImageView) itemView.findViewById(R.id.result_signature_icon);
-            vSigStatusText = (TextView) itemView.findViewById(R.id.result_signature_text);
+            vSigStatusIcon = itemView.findViewById(R.id.result_signature_icon);
+            vSigStatusText = itemView.findViewById(R.id.result_signature_text);
             vSignatureLayout = itemView.findViewById(R.id.result_signature_layout);
-            vSignatureName = (TextView) itemView.findViewById(R.id.result_signature_name);
-            vSignatureMail = (TextView) itemView.findViewById(R.id.result_signature_email);
-            vSignatureAction = (ViewAnimator) itemView.findViewById(R.id.result_signature_action);
+            vSignatureName = itemView.findViewById(R.id.result_signature_name);
+            vSignatureMail = itemView.findViewById(R.id.result_signature_email);
+            vSignatureAction = itemView.findViewById(R.id.result_signature_action);
 
-            vFileList = (LinearLayout) itemView.findViewById(R.id.file_list);
+            vFileList = itemView.findViewById(R.id.file_list);
             for (int i = 0; i < vFileList.getChildCount(); i++) {
                 mFileHolderList.add(new SubViewHolder(vFileList.getChildAt(i)));
                 mCurrentFileListSize += 1;
@@ -1238,10 +1238,10 @@ public class DecryptListFragment
 
             vContextMenu = itemView.findViewById(R.id.context_menu);
 
-            vErrorMsg = (TextView) itemView.findViewById(R.id.result_error_msg);
-            vErrorViewLog = (ImageView) itemView.findViewById(R.id.result_error_log);
+            vErrorMsg = itemView.findViewById(R.id.result_error_msg);
+            vErrorViewLog = itemView.findViewById(R.id.result_error_log);
 
-            vCancelledRetry = (ImageView) itemView.findViewById(R.id.cancel_retry);
+            vCancelledRetry = itemView.findViewById(R.id.cancel_retry);
 
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DeleteKeyDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DeleteKeyDialogActivity.java
@@ -148,7 +148,7 @@ public class DeleteKeyDialogActivity extends FragmentActivity {
             @Override
             public RevokeKeyringParcel createOperationInput() {
                 return RevokeKeyringParcel.createRevokeKeyringParcel(mMasterKeyIds[0], true,
-                        (HkpKeyserverAddress) getIntent().getParcelableExtra(EXTRA_KEYSERVER));
+                        getIntent().getParcelableExtra(EXTRA_KEYSERVER));
             }
 
             @Override
@@ -261,7 +261,7 @@ public class DeleteKeyDialogActivity extends FragmentActivity {
             mInflateView = inflater.inflate(R.layout.view_key_delete_fragment, null);
             builder.setView(mInflateView);
 
-            mMainMessage = (TextView) mInflateView.findViewById(R.id.mainMessage);
+            mMainMessage = mInflateView.findViewById(R.id.mainMessage);
 
             // If only a single key has been selected
             if (masterKeyIds.length == 1) {
@@ -358,7 +358,7 @@ public class DeleteKeyDialogActivity extends FragmentActivity {
             View view = inflater.inflate(R.layout.del_rev_dialog, null);
             builder.setView(view);
 
-            final Spinner spinner = (Spinner) view.findViewById(R.id.spinner);
+            final Spinner spinner = view.findViewById(R.id.spinner);
 
             builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DisplayTextFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DisplayTextFragment.java
@@ -95,7 +95,7 @@ public class DisplayTextFragment extends DecryptFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.decrypt_text_fragment, container, false);
-        mText = (TextView) view.findViewById(R.id.decrypt_text_plaintext);
+        mText = view.findViewById(R.id.decrypt_text_plaintext);
         return view;
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EditIdentitiesFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EditIdentitiesFragment.java
@@ -108,9 +108,9 @@ public class EditIdentitiesFragment extends Fragment
     public View onCreateView(LayoutInflater inflater, ViewGroup superContainer, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.edit_identities_fragment, null);
 
-        mUploadKeyCheckbox = (CheckBox) view.findViewById(R.id.edit_identities_upload_checkbox);
-        mUserIdsList = (ListView) view.findViewById(R.id.edit_identities_user_ids);
-        mUserIdsAddedList = (ListView) view.findViewById(R.id.edit_identities_user_ids_added);
+        mUploadKeyCheckbox = view.findViewById(R.id.edit_identities_upload_checkbox);
+        mUserIdsList = view.findViewById(R.id.edit_identities_user_ids);
+        mUserIdsAddedList = view.findViewById(R.id.edit_identities_user_ids_added);
         mAddUserId = view.findViewById(R.id.edit_identities_add_user_id);
 
         // If this is a debug build, don't upload by default

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EditKeyFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EditKeyFragment.java
@@ -131,10 +131,10 @@ public class EditKeyFragment extends QueueingCryptoOperationFragment<SaveKeyring
     public View onCreateView(LayoutInflater inflater, ViewGroup superContainer, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.edit_key_fragment, superContainer, false);
 
-        mUserIdsList = (ListView) view.findViewById(R.id.edit_key_user_ids);
-        mSubkeysList = (ListView) view.findViewById(R.id.edit_key_keys);
-        mUserIdsAddedList = (ListView) view.findViewById(R.id.edit_key_user_ids_added);
-        mSubkeysAddedList = (ListView) view.findViewById(R.id.edit_key_subkeys_added);
+        mUserIdsList = view.findViewById(R.id.edit_key_user_ids);
+        mSubkeysList = view.findViewById(R.id.edit_key_keys);
+        mUserIdsAddedList = view.findViewById(R.id.edit_key_user_ids_added);
+        mSubkeysAddedList = view.findViewById(R.id.edit_key_subkeys_added);
         mChangePassphrase = view.findViewById(R.id.edit_key_action_change_passphrase);
         mAddUserId = view.findViewById(R.id.edit_key_action_add_user_id);
         mAddSubkey = view.findViewById(R.id.edit_key_action_add_key);
@@ -341,7 +341,7 @@ public class EditKeyFragment extends QueueingCryptoOperationFragment<SaveKeyring
                     // cache new returned passphrase!
                     mSkpBuilder.setNewUnlock(ChangeUnlockParcel.createChangeUnlockParcel(
                             mSkpBuilder.getMasterKeyId(), mSkpBuilder.getFingerprint(),
-                            (Passphrase) data.getParcelable(SetPassphraseDialogFragment.MESSAGE_NEW_PASSPHRASE)));
+                            data.getParcelable(SetPassphraseDialogFragment.MESSAGE_NEW_PASSPHRASE)));
                 }
             }
         };

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptFilesActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptFilesActivity.java
@@ -55,7 +55,7 @@ public class EncryptFilesActivity extends EncryptActivity {
         if (Intent.ACTION_SEND.equals(action) && type != null) {
             // Files via content provider, override uri and action
             uris.clear();
-            uris.add(intent.<Uri>getParcelableExtra(Intent.EXTRA_STREAM));
+            uris.add(intent.getParcelableExtra(Intent.EXTRA_STREAM));
         }
 
         if (Intent.ACTION_SEND_MULTIPLE.equals(action) && type != null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptFilesFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptFilesFragment.java
@@ -103,7 +103,7 @@ public class EncryptFilesFragment
 
     private AfterEncryptAction mAfterEncryptAction;
     private enum AfterEncryptAction {
-        SAVE, SHARE, COPY;
+        SAVE, SHARE, COPY
     }
 
     private ArrayList<Uri> mOutputUris;
@@ -140,7 +140,7 @@ public class EncryptFilesFragment
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.encrypt_files_fragment, container, false);
-        mSelectedFiles = (RecyclerView) view.findViewById(R.id.selected_files_list);
+        mSelectedFiles = view.findViewById(R.id.selected_files_list);
 
         mSelectedFiles.addItemDecoration(new SpacesItemDecoration(
                 FormattingUtils.dpToPx(getActivity(), 4)));
@@ -797,10 +797,10 @@ public class EncryptFilesFragment
 
             public ViewHolder(View itemView) {
                 super(itemView);
-                filename = (TextView) itemView.findViewById(R.id.filename);
-                fileSize = (TextView) itemView.findViewById(R.id.filesize);
+                filename = itemView.findViewById(R.id.filename);
+                fileSize = itemView.findViewById(R.id.filesize);
                 removeButton = itemView.findViewById(R.id.action_remove_file_from_list);
-                thumbnail = (ImageView) itemView.findViewById(R.id.thumbnail);
+                thumbnail = itemView.findViewById(R.id.thumbnail);
             }
         }
 
@@ -809,7 +809,7 @@ public class EncryptFilesFragment
 
             public FooterHolder(View itemView) {
                 super(itemView);
-                mAddButton = (Button) itemView.findViewById(R.id.file_list_entry_add);
+                mAddButton = itemView.findViewById(R.id.file_list_entry_add);
             }
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptModeAsymmetricFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptModeAsymmetricFragment.java
@@ -80,11 +80,11 @@ public class EncryptModeAsymmetricFragment extends EncryptModeFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.encrypt_asymmetric_fragment, container, false);
 
-        mSignKeySpinner = (KeySpinner) view.findViewById(R.id.sign);
-        mEncryptKeyView = (EncryptKeyCompletionView) view.findViewById(R.id.recipient_list);
+        mSignKeySpinner = view.findViewById(R.id.sign);
+        mEncryptKeyView = view.findViewById(R.id.recipient_list);
         mEncryptKeyView.setThreshold(1); // Start working from first character
 
-        final ViewAnimator vSignatureIcon = (ViewAnimator) view.findViewById(R.id.result_signature_icon);
+        final ViewAnimator vSignatureIcon = view.findViewById(R.id.result_signature_icon);
         mSignKeySpinner.setOnKeyChangedListener(new OnKeyChangedListener() {
             @Override
             public void onKeyChanged(long masterKeyId) {
@@ -95,7 +95,7 @@ public class EncryptModeAsymmetricFragment extends EncryptModeFragment {
             }
         });
 
-        final ViewAnimator vEncryptionIcon = (ViewAnimator) view.findViewById(R.id.result_encryption_icon);
+        final ViewAnimator vEncryptionIcon = view.findViewById(R.id.result_encryption_icon);
         mEncryptKeyView.setTokenListener(new TokenListener<KeyItem>() {
             @Override
             public void onTokenAdded(KeyItem o) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptModeSymmetricFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptModeSymmetricFragment.java
@@ -47,8 +47,8 @@ public class EncryptModeSymmetricFragment extends EncryptModeFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.encrypt_symmetric_fragment, container, false);
 
-        mPassphrase = (EditText) view.findViewById(R.id.passphrase);
-        mPassphraseAgain = (EditText) view.findViewById(R.id.passphraseAgain);
+        mPassphrase = view.findViewById(R.id.passphrase);
+        mPassphraseAgain = view.findViewById(R.id.passphraseAgain);
 
         return view;
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptTextActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptTextActivity.java
@@ -77,7 +77,7 @@ public class EncryptTextActivity extends EncryptActivity {
                 sharedText = extras.getString(Intent.EXTRA_TEXT);
             } else  if (extras.containsKey(Intent.EXTRA_STREAM)) {
                 try {
-                    sharedText = FileHelper.readTextFromUri(this, extras.<Uri>getParcelable(Intent.EXTRA_STREAM), null);
+                    sharedText = FileHelper.readTextFromUri(this, extras.getParcelable(Intent.EXTRA_STREAM), null);
                 } catch (IOException e) {
                     Toast.makeText(this, R.string.error_preparing_data, Toast.LENGTH_LONG).show();
                     finish();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptTextFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptTextFragment.java
@@ -98,7 +98,7 @@ public class EncryptTextFragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.encrypt_text_fragment, container, false);
 
-        TextView textView = (TextView) view.findViewById(R.id.encrypt_text_text);
+        TextView textView = view.findViewById(R.id.encrypt_text_text);
         textView.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/HelpAboutFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/HelpAboutFragment.java
@@ -42,10 +42,10 @@ public class HelpAboutFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.help_about_fragment, container, false);
 
-        TextView versionText = (TextView) view.findViewById(R.id.help_about_version);
+        TextView versionText = view.findViewById(R.id.help_about_version);
         versionText.setText(getString(R.string.help_about_version) + " " + getVersion());
 
-        HtmlTextView aboutTextView = (HtmlTextView) view.findViewById(R.id.help_about_text);
+        HtmlTextView aboutTextView = view.findViewById(R.id.help_about_text);
 
         // load markdown from raw resource
         try {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/HelpActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/HelpActivity.java
@@ -63,9 +63,9 @@ public class HelpActivity extends BaseActivity {
             }
         });
 
-        ViewPager viewPager = (ViewPager) findViewById(R.id.pager);
+        ViewPager viewPager = findViewById(R.id.pager);
         PagerSlidingTabStrip slidingTabLayout =
-                (PagerSlidingTabStrip) findViewById(R.id.sliding_tab_layout);
+                findViewById(R.id.sliding_tab_layout);
 
         mTabsAdapter = new PagerTabStripAdapter(this);
         viewPager.setAdapter(mTabsAdapter);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
@@ -301,7 +301,7 @@ public class ImportKeysActivity extends BaseActivity implements ImportKeysListen
     private boolean isFingerprintValid(String fingerprint) {
         if (fingerprint == null || fingerprint.length() < 40) {
             Notify.create(this, R.string.import_qr_code_too_short_fingerprint, Notify.Style.ERROR)
-                    .show((ViewGroup) findViewById(R.id.import_snackbar));
+                    .show(findViewById(R.id.import_snackbar));
             return false;
         } else {
             return true;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
@@ -196,11 +196,11 @@ public class KeyListFragment extends RecyclerFragment<KeySectionedListAdapter>
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.key_list_fragment, container, false);
 
-        mFab = (FloatingActionsMenu) view.findViewById(R.id.fab_main);
+        mFab = view.findViewById(R.id.fab_main);
 
-        FloatingActionButton fabQrCode = (FloatingActionButton) view.findViewById(R.id.fab_add_qr_code);
-        FloatingActionButton fabCloud = (FloatingActionButton) view.findViewById(R.id.fab_add_cloud);
-        FloatingActionButton fabFile = (FloatingActionButton) view.findViewById(R.id.fab_add_file);
+        FloatingActionButton fabQrCode = view.findViewById(R.id.fab_add_qr_code);
+        FloatingActionButton fabCloud = view.findViewById(R.id.fab_add_cloud);
+        FloatingActionButton fabFile = view.findViewById(R.id.fab_add_file);
 
         fabQrCode.setOnClickListener(new OnClickListener() {
             @Override
@@ -246,8 +246,8 @@ public class KeyListFragment extends RecyclerFragment<KeySectionedListAdapter>
         hideList(false);
 
         // click on search button (in empty view) starts query for search string
-        vSearchContainer = (ViewAnimator) activity.findViewById(R.id.search_container);
-        vSearchButton = (Button) activity.findViewById(R.id.search_button);
+        vSearchContainer = activity.findViewById(R.id.search_container);
+        vSearchButton = activity.findViewById(R.id.search_button);
         vSearchButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -261,7 +261,7 @@ public class KeyListFragment extends RecyclerFragment<KeySectionedListAdapter>
         setAdapter(adapter);
         setLayoutManager(new LayoutManager(getActivity()));
 
-        FastScroller fastScroller = (FastScroller) getActivity().findViewById(R.id.fastscroll);
+        FastScroller fastScroller = getActivity().findViewById(R.id.fastscroll);
         fastScroller.setRecyclerView(getRecyclerView());
 
         // Prepare the loader. Either re-connect with an existing one,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MainActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MainActivity.java
@@ -68,7 +68,7 @@ public class MainActivity extends BaseSecurityTokenActivity implements FabContai
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main_activity);
 
-        mToolbar = (Toolbar) findViewById(R.id.toolbar);
+        mToolbar = findViewById(R.id.toolbar);
         mToolbar.setTitle(R.string.app_name);
         setSupportActionBar(mToolbar);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MultiUserIdsFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MultiUserIdsFragment.java
@@ -76,7 +76,7 @@ public class MultiUserIdsFragment extends Fragment implements LoaderManager.Load
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.multi_user_ids_fragment, null);
 
-        mUserIds = (ListView) view.findViewById(R.id.view_key_user_ids);
+        mUserIds = view.findViewById(R.id.view_key_user_ids);
 
         return view;
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -186,12 +186,12 @@ public class PassphraseDialogActivity extends FragmentActivity {
                 alert.setView(view);
 
                 mBackupCodeEditText = new EditText[6];
-                mBackupCodeEditText[0] = (EditText) view.findViewById(R.id.backup_code_1);
-                mBackupCodeEditText[1] = (EditText) view.findViewById(R.id.backup_code_2);
-                mBackupCodeEditText[2] = (EditText) view.findViewById(R.id.backup_code_3);
-                mBackupCodeEditText[3] = (EditText) view.findViewById(R.id.backup_code_4);
-                mBackupCodeEditText[4] = (EditText) view.findViewById(R.id.backup_code_5);
-                mBackupCodeEditText[5] = (EditText) view.findViewById(R.id.backup_code_6);
+                mBackupCodeEditText[0] = view.findViewById(R.id.backup_code_1);
+                mBackupCodeEditText[1] = view.findViewById(R.id.backup_code_2);
+                mBackupCodeEditText[2] = view.findViewById(R.id.backup_code_3);
+                mBackupCodeEditText[3] = view.findViewById(R.id.backup_code_4);
+                mBackupCodeEditText[4] = view.findViewById(R.id.backup_code_5);
+                mBackupCodeEditText[5] = view.findViewById(R.id.backup_code_6);
 
                 setupEditTextFocusNext(mBackupCodeEditText);
 
@@ -205,13 +205,13 @@ public class PassphraseDialogActivity extends FragmentActivity {
             mLayout = (ViewAnimator) inflater.inflate(R.layout.passphrase_dialog, null);
             alert.setView(mLayout);
 
-            mPassphraseText = (TextView) mLayout.findViewById(R.id.passphrase_text);
-            mPassphraseEditText = (EditText) mLayout.findViewById(R.id.passphrase_passphrase);
+            mPassphraseText = mLayout.findViewById(R.id.passphrase_text);
+            mPassphraseEditText = mLayout.findViewById(R.id.passphrase_passphrase);
 
             View vTimeToLiveLayout = mLayout.findViewById(R.id.remember_layout);
             vTimeToLiveLayout.setVisibility(mRequiredInput.mSkipCaching ? View.GONE : View.VISIBLE);
 
-            mTimeToLiveSpinner = (CacheTTLSpinner) mLayout.findViewById(R.id.ttl_spinner);
+            mTimeToLiveSpinner = mLayout.findViewById(R.id.ttl_spinner);
             int ttlSeconds = Preferences.getPreferences(getContext()).getCacheTtlSeconds();
             mTimeToLiveSpinner.setSelectedTimeToLive(ttlSeconds);
 
@@ -293,7 +293,7 @@ public class PassphraseDialogActivity extends FragmentActivity {
             mPassphraseEditText.setImeActionLabel(getString(android.R.string.ok), EditorInfo.IME_ACTION_DONE);
             mPassphraseEditText.setOnEditorActionListener(this);
 
-            final ImageButton keyboard = (ImageButton) mLayout.findViewById(R.id.passphrase_keyboard);
+            final ImageButton keyboard = mLayout.findViewById(R.id.passphrase_keyboard);
 
             if (keyType == CanonicalizedSecretKey.SecretKeyType.DIVERT_TO_CARD) {
                 if (Preferences.getPreferences(activity).useNumKeypadForSecurityTokenPin()) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/QrCodeCaptureActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/QrCodeCaptureActivity.java
@@ -45,7 +45,7 @@ public class QrCodeCaptureActivity extends FragmentActivity {
 
         setContentView(R.layout.qr_code_capture_activity);
 
-        barcodeScannerView = (CompoundBarcodeView) findViewById(R.id.zxing_barcode_scanner);
+        barcodeScannerView = findViewById(R.id.zxing_barcode_scanner);
         barcodeScannerView.setStatusText(getString(R.string.import_qr_code_text));
 
         if (savedInstanceState != null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/QrCodeViewActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/QrCodeViewActivity.java
@@ -65,8 +65,8 @@ public class QrCodeViewActivity extends BaseActivity {
             return;
         }
 
-        mQrCode = (ImageView) findViewById(R.id.qr_code_image);
-        mQrCodeLayout = (CardView) findViewById(R.id.qr_code_image_layout);
+        mQrCode = findViewById(R.id.qr_code_image);
+        mQrCodeLayout = findViewById(R.id.qr_code_image_layout);
 
         mQrCodeLayout.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/RetryUploadDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/RetryUploadDialogActivity.java
@@ -21,6 +21,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentActivity;
@@ -74,7 +75,7 @@ public class RetryUploadDialogActivity extends FragmentActivity {
                 public void onClick(DialogInterface dialog, int which) {
                     Intent intent = new Intent();
                     intent.putExtra(RESULT_CRYPTO_INPUT, getActivity()
-                            .getIntent().getParcelableExtra(EXTRA_CRYPTO_INPUT));
+                            .getIntent().<Parcelable>getParcelableExtra(EXTRA_CRYPTO_INPUT));
                     getActivity().setResult(RESULT_OK, intent);
                     getActivity().finish();
                 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SafeSlingerActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SafeSlingerActivity.java
@@ -75,7 +75,7 @@ public class SafeSlingerActivity extends BaseActivity
 
         mMasterKeyId = getIntent().getLongExtra(EXTRA_MASTER_KEY_ID, 0);
 
-        NumberPicker picker = (NumberPicker) findViewById(R.id.safe_slinger_picker);
+        NumberPicker picker = findViewById(R.id.safe_slinger_picker);
         picker.setMinValue(2);
         picker.setMaxValue(10);
         picker.setOnValueChangedListener(new NumberPicker.OnValueChangeListener() {
@@ -85,7 +85,7 @@ public class SafeSlingerActivity extends BaseActivity
             }
         });
 
-        ImageView buttonIcon = (ImageView) findViewById(R.id.safe_slinger_button_image);
+        ImageView buttonIcon = findViewById(R.id.safe_slinger_button_image);
         buttonIcon.setColorFilter(FormattingUtils.getColorFromAttr(this, R.attr.colorTertiaryText),
                 PorterDuff.Mode.SRC_IN);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SecurityTokenChangePinOperationActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SecurityTokenChangePinOperationActivity.java
@@ -75,7 +75,7 @@ public class SecurityTokenChangePinOperationActivity extends BaseSecurityTokenAc
         super.onCreate(savedInstanceState);
         Timber.d("NfcOperationActivity.onCreate");
 
-        nfcGuideView = (NfcGuideView) findViewById(R.id.nfc_guide_view);
+        nfcGuideView = findViewById(R.id.nfc_guide_view);
 
         // prevent annoying orientation changes while fumbling with the device
         OrientationUtils.lockOrientation(this);
@@ -86,14 +86,14 @@ public class SecurityTokenChangePinOperationActivity extends BaseSecurityTokenAc
 
         setTitle(R.string.security_token_nfc_text);
 
-        vAnimator = (ViewAnimator) findViewById(R.id.view_animator);
+        vAnimator = findViewById(R.id.view_animator);
         vAnimator.setDisplayedChild(0);
 
         nfcGuideView.setCurrentStatus(NfcGuideView.NfcGuideViewStatus.STARTING_POSITION);
 
-        vErrorText = (TextView) findViewById(R.id.security_token_activity_3_error_text);
-        vErrorTextPin = (TextView) findViewById(R.id.security_token_activity_4_error_text);
-        vErrorTryAgainButton = (Button) findViewById(R.id.security_token_activity_3_error_try_again);
+        vErrorText = findViewById(R.id.security_token_activity_3_error_text);
+        vErrorTextPin = findViewById(R.id.security_token_activity_4_error_text);
+        vErrorTryAgainButton = findViewById(R.id.security_token_activity_3_error_try_again);
         vErrorTryAgainButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -105,7 +105,7 @@ public class SecurityTokenChangePinOperationActivity extends BaseSecurityTokenAc
                 nfcGuideView.setCurrentStatus(NfcGuideView.NfcGuideViewStatus.STARTING_POSITION);
             }
         });
-        Button vCancel = (Button) findViewById(R.id.security_token_activity_0_cancel);
+        Button vCancel = findViewById(R.id.security_token_activity_0_cancel);
         vCancel.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SecurityTokenOperationActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SecurityTokenOperationActivity.java
@@ -94,7 +94,7 @@ public class SecurityTokenOperationActivity extends BaseSecurityTokenActivity {
         super.onCreate(savedInstanceState);
         Timber.d("NfcOperationActivity.onCreate");
 
-        nfcGuideView = (NfcGuideView) findViewById(R.id.nfc_guide_view);
+        nfcGuideView = findViewById(R.id.nfc_guide_view);
 
         // prevent annoying orientation changes while fumbling with the device
         OrientationUtils.lockOrientation(this);
@@ -107,13 +107,13 @@ public class SecurityTokenOperationActivity extends BaseSecurityTokenActivity {
 
         setTitle(R.string.security_token_nfc_text);
 
-        vAnimator = (ViewAnimator) findViewById(R.id.view_animator);
+        vAnimator = findViewById(R.id.view_animator);
         vAnimator.setDisplayedChild(0);
 
         nfcGuideView.setCurrentStatus(NfcGuideView.NfcGuideViewStatus.STARTING_POSITION);
 
-        vErrorText = (TextView) findViewById(R.id.security_token_activity_3_error_text);
-        vErrorTryAgainButton = (Button) findViewById(R.id.security_token_activity_3_error_try_again);
+        vErrorText = findViewById(R.id.security_token_activity_3_error_text);
+        vErrorTryAgainButton = findViewById(R.id.security_token_activity_3_error_try_again);
         vErrorTryAgainButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -126,7 +126,7 @@ public class SecurityTokenOperationActivity extends BaseSecurityTokenActivity {
                 nfcGuideView.setCurrentStatus(NfcGuideView.NfcGuideViewStatus.STARTING_POSITION);
             }
         });
-        Button vCancel = (Button) findViewById(R.id.security_token_activity_0_cancel);
+        Button vCancel = findViewById(R.id.security_token_activity_0_cancel);
         vCancel.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsActivity.java
@@ -100,7 +100,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
      * Hack to get Toolbar in PreferenceActivity. See http://stackoverflow.com/a/26614696
      */
     private void setupToolbar() {
-        ViewGroup root = (ViewGroup) findViewById(android.R.id.content);
+        ViewGroup root = findViewById(android.R.id.content);
         LinearLayout content = (LinearLayout) root.getChildAt(0);
         LinearLayout toolbarContainer = (LinearLayout) View.inflate(this, R.layout.preference_toolbar, null);
 
@@ -108,7 +108,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         toolbarContainer.addView(content);
         root.addView(toolbarContainer);
 
-        Toolbar toolbar = (Toolbar) toolbarContainer.findViewById(R.id.toolbar);
+        Toolbar toolbar = toolbarContainer.findViewById(R.id.toolbar);
 
         toolbar.setTitle(R.string.title_preferences);
         // noinspection deprecation, TODO use alternative in API level 21

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
@@ -92,7 +92,7 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
 
         mAdapter = new KeyserverListAdapter(mKeyserversMutable);
 
-        RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.keyserver_recycler_view);
+        RecyclerView recyclerView = view.findViewById(R.id.keyserver_recycler_view);
         // recyclerView.setHasFixedSize(true); // the size of the first item changes
         recyclerView.setAdapter(mAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
@@ -312,11 +312,11 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
 
             public ViewHolder(View itemView) {
                 super(itemView);
-                outerLayout = (ViewGroup) itemView.findViewById(R.id.outer_layout);
-                selectedServerLabel = (TextView) itemView.findViewById(
+                outerLayout = itemView.findViewById(R.id.outer_layout);
+                selectedServerLabel = itemView.findViewById(
                         R.id.selected_keyserver_title);
-                keyserverUrl = (TextView) itemView.findViewById(R.id.keyserver_tv);
-                dragHandleView = (ImageView) itemView.findViewById(R.id.drag_handle);
+                keyserverUrl = itemView.findViewById(R.id.keyserver_tv);
+                dragHandleView = itemView.findViewById(R.id.drag_handle);
 
                 itemView.setClickable(true);
             }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsSmartPGPAuthorityFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsSmartPGPAuthorityFragment.java
@@ -95,7 +95,7 @@ public class SettingsSmartPGPAuthorityFragment extends Fragment implements Recyc
         mAuthorities = new ArrayList<>(authorities);
         mAdapter = new AuthorityListAdapter(mAuthorities);
 
-        RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.smartpgp_authority_recycler_view);
+        RecyclerView recyclerView = view.findViewById(R.id.smartpgp_authority_recycler_view);
         recyclerView.setAdapter(mAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
 
@@ -316,8 +316,8 @@ public class SettingsSmartPGPAuthorityFragment extends Fragment implements Recyc
 
             public ViewHolder(View itemView) {
                 super(itemView);
-                outerLayout = (ViewGroup) itemView.findViewById(R.id.outer_layout);
-                authorityName = (TextView) itemView.findViewById(R.id.smartpgp_authority_tv);
+                outerLayout = itemView.findViewById(R.id.outer_layout);
+                authorityName = itemView.findViewById(R.id.smartpgp_authority_tv);
                 itemView.setClickable(true);
             }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/UploadKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/UploadKeyActivity.java
@@ -59,7 +59,7 @@ public class UploadKeyActivity extends BaseActivity
         super.onCreate(savedInstanceState);
 
         mUploadButton = findViewById(R.id.upload_key_action_upload);
-        mKeyServerSpinner = (Spinner) findViewById(R.id.upload_key_keyserver);
+        mKeyServerSpinner = findViewById(R.id.upload_key_keyserver);
 
         MultiUserIdsFragment mMultiUserIdsFragment = (MultiUserIdsFragment)
                 getSupportFragmentManager().findFragmentById(R.id.multi_user_ids_fragment);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewCertActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewCertActivity.java
@@ -84,15 +84,15 @@ public class ViewCertActivity extends BaseActivity
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
 
-        mSigneeKey = (TextView) findViewById(R.id.signee_key);
-        mSigneeUid = (TextView) findViewById(R.id.signee_uid);
-        mAlgorithm = (TextView) findViewById(R.id.algorithm);
-        mType = (TextView) findViewById(R.id.signature_type);
-        mReason = (TextView) findViewById(R.id.reason);
-        mCreation = (TextView) findViewById(R.id.creation);
+        mSigneeKey = findViewById(R.id.signee_key);
+        mSigneeUid = findViewById(R.id.signee_uid);
+        mAlgorithm = findViewById(R.id.algorithm);
+        mType = findViewById(R.id.signature_type);
+        mReason = findViewById(R.id.reason);
+        mCreation = findViewById(R.id.creation);
 
-        mCertifierKey = (TextView) findViewById(R.id.signer_key_id);
-        mCertifierUid = (TextView) findViewById(R.id.signer_uid);
+        mCertifierKey = findViewById(R.id.signer_key_id);
+        mCertifierUid = findViewById(R.id.signer_uid);
 
         mRowReason = findViewById(R.id.row_reason);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvActivity.java
@@ -90,8 +90,8 @@ public class ViewKeyAdvActivity extends BaseActivity implements
 
         mKeyRepository = KeyRepository.create(this);
 
-        mViewPager = (ViewPager) findViewById(R.id.pager);
-        mSlidingTabLayout = (PagerSlidingTabStrip) findViewById(R.id.sliding_tab_layout);
+        mViewPager = findViewById(R.id.pager);
+        mSlidingTabLayout = findViewById(R.id.sliding_tab_layout);
 
         mDataUri = getIntent().getData();
         if (mDataUri == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvShareFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvShareFragment.java
@@ -93,8 +93,8 @@ public class ViewKeyAdvShareFragment extends LoaderFragment implements
         View root = super.onCreateView(inflater, superContainer, savedInstanceState);
         View view = inflater.inflate(R.layout.view_key_adv_share_fragment, getContainer());
 
-        mFingerprintView = (TextView) view.findViewById(R.id.view_key_fingerprint);
-        mQrCode = (ImageView) view.findViewById(R.id.view_key_qr_code);
+        mFingerprintView = view.findViewById(R.id.view_key_fingerprint);
+        mQrCode = view.findViewById(R.id.view_key_qr_code);
 
         // We cache the QR code bitmap in its smallest possible size, then scale
         // it manually for the correct size whenever the layout of the ImageView
@@ -123,7 +123,7 @@ public class ViewKeyAdvShareFragment extends LoaderFragment implements
                 }
             }
         });
-        mQrCodeLayout = (CardView) view.findViewById(R.id.view_key_qr_code_layout);
+        mQrCodeLayout = view.findViewById(R.id.view_key_qr_code_layout);
         mQrCodeLayout.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -135,7 +135,7 @@ public class ViewKeyAdvShareFragment extends LoaderFragment implements
         View vFingerprintClipboardButton = view.findViewById(R.id.view_key_action_fingerprint_clipboard);
         View vKeyShareButton = view.findViewById(R.id.view_key_action_key_share);
         View vKeyClipboardButton = view.findViewById(R.id.view_key_action_key_clipboard);
-        ImageButton vKeySafeSlingerButton = (ImageButton) view.findViewById(R.id.view_key_action_key_safeslinger);
+        ImageButton vKeySafeSlingerButton = view.findViewById(R.id.view_key_action_key_safeslinger);
         View vKeySshShareButton = view.findViewById(R.id.view_key_action_key_ssh_share);
         View vKeySshClipboardButton = view.findViewById(R.id.view_key_action_key_ssh_clipboard);
         View vKeyUploadButton = view.findViewById(R.id.view_key_action_upload);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvStartFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvStartFragment.java
@@ -37,8 +37,7 @@ public class ViewKeyAdvStartFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.view_key_adv_start_fragment, container, false);
 
-        HtmlTextView textView = (HtmlTextView)
-                view.findViewById(R.id.view_key_adv_start_text);
+        HtmlTextView textView = view.findViewById(R.id.view_key_adv_start_text);
 
         // load markdown from raw resource
         try {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvSubkeysFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvSubkeysFragment.java
@@ -86,8 +86,8 @@ public class ViewKeyAdvSubkeysFragment extends LoaderFragment implements
         View root = super.onCreateView(inflater, superContainer, savedInstanceState);
         View view = inflater.inflate(R.layout.view_key_adv_subkeys_fragment, getContainer());
 
-        mSubkeysList = (ListView) view.findViewById(R.id.view_key_subkeys);
-        mSubkeysAddedList = (ListView) view.findViewById(R.id.view_key_subkeys_added);
+        mSubkeysList = view.findViewById(R.id.view_key_subkeys);
+        mSubkeysAddedList = view.findViewById(R.id.view_key_subkeys_added);
         mSubkeysAddedLayout = view.findViewById(R.id.view_key_subkeys_add_layout);
 
         mSubkeysList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
@@ -108,7 +108,7 @@ public class ViewKeyAdvSubkeysFragment extends LoaderFragment implements
         footer.setLayoutParams(params);
         mSubkeysAddedList.addFooterView(footer, null, false);
 
-        mSubkeyAddFabLayout = (ViewAnimator) view.findViewById(R.id.view_key_subkey_fab_layout);
+        mSubkeyAddFabLayout = view.findViewById(R.id.view_key_subkey_fab_layout);
         view.findViewById(R.id.view_key_subkey_fab).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvUserIdsFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvUserIdsFragment.java
@@ -85,8 +85,8 @@ public class ViewKeyAdvUserIdsFragment extends LoaderFragment implements
         View root = super.onCreateView(inflater, superContainer, savedInstanceState);
         View view = inflater.inflate(R.layout.view_key_adv_user_ids_fragment, getContainer());
 
-        mUserIds = (ListView) view.findViewById(R.id.view_key_user_ids);
-        mUserIdsAddedList = (ListView) view.findViewById(R.id.view_key_user_ids_added);
+        mUserIds = view.findViewById(R.id.view_key_user_ids);
+        mUserIdsAddedList = view.findViewById(R.id.view_key_user_ids_added);
         mUserIdsAddedLayout = view.findViewById(R.id.view_key_user_ids_add_layout);
 
         mUserIds.setOnItemClickListener(new AdapterView.OnItemClickListener() {
@@ -107,7 +107,7 @@ public class ViewKeyAdvUserIdsFragment extends LoaderFragment implements
         footer.setLayoutParams(params);
         mUserIdsAddedList.addFooterView(footer, null, false);
 
-        mUserIdAddFabLayout = (ViewAnimator) view.findViewById(R.id.view_key_subkey_fab_layout);
+        mUserIdAddFabLayout = view.findViewById(R.id.view_key_subkey_fab_layout);
         view.findViewById(R.id.view_key_subkey_fab).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyKeybaseFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyKeybaseFragment.java
@@ -105,10 +105,10 @@ public class ViewKeyKeybaseFragment extends LoaderFragment implements
         View view = inflater.inflate(R.layout.view_key_adv_keybase_fragment, getContainer());
         mInflater = inflater;
 
-        mReportHeader = (TextView) view.findViewById(R.id.view_key_trust_cloud_narrative);
-        mProofListing = (TableLayout) view.findViewById(R.id.view_key_proof_list);
+        mReportHeader = view.findViewById(R.id.view_key_trust_cloud_narrative);
+        mProofListing = view.findViewById(R.id.view_key_proof_list);
         mProofVerifyHeader = view.findViewById(R.id.view_key_proof_verify_header);
-        mProofVerifyDetail = (TextView) view.findViewById(R.id.view_key_proof_verify_detail);
+        mProofVerifyDetail = view.findViewById(R.id.view_key_proof_verify_detail);
         mReportHeader.setVisibility(View.GONE);
         mProofListing.setVisibility(View.GONE);
         mProofVerifyHeader.setVisibility(View.GONE);
@@ -337,8 +337,8 @@ public class ViewKeyKeybaseFragment extends LoaderFragment implements
             int rowNumber = 1;
             for (CharSequence s : result.mProofs) {
                 TableRow row = (TableRow) mInflater.inflate(R.layout.view_key_adv_keybase_proof, null);
-                TextView number = (TextView) row.findViewById(R.id.proof_number);
-                TextView text = (TextView) row.findViewById(R.id.proof_text);
+                TextView number = row.findViewById(R.id.proof_number);
+                TextView text = row.findViewById(R.id.proof_text);
                 number.setText(Integer.toString(rowNumber++) + ". ");
                 text.setText(s);
                 text.setMovementMethod(LinkMovementMethod.getInstance());

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/CertSectionedListAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/CertSectionedListAdapter.java
@@ -97,9 +97,9 @@ public class CertSectionedListAdapter extends SectionCursorAdapter<CertCursor, S
             itemView.setClickable(true);
             itemView.setOnClickListener(this);
 
-            mSignerName = (TextView) itemView.findViewById(R.id.signerName);
-            mSignStatus = (TextView) itemView.findViewById(R.id.signStatus);
-            mSignerKeyId = (TextView) itemView.findViewById(R.id.signerKeyId);
+            mSignerName = itemView.findViewById(R.id.signerName);
+            mSignStatus = itemView.findViewById(R.id.signStatus);
+            mSignerKeyId = itemView.findViewById(R.id.signerKeyId);
         }
 
         public void bind(CertCursor cursor) {
@@ -154,7 +154,7 @@ public class CertSectionedListAdapter extends SectionCursorAdapter<CertCursor, S
 
         public CertSectionViewHolder(View itemView) {
             super(itemView);
-            mHeaderText = (TextView) itemView.findViewById(R.id.stickylist_header_text);
+            mHeaderText = itemView.findViewById(R.id.stickylist_header_text);
         }
 
         public void bind(String text) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/IdentityAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/IdentityAdapter.java
@@ -140,10 +140,10 @@ public class IdentityAdapter extends RecyclerView.Adapter<ViewHolder> {
         public LinkedIdViewHolder(View view, final IdentityClickListener identityClickListener) {
             super(view);
 
-            vVerified = (ImageView) view.findViewById(R.id.linked_id_certified_icon);
-            vIcon = (ImageView) view.findViewById(R.id.linked_id_type_icon);
-            vTitle = (TextView) view.findViewById(R.id.linked_id_title);
-            vComment = (TextView) view.findViewById(R.id.linked_id_comment);
+            vVerified = view.findViewById(R.id.linked_id_certified_icon);
+            vIcon = view.findViewById(R.id.linked_id_type_icon);
+            vTitle = view.findViewById(R.id.linked_id_title);
+            vComment = view.findViewById(R.id.linked_id_comment);
 
             view.setOnClickListener(new OnClickListener() {
                 @Override
@@ -214,12 +214,12 @@ public class IdentityAdapter extends RecyclerView.Adapter<ViewHolder> {
         private UserIdViewHolder(View view, final IdentityClickListener identityClickListener) {
             super(view);
 
-            vName = (TextView) view.findViewById(R.id.user_id_item_name);
-            vAddress = (TextView) view.findViewById(R.id.user_id_item_address);
-            vComment = (TextView) view.findViewById(R.id.user_id_item_comment);
+            vName = view.findViewById(R.id.user_id_item_name);
+            vAddress = view.findViewById(R.id.user_id_item_address);
+            vComment = view.findViewById(R.id.user_id_item_comment);
 
-            vIcon = (ImageView) view.findViewById(R.id.trust_id_app_icon);
-            vMore = (ImageView) view.findViewById(R.id.user_id_item_more);
+            vIcon = view.findViewById(R.id.trust_id_app_icon);
+            vMore = view.findViewById(R.id.user_id_item_more);
 
             view.setOnClickListener(new OnClickListener() {
                 @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeyAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeyAdapter.java
@@ -113,12 +113,12 @@ public class KeyAdapter extends CursorAdapter {
         public KeyItemViewHolder(View view) {
             mView = view;
             mLayoutData = view.findViewById(R.id.key_list_item_data);
-            mMainUserId = (TextView) view.findViewById(R.id.key_list_item_name);
-            mMainUserIdRest = (TextView) view.findViewById(R.id.key_list_item_email);
-            mStatus = (ImageView) view.findViewById(R.id.key_list_item_status_icon);
+            mMainUserId = view.findViewById(R.id.key_list_item_name);
+            mMainUserIdRest = view.findViewById(R.id.key_list_item_email);
+            mStatus = view.findViewById(R.id.key_list_item_status_icon);
             mSlinger = view.findViewById(R.id.key_list_item_slinger_view);
-            mSlingerButton = (ImageButton) view.findViewById(R.id.key_list_item_slinger_button);
-            mCreationDate = (TextView) view.findViewById(R.id.key_list_item_creation);
+            mSlingerButton = view.findViewById(R.id.key_list_item_slinger_button);
+            mCreationDate = view.findViewById(R.id.key_list_item_creation);
         }
 
         public void setData(Context context, KeyItem item, Highlighter highlighter, boolean enabled) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
@@ -363,13 +363,13 @@ public class KeySectionedListAdapter extends SectionCursorAdapter<KeySectionedLi
         KeyItemViewHolder(View itemView) {
             super(itemView);
 
-            mMainUserId = (TextView) itemView.findViewById(R.id.key_list_item_name);
-            mMainUserIdRest = (TextView) itemView.findViewById(R.id.key_list_item_email);
-            mStatus = (ImageView) itemView.findViewById(R.id.key_list_item_status_icon);
+            mMainUserId = itemView.findViewById(R.id.key_list_item_name);
+            mMainUserIdRest = itemView.findViewById(R.id.key_list_item_email);
+            mStatus = itemView.findViewById(R.id.key_list_item_status_icon);
             mSlinger = itemView.findViewById(R.id.key_list_item_slinger_view);
-            mSlingerButton = (ImageButton) itemView.findViewById(R.id.key_list_item_slinger_button);
-            mCreationDate = (TextView) itemView.findViewById(R.id.key_list_item_creation);
-            mTrustIdIcon = (ImageView) itemView.findViewById(R.id.key_list_item_tid_icon);
+            mSlingerButton = itemView.findViewById(R.id.key_list_item_slinger_button);
+            mCreationDate = itemView.findViewById(R.id.key_list_item_creation);
+            mTrustIdIcon = itemView.findViewById(R.id.key_list_item_tid_icon);
 
             itemView.setClickable(true);
             itemView.setLongClickable(true);
@@ -563,7 +563,7 @@ public class KeySectionedListAdapter extends SectionCursorAdapter<KeySectionedLi
 
         public KeyHeaderViewHolder(View itemView) {
             super(itemView);
-            mText1 = (TextView) itemView.findViewById(android.R.id.text1);
+            mText1 = itemView.findViewById(android.R.id.text1);
         }
 
         public void bind(String title) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySelectableAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySelectableAdapter.java
@@ -48,7 +48,7 @@ public class KeySelectableAdapter extends KeyAdapter implements OnItemClickListe
 
         public KeySelectableItemViewHolder(View view) {
             super(view);
-            mCheckbox = (CheckBox) view.findViewById(R.id.selected);
+            mCheckbox = view.findViewById(R.id.selected);
         }
 
         public void setCheckedState(boolean checked) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/MultiUserIdsAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/MultiUserIdsAdapter.java
@@ -75,9 +75,9 @@ public class MultiUserIdsAdapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
-        TextView vHeaderId = (TextView) view.findViewById(R.id.user_id_header);
-        TextView vName = (TextView) view.findViewById(R.id.user_id_item_name);
-        TextView vAddresses = (TextView) view.findViewById(R.id.user_id_item_addresses);
+        TextView vHeaderId = view.findViewById(R.id.user_id_header);
+        TextView vName = view.findViewById(R.id.user_id_item_name);
+        TextView vAddresses = view.findViewById(R.id.user_id_item_addresses);
 
         byte[] data = cursor.getBlob(1);
         int isHeader = cursor.getInt(2);
@@ -135,7 +135,7 @@ public class MultiUserIdsAdapter extends CursorAdapter {
             vAddresses.setVisibility(View.GONE);
         }
 
-        final CheckBox vCheckBox = (CheckBox) view.findViewById(R.id.user_id_item_check_box);
+        final CheckBox vCheckBox = view.findViewById(R.id.user_id_item_check_box);
         final int position = cursor.getPosition();
         vCheckBox.setOnCheckedChangeListener(null);
         vCheckBox.setChecked(mCheckStates.get(position));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/NestedLogAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/NestedLogAdapter.java
@@ -152,8 +152,8 @@ public class NestedLogAdapter extends RecyclerView.Adapter<NestedLogAdapter.LogE
         public LogEntryViewHolder(View itemView) {
             super(itemView);
 
-            mLogText = (TextView) itemView.findViewById(R.id.log_text);
-            mLogImg = (ImageView) itemView.findViewById(R.id.log_img);
+            mLogText = itemView.findViewById(R.id.log_text);
+            mLogImg = itemView.findViewById(R.id.log_img);
         }
 
         public void bind(OperationResult.LogEntryParcel entry, int indentFactor) {
@@ -213,8 +213,8 @@ public class NestedLogAdapter extends RecyclerView.Adapter<NestedLogAdapter.LogE
             itemView.setClickable(true);
             itemView.setOnClickListener(this);
 
-            mSublogText = (TextView) itemView.findViewById(R.id.log_second_text);
-            mSublogImg = (ImageView) itemView.findViewById(R.id.log_second_img);
+            mSublogText = itemView.findViewById(R.id.log_second_text);
+            mSublogImg = itemView.findViewById(R.id.log_second_img);
         }
 
         @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SubkeysAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SubkeysAdapter.java
@@ -152,18 +152,18 @@ public class SubkeysAdapter extends CursorAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
-        TextView vKeyId = (TextView) view.findViewById(R.id.subkey_item_key_id);
-        TextView vKeyDetails = (TextView) view.findViewById(R.id.subkey_item_details);
-        TextView vKeyExpiry = (TextView) view.findViewById(R.id.subkey_item_expiry);
-        ImageView vCertifyIcon = (ImageView) view.findViewById(R.id.subkey_item_ic_certify);
-        ImageView vSignIcon = (ImageView) view.findViewById(R.id.subkey_item_ic_sign);
-        ImageView vEncryptIcon = (ImageView) view.findViewById(R.id.subkey_item_ic_encrypt);
-        ImageView vAuthenticateIcon = (ImageView) view.findViewById(R.id.subkey_item_ic_authenticate);
-        ImageView vEditImage = (ImageView) view.findViewById(R.id.subkey_item_edit_image);
-        ImageView vStatus = (ImageView) view.findViewById(R.id.subkey_item_status);
+        TextView vKeyId = view.findViewById(R.id.subkey_item_key_id);
+        TextView vKeyDetails = view.findViewById(R.id.subkey_item_details);
+        TextView vKeyExpiry = view.findViewById(R.id.subkey_item_expiry);
+        ImageView vCertifyIcon = view.findViewById(R.id.subkey_item_ic_certify);
+        ImageView vSignIcon = view.findViewById(R.id.subkey_item_ic_sign);
+        ImageView vEncryptIcon = view.findViewById(R.id.subkey_item_ic_encrypt);
+        ImageView vAuthenticateIcon = view.findViewById(R.id.subkey_item_ic_authenticate);
+        ImageView vEditImage = view.findViewById(R.id.subkey_item_edit_image);
+        ImageView vStatus = view.findViewById(R.id.subkey_item_status);
 
         // not used:
-        ImageView deleteImage = (ImageView) view.findViewById(R.id.subkey_item_delete_button);
+        ImageView deleteImage = view.findViewById(R.id.subkey_item_delete_button);
         deleteImage.setVisibility(View.GONE);
 
         long keyId = cursor.getLong(INDEX_KEY_ID);
@@ -334,7 +334,7 @@ public class SubkeysAdapter extends CursorAdapter {
     public View newView(Context context, Cursor cursor, ViewGroup parent) {
         View view = mInflater.inflate(R.layout.view_key_adv_subkey_item, null);
         if (mDefaultTextColor == null) {
-            TextView keyId = (TextView) view.findViewById(R.id.subkey_item_key_id);
+            TextView keyId = view.findViewById(R.id.subkey_item_key_id);
             mDefaultTextColor = keyId.getTextColors();
         }
         return view;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SubkeysAddedAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/SubkeysAddedAdapter.java
@@ -73,21 +73,21 @@ public class SubkeysAddedAdapter extends ArrayAdapter<SaveKeyringParcel.SubkeyAd
             // Not recycled, inflate a new view
             convertView = mInflater.inflate(R.layout.view_key_adv_subkey_item, parent, false);
             final ViewHolder holder = new ViewHolder();
-            holder.vKeyId = (TextView) convertView.findViewById(R.id.subkey_item_key_id);
-            holder.vKeyDetails = (TextView) convertView.findViewById(R.id.subkey_item_details);
-            holder.vKeyExpiry = (TextView) convertView.findViewById(R.id.subkey_item_expiry);
-            holder.vCertifyIcon = (ImageView) convertView.findViewById(R.id.subkey_item_ic_certify);
-            holder.vSignIcon = (ImageView) convertView.findViewById(R.id.subkey_item_ic_sign);
-            holder.vEncryptIcon = (ImageView) convertView.findViewById(R.id.subkey_item_ic_encrypt);
-            holder.vAuthenticateIcon = (ImageView) convertView.findViewById(R.id.subkey_item_ic_authenticate);
+            holder.vKeyId = convertView.findViewById(R.id.subkey_item_key_id);
+            holder.vKeyDetails = convertView.findViewById(R.id.subkey_item_details);
+            holder.vKeyExpiry = convertView.findViewById(R.id.subkey_item_expiry);
+            holder.vCertifyIcon = convertView.findViewById(R.id.subkey_item_ic_certify);
+            holder.vSignIcon = convertView.findViewById(R.id.subkey_item_ic_sign);
+            holder.vEncryptIcon = convertView.findViewById(R.id.subkey_item_ic_encrypt);
+            holder.vAuthenticateIcon = convertView.findViewById(R.id.subkey_item_ic_authenticate);
 
-            holder.vDelete = (ImageButton) convertView.findViewById(R.id.subkey_item_delete_button);
+            holder.vDelete = convertView.findViewById(R.id.subkey_item_delete_button);
             holder.vDelete.setVisibility(View.VISIBLE); // always visible
 
             // not used:
-            ImageView vEdit = (ImageView) convertView.findViewById(R.id.subkey_item_edit_image);
+            ImageView vEdit = convertView.findViewById(R.id.subkey_item_edit_image);
             vEdit.setVisibility(View.GONE);
-            ImageView vStatus = (ImageView) convertView.findViewById(R.id.subkey_item_status);
+            ImageView vStatus = convertView.findViewById(R.id.subkey_item_status);
             vStatus.setVisibility(View.GONE);
 
             convertView.setTag(holder);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAdapter.java
@@ -56,13 +56,13 @@ public class UserIdsAdapter extends UserAttributesAdapter {
 
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
-        TextView vName = (TextView) view.findViewById(R.id.user_id_item_name);
-        TextView vAddress = (TextView) view.findViewById(R.id.user_id_item_address);
-        TextView vComment = (TextView) view.findViewById(R.id.user_id_item_comment);
-        ImageView vVerified = (ImageView) view.findViewById(R.id.user_id_item_certified);
-        ViewAnimator vVerifiedLayout = (ViewAnimator) view.findViewById(R.id.user_id_icon_animator);
+        TextView vName = view.findViewById(R.id.user_id_item_name);
+        TextView vAddress = view.findViewById(R.id.user_id_item_address);
+        TextView vComment = view.findViewById(R.id.user_id_item_comment);
+        ImageView vVerified = view.findViewById(R.id.user_id_item_certified);
+        ViewAnimator vVerifiedLayout = view.findViewById(R.id.user_id_icon_animator);
 
-        ImageView vDeleteButton = (ImageView) view.findViewById(R.id.user_id_item_delete_button);
+        ImageView vDeleteButton = view.findViewById(R.id.user_id_item_delete_button);
         vDeleteButton.setVisibility(View.GONE); // not used
 
         String userId = cursor.getString(INDEX_USER_ID);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAddedAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/UserIdsAddedAdapter.java
@@ -66,15 +66,15 @@ public class UserIdsAddedAdapter extends ArrayAdapter<String> {
             // Not recycled, inflate a new view
             convertView = mInflater.inflate(R.layout.view_key_adv_user_id_item, null);
             final ViewHolder holder = new ViewHolder();
-            holder.vAddress = (TextView) convertView.findViewById(R.id.user_id_item_address);
-            holder.vName = (TextView) convertView.findViewById(R.id.user_id_item_name);
-            holder.vComment = (TextView) convertView.findViewById(R.id.user_id_item_comment);
-            holder.vDelete = (ImageButton) convertView.findViewById(R.id.user_id_item_delete_button);
+            holder.vAddress = convertView.findViewById(R.id.user_id_item_address);
+            holder.vName = convertView.findViewById(R.id.user_id_item_name);
+            holder.vComment = convertView.findViewById(R.id.user_id_item_comment);
+            holder.vDelete = convertView.findViewById(R.id.user_id_item_delete_button);
             holder.vDelete.setVisibility(View.VISIBLE); // always visible
 
             // not used:
             View certifiedLayout = convertView.findViewById(R.id.user_id_icon_animator);
-            ImageView editImage = (ImageView) convertView.findViewById(R.id.user_id_item_edit_image);
+            ImageView editImage = convertView.findViewById(R.id.user_id_item_edit_image);
             certifiedLayout.setVisibility(View.GONE);
             editImage.setVisibility(View.GONE);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/BaseActivity.java
@@ -87,7 +87,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     }
 
     protected void initToolbar() {
-        mToolbar = (Toolbar) findViewById(R.id.toolbar);
+        mToolbar = findViewById(R.id.toolbar);
         if (mToolbar != null) {
             setSupportActionBar(mToolbar);
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -121,7 +121,7 @@ public abstract class BaseActivity extends AppCompatActivity {
                 .getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
         final View customActionBarView = inflater.inflate(R.layout.full_screen_dialog, null);
 
-        TextView firstTextView = ((TextView) customActionBarView.findViewById(R.id.full_screen_dialog_done_text));
+        TextView firstTextView = customActionBarView.findViewById(R.id.full_screen_dialog_done_text);
         firstTextView.setText(doneText);
         customActionBarView.findViewById(R.id.full_screen_dialog_done).setOnClickListener(
                 doneOnClickListener);
@@ -174,12 +174,12 @@ public abstract class BaseActivity extends AppCompatActivity {
         final View customActionBarView = inflater.inflate(
                 R.layout.full_screen_dialog_2, null);
 
-        TextView firstTextView = ((TextView) customActionBarView.findViewById(R.id.actionbar_done_text));
+        TextView firstTextView = customActionBarView.findViewById(R.id.actionbar_done_text);
         firstTextView.setText(firstText);
         firstTextView.setCompoundDrawablesWithIntrinsicBounds(firstDrawableId, 0, 0, 0);
         customActionBarView.findViewById(R.id.actionbar_done).setOnClickListener(
                 firstOnClickListener);
-        TextView secondTextView = ((TextView) customActionBarView.findViewById(R.id.actionbar_cancel_text));
+        TextView secondTextView = customActionBarView.findViewById(R.id.actionbar_cancel_text);
         secondTextView.setText(secondText);
         secondTextView.setCompoundDrawablesWithIntrinsicBounds(secondDrawableId, 0, 0, 0);
         customActionBarView.findViewById(R.id.actionbar_cancel).setOnClickListener(

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/LoaderFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/LoaderFragment.java
@@ -45,7 +45,7 @@ public abstract class LoaderFragment extends Fragment {
         View root = inflater.inflate(R.layout.loader_layout, container, false);
 
         mContentShown = true;
-        mContainer = (ViewGroup) root.findViewById(R.id.loader_container);
+        mContainer = root.findViewById(R.id.loader_container);
         mProgressContainer = root.findViewById(R.id.loader_progress);
 
         // content is not shown (by visibility statuses in the layout files)

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddEditKeyserverDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddEditKeyserverDialogFragment.java
@@ -129,12 +129,12 @@ public class AddEditKeyserverDialogFragment extends DialogFragment implements On
         View view = inflater.inflate(R.layout.add_keyserver_dialog, null);
         alert.setView(view);
 
-        mKeyserverEditText = (EditText) view.findViewById(R.id.keyserver_url_edit_text);
-        mKeyserverEditTextLayout = (TextInputLayout) view.findViewById(R.id.keyserver_url_edit_text_layout);
-        mKeyserverEditOnionText = (EditText) view.findViewById(R.id.keyserver_onion_edit_text);
-        mKeyserverEditOnionTextLayout = (TextInputLayout) view.findViewById(R.id.keyserver_onion_edit_text_layout);
-        mVerifyKeyserverCheckBox = (CheckBox) view.findViewById(R.id.verify_connection_checkbox);
-        mOnlyTrustedKeyserverCheckBox = (CheckBox) view.findViewById(R.id.only_trusted_keyserver_checkbox);
+        mKeyserverEditText = view.findViewById(R.id.keyserver_url_edit_text);
+        mKeyserverEditTextLayout = view.findViewById(R.id.keyserver_url_edit_text_layout);
+        mKeyserverEditOnionText = view.findViewById(R.id.keyserver_onion_edit_text);
+        mKeyserverEditOnionTextLayout = view.findViewById(R.id.keyserver_onion_edit_text_layout);
+        mVerifyKeyserverCheckBox = view.findViewById(R.id.verify_connection_checkbox);
+        mOnlyTrustedKeyserverCheckBox = view.findViewById(R.id.only_trusted_keyserver_checkbox);
         mVerifyKeyserverCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddEditSmartPGPAuthorityDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddEditSmartPGPAuthorityDialogFragment.java
@@ -114,9 +114,9 @@ public class AddEditSmartPGPAuthorityDialogFragment extends DialogFragment imple
         View view = inflater.inflate(R.layout.add_smartpgp_authority_dialog, null);
         alert.setView(view);
 
-        mAuthorityAliasText = (EditText) view.findViewById(R.id.smartpgp_authority_alias_edit_text);
-        mAuthorityAliasTextLayout = (TextInputLayout) view.findViewById(R.id.smartpgp_authority_alias_edit_text_layout);
-        mAuthorityAdd = (Button) view.findViewById(R.id.smartpgp_authority_filename);
+        mAuthorityAliasText = view.findViewById(R.id.smartpgp_authority_alias_edit_text);
+        mAuthorityAliasTextLayout = view.findViewById(R.id.smartpgp_authority_alias_edit_text_layout);
+        mAuthorityAdd = view.findViewById(R.id.smartpgp_authority_filename);
 
         mAuthorityAdd.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddEmailDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddEmailDialogFragment.java
@@ -79,7 +79,7 @@ public class AddEmailDialogFragment extends DialogFragment implements OnEditorAc
         View view = inflater.inflate(R.layout.add_email_dialog, null);
         alert.setView(view);
 
-        mEmail = (EmailEditText) view.findViewById(R.id.add_email_address);
+        mEmail = view.findViewById(R.id.add_email_address);
 
         alert.setPositiveButton(android.R.string.ok, new OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
@@ -113,16 +113,16 @@ public class AddSubkeyDialogFragment extends DialogFragment {
         View view = mInflater.inflate(R.layout.add_subkey_dialog, null);
         dialog.setView(view);
 
-        mNoExpiryCheckBox = (CheckBox) view.findViewById(R.id.add_subkey_no_expiry);
-        mExpiryRow = (TableRow) view.findViewById(R.id.add_subkey_expiry_row);
-        mExpiryDatePicker = (DatePicker) view.findViewById(R.id.add_subkey_expiry_date_picker);
-        mKeyTypeSpinner = (Spinner) view.findViewById(R.id.add_subkey_type);
-        mUsageRadioGroup = (RadioGroup) view.findViewById(R.id.add_subkey_usage_group);
-        mUsageNone = (RadioButton) view.findViewById(R.id.add_subkey_usage_none);
-        mUsageSign = (RadioButton) view.findViewById(R.id.add_subkey_usage_sign);
-        mUsageEncrypt = (RadioButton) view.findViewById(R.id.add_subkey_usage_encrypt);
-        mUsageSignAndEncrypt = (RadioButton) view.findViewById(R.id.add_subkey_usage_sign_and_encrypt);
-        mUsageAuthentication = (RadioButton) view.findViewById(R.id.add_subkey_usage_authentication);
+        mNoExpiryCheckBox = view.findViewById(R.id.add_subkey_no_expiry);
+        mExpiryRow = view.findViewById(R.id.add_subkey_expiry_row);
+        mExpiryDatePicker = view.findViewById(R.id.add_subkey_expiry_date_picker);
+        mKeyTypeSpinner = view.findViewById(R.id.add_subkey_type);
+        mUsageRadioGroup = view.findViewById(R.id.add_subkey_usage_group);
+        mUsageNone = view.findViewById(R.id.add_subkey_usage_none);
+        mUsageSign = view.findViewById(R.id.add_subkey_usage_sign);
+        mUsageEncrypt = view.findViewById(R.id.add_subkey_usage_encrypt);
+        mUsageSignAndEncrypt = view.findViewById(R.id.add_subkey_usage_sign_and_encrypt);
+        mUsageAuthentication = view.findViewById(R.id.add_subkey_usage_authentication);
 
         if(mWillBeMasterKey) {
             dialog.setTitle(R.string.title_change_master_key);
@@ -351,8 +351,8 @@ public class AddSubkeyDialogFragment extends DialogFragment {
 
             Choice c = this.getItem(position);
 
-            TextView text1 = (TextView) convertView.findViewById(android.R.id.text1);
-            TextView text2 = (TextView) convertView.findViewById(android.R.id.text2);
+            TextView text1 = convertView.findViewById(android.R.id.text1);
+            TextView text2 = convertView.findViewById(android.R.id.text2);
 
             text1.setText(c.getName());
             text2.setText(Html.fromHtml(c.getDescription()));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddUserIdDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddUserIdDialogFragment.java
@@ -86,8 +86,8 @@ public class AddUserIdDialogFragment extends DialogFragment implements OnEditorA
         View view = inflater.inflate(R.layout.add_user_id_dialog, null);
         alert.setView(view);
 
-        mName = (NameEditText) view.findViewById(R.id.add_user_id_name);
-        mEmail = (EmailEditText) view.findViewById(R.id.add_user_id_address);
+        mName = view.findViewById(R.id.add_user_id_name);
+        mEmail = view.findViewById(R.id.add_user_id_address);
 
         mName.setText(predefinedName);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/DeleteFileDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/DeleteFileDialogFragment.java
@@ -166,7 +166,7 @@ public class DeleteFileDialogFragment extends DialogFragment {
      */
     public interface OnDeletedListener {
 
-        public void onDeleted();
+        void onDeleted();
 
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/EditSubkeyExpiryDialogFragment.java
@@ -101,10 +101,10 @@ public class EditSubkeyExpiryDialogFragment extends DialogFragment {
         View view = inflater.inflate(R.layout.edit_subkey_expiry_dialog, null);
         alert.setView(view);
 
-        final CheckBox noExpiry = (CheckBox) view.findViewById(R.id.edit_subkey_expiry_no_expiry);
-        final DatePicker datePicker = (DatePicker) view.findViewById(R.id.edit_subkey_expiry_date_picker);
-        final TextView currentExpiry = (TextView) view.findViewById(R.id.edit_subkey_expiry_current_expiry);
-        final LinearLayout expiryLayout = (LinearLayout) view.findViewById(R.id.edit_subkey_expiry_layout);
+        final CheckBox noExpiry = view.findViewById(R.id.edit_subkey_expiry_no_expiry);
+        final DatePicker datePicker = view.findViewById(R.id.edit_subkey_expiry_date_picker);
+        final TextView currentExpiry = view.findViewById(R.id.edit_subkey_expiry_current_expiry);
+        final LinearLayout expiryLayout = view.findViewById(R.id.edit_subkey_expiry_layout);
 
         noExpiry.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/SetPassphraseDialogFragment.java
@@ -95,9 +95,9 @@ public class SetPassphraseDialogFragment extends DialogFragment implements OnEdi
         View view = inflater.inflate(R.layout.passphrase_repeat_dialog, null);
         alert.setView(view);
 
-        mPassphraseEditText = (PassphraseEditText) view.findViewById(R.id.passphrase_passphrase);
-        mPassphraseAgainEditText = (EditText) view.findViewById(R.id.passphrase_passphrase_again);
-        mNoPassphraseCheckBox = (CheckBox) view.findViewById(R.id.passphrase_no_passphrase);
+        mPassphraseEditText = view.findViewById(R.id.passphrase_passphrase);
+        mPassphraseAgainEditText = view.findViewById(R.id.passphrase_passphrase_again);
+        mNoPassphraseCheckBox = view.findViewById(R.id.passphrase_no_passphrase);
 
         mNoPassphraseCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/LinkedIdViewFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/LinkedIdViewFragment.java
@@ -270,10 +270,10 @@ public class LinkedIdViewFragment extends CryptoOperationFragment implements
         private final TextSwitcher vText;
 
         ViewHolder(View root) {
-            vLinkedCerts = (CertListWidget) root.findViewById(R.id.linked_id_certs);
-            vKeySpinner = (CertifyKeySpinner) root.findViewById(R.id.cert_key_spinner);
+            vLinkedCerts = root.findViewById(R.id.linked_id_certs);
+            vKeySpinner = root.findViewById(R.id.cert_key_spinner);
             vKeySpinnerContainer = root.findViewById(R.id.cert_key_spincontainer);
-            vButtonSwitcher = (ViewAnimator) root.findViewById(R.id.button_animator);
+            vButtonSwitcher = root.findViewById(R.id.button_animator);
 
             mLinkedIdHolder = new IdentityAdapter.LinkedIdViewHolder(root, null);
 
@@ -282,11 +282,11 @@ public class LinkedIdViewFragment extends CryptoOperationFragment implements
             vButtonConfirm = root.findViewById(R.id.button_confirm);
             vButtonView = root.findViewById(R.id.button_view);
 
-            vVerifyingContainer = (ViewAnimator) root.findViewById(R.id.linked_verify_container);
-            vItemCertified = (ViewAnimator) root.findViewById(R.id.linked_id_certified);
+            vVerifyingContainer = root.findViewById(R.id.linked_verify_container);
+            vItemCertified = root.findViewById(R.id.linked_id_certified);
 
-            vProgress = (ViewAnimator) root.findViewById(R.id.linked_cert_progress);
-            vText = (TextSwitcher) root.findViewById(R.id.linked_cert_text);
+            vProgress = root.findViewById(R.id.linked_cert_progress);
+            vText = root.findViewById(R.id.linked_cert_text);
         }
 
         enum VerifyState {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/ViewKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/ViewKeyActivity.java
@@ -180,18 +180,18 @@ public class ViewKeyActivity extends BaseSecurityTokenActivity implements
 
         setTitle(null);
 
-        mStatusText = (TextView) findViewById(R.id.view_key_status);
-        mStatusImage = (ImageView) findViewById(R.id.view_key_status_image);
-        mAppBarLayout = (AppBarLayout) findViewById(R.id.app_bar_layout);
-        mCollapsingToolbarLayout = (CollapsingToolbarLayout) findViewById(R.id.collapsing_toolbar);
+        mStatusText = findViewById(R.id.view_key_status);
+        mStatusImage = findViewById(R.id.view_key_status_image);
+        mAppBarLayout = findViewById(R.id.app_bar_layout);
+        mCollapsingToolbarLayout = findViewById(R.id.collapsing_toolbar);
 
-        mActionEncryptFile = (ImageButton) findViewById(R.id.view_key_action_encrypt_files);
-        mActionEncryptText = (ImageButton) findViewById(R.id.view_key_action_encrypt_text);
-        mFab = (FloatingActionButton) findViewById(R.id.fab);
-        mPhoto = (ImageView) findViewById(R.id.view_key_photo);
-        mPhotoLayout = (FrameLayout) findViewById(R.id.view_key_photo_layout);
-        mQrCode = (ImageView) findViewById(R.id.view_key_qr_code);
-        mQrCodeLayout = (CardView) findViewById(R.id.view_key_qr_code_layout);
+        mActionEncryptFile = findViewById(R.id.view_key_action_encrypt_files);
+        mActionEncryptText = findViewById(R.id.view_key_action_encrypt_text);
+        mFab = findViewById(R.id.fab);
+        mPhoto = findViewById(R.id.view_key_photo);
+        mPhotoLayout = findViewById(R.id.view_key_photo_layout);
+        mQrCode = findViewById(R.id.view_key_qr_code);
+        mQrCodeLayout = findViewById(R.id.view_key_qr_code_layout);
 
         mRotateSpin = AnimationUtils.loadAnimation(this, R.anim.rotate_spin);
 
@@ -436,7 +436,7 @@ public class ViewKeyActivity extends BaseSecurityTokenActivity implements
                     // use new passphrase!
                     mChangeUnlockParcel = ChangeUnlockParcel.createChangeUnlockParcel(
                             mMasterKeyId, mFingerprint,
-                            (Passphrase) data.getParcelable(SetPassphraseDialogFragment.MESSAGE_NEW_PASSPHRASE)
+                            data.getParcelable(SetPassphraseDialogFragment.MESSAGE_NEW_PASSPHRASE)
                     );
 
                     mEditOpHelper.cryptoOperation();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/ViewKeyFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/ViewKeyFragment.java
@@ -91,11 +91,11 @@ public class ViewKeyFragment extends LoaderFragment implements ViewKeyMvpView, O
         View root = super.onCreateView(inflater, superContainer, savedInstanceState);
         View view = inflater.inflate(R.layout.view_key_fragment, getContainer());
 
-        mIdentitiesCardView = (IdentitiesCardView) view.findViewById(R.id.card_identities);
+        mIdentitiesCardView = view.findViewById(R.id.card_identities);
 
-        mSystemContactCard = (SystemContactCardView) view.findViewById(R.id.linked_system_contact_card);
-        mKeyStatusHealth = (KeyHealthView) view.findViewById(R.id.key_status_health);
-        mKeyStatusKeyserver = (KeyserverStatusView) view.findViewById(R.id.key_status_keyserver);
+        mSystemContactCard = view.findViewById(R.id.linked_system_contact_card);
+        mKeyStatusHealth = view.findViewById(R.id.key_status_health);
+        mKeyStatusKeyserver = view.findViewById(R.id.key_status_keyserver);
 
         return root;
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/IdentitiesCardView.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/IdentitiesCardView.java
@@ -46,11 +46,11 @@ public class IdentitiesCardView extends CardView implements IdentitiesMvpView {
 
         View view = LayoutInflater.from(context).inflate(R.layout.identities_card, this, true);
 
-        vIdentities = (RecyclerView) view.findViewById(R.id.view_key_user_ids);
+        vIdentities = view.findViewById(R.id.view_key_user_ids);
         vIdentities.setLayoutManager(new LinearLayoutManager(context));
         vIdentities.addItemDecoration(new DividerItemDecoration(context, DividerItemDecoration.VERTICAL_LIST, false));
 
-        userIdsEditButton = (Button) view.findViewById(R.id.view_key_card_user_ids_edit);
+        userIdsEditButton = view.findViewById(R.id.view_key_card_user_ids_edit);
         userIdsEditButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -60,7 +60,7 @@ public class IdentitiesCardView extends CardView implements IdentitiesMvpView {
             }
         });
 
-        linkedIdsAddButton = (Button) view.findViewById(R.id.view_key_card_linked_ids_add);
+        linkedIdsAddButton = view.findViewById(R.id.view_key_card_linked_ids_add);
         linkedIdsAddButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/KeyHealthView.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/KeyHealthView.java
@@ -69,22 +69,22 @@ public class KeyHealthView extends LinearLayout implements KeyHealthMvpView, OnC
         View view = LayoutInflater.from(context).inflate(R.layout.key_health_card_content, this, true);
 
         vLayout = view.findViewById(R.id.key_health_layout);
-        vTitle = (TextView) view.findViewById(R.id.key_health_title);
-        vSubtitle = (TextView) view.findViewById(R.id.key_health_subtitle);
-        vIcon = (ImageView) view.findViewById(R.id.key_health_icon);
-        vExpander = (ImageView) view.findViewById(R.id.key_health_expander);
+        vTitle = view.findViewById(R.id.key_health_title);
+        vSubtitle = view.findViewById(R.id.key_health_subtitle);
+        vIcon = view.findViewById(R.id.key_health_icon);
+        vExpander = view.findViewById(R.id.key_health_expander);
 
         vLayout.setOnClickListener(this);
 
         vKeyStatusDivider = view.findViewById(R.id.key_health_divider);
-        vKeyStatusList = (KeyStatusList) view.findViewById(R.id.key_health_status_list);
+        vKeyStatusList = view.findViewById(R.id.key_health_status_list);
 
         vInsecureLayout = view.findViewById(R.id.key_insecure_layout);
-        vInsecureProblem = (TextView) view.findViewById(R.id.key_insecure_problem);
-        vInsecureSolution = (TextView) view.findViewById(R.id.key_insecure_solution);
+        vInsecureProblem = view.findViewById(R.id.key_insecure_problem);
+        vInsecureSolution = view.findViewById(R.id.key_insecure_solution);
 
         vExpiryLayout = view.findViewById(R.id.key_expiry_layout);
-        vExpiryText = (TextView) view.findViewById(R.id.key_expiry_text);
+        vExpiryText = view.findViewById(R.id.key_expiry_text);
     }
 
     private enum KeyHealthDisplayStatus {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/KeyStatusList.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/KeyStatusList.java
@@ -50,13 +50,13 @@ public class KeyStatusList extends LinearLayout implements KeyStatusMvpView {
         vSignLayout = view.findViewById(R.id.cap_sign);
         vDecryptLayout = view.findViewById(R.id.cap_decrypt);
 
-        vCertText = (TextView) view.findViewById(R.id.cap_cert_text);
-        vSignText = (TextView) view.findViewById(R.id.cap_sign_text);
-        vDecryptText = (TextView) view.findViewById(R.id.cap_decrypt_text);
+        vCertText = view.findViewById(R.id.cap_cert_text);
+        vSignText = view.findViewById(R.id.cap_sign_text);
+        vDecryptText = view.findViewById(R.id.cap_decrypt_text);
 
-        vCertIcon = (ImageView) view.findViewById(R.id.cap_cert_icon);
-        vSignIcon = (ImageView) view.findViewById(R.id.cap_sign_icon);
-        vDecryptIcon = (ImageView) view.findViewById(R.id.cap_decrypt_icon);
+        vCertIcon = view.findViewById(R.id.cap_cert_icon);
+        vSignIcon = view.findViewById(R.id.cap_sign_icon);
+        vDecryptIcon = view.findViewById(R.id.cap_decrypt_icon);
 
         vCertToken = view.findViewById(R.id.cap_cert_security_token);
         vSignToken = view.findViewById(R.id.cap_sign_security_token);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/KeyserverStatusView.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/KeyserverStatusView.java
@@ -50,9 +50,9 @@ public class KeyserverStatusView extends FrameLayout implements KeyserverStatusM
 
         vLayout = view.findViewById(R.id.keyserver_status_layout);
 
-        vTitle = (TextView) view.findViewById(R.id.keyserver_status_title);
-        vSubtitle = (TextView) view.findViewById(R.id.keyserver_status_subtitle);
-        vIcon = (ImageView) view.findViewById(R.id.keyserver_icon);
+        vTitle = view.findViewById(R.id.keyserver_status_title);
+        vSubtitle = view.findViewById(R.id.keyserver_status_subtitle);
+        vIcon = view.findViewById(R.id.keyserver_icon);
 //        vExpander = (ImageView) view.findViewById(R.id.key_health_expander);
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/SystemContactCardView.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/view/SystemContactCardView.java
@@ -46,9 +46,9 @@ public class SystemContactCardView extends CardView implements SystemContactMvpV
 
         View view = LayoutInflater.from(context).inflate(R.layout.system_contact_card, this, true);
 
-        vSystemContactLayout = (LinearLayout) view.findViewById(R.id.system_contact_layout);
-        vSystemContactName = (TextView) view.findViewById(R.id.system_contact_name);
-        vSystemContactPicture = (ImageView) view.findViewById(R.id.system_contact_picture);
+        vSystemContactLayout = view.findViewById(R.id.system_contact_layout);
+        vSystemContactName = view.findViewById(R.id.system_contact_name);
+        vSystemContactPicture = view.findViewById(R.id.system_contact_picture);
 
         vSystemContactLayout.setOnClickListener(this);
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateFinalFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateFinalFragment.java
@@ -85,10 +85,10 @@ public abstract class LinkedIdCreateFinalFragment extends CryptoOperationFragmen
             }
         });
 
-        mVerifyAnimator = (ViewAnimator) view.findViewById(R.id.verify_progress);
-        mVerifyImage = (ImageView) view.findViewById(R.id.verify_image);
-        mVerifyStatus = (TextView) view.findViewById(R.id.verify_status);
-        mVerifyButtonAnimator = (ViewAnimator) view.findViewById(R.id.verify_buttons);
+        mVerifyAnimator = view.findViewById(R.id.verify_progress);
+        mVerifyImage = view.findViewById(R.id.verify_image);
+        mVerifyStatus = view.findViewById(R.id.verify_status);
+        mVerifyButtonAnimator = view.findViewById(R.id.verify_buttons);
 
         view.findViewById(R.id.button_verify).setOnClickListener(new OnClickListener() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateGithubFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateGithubFragment.java
@@ -112,18 +112,18 @@ public class LinkedIdCreateGithubFragment extends CryptoOperationFragment<SaveKe
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.linked_create_github_fragment, container, false);
 
-        mButtonContainer = (ViewAnimator) view.findViewById(R.id.button_container);
+        mButtonContainer = view.findViewById(R.id.button_container);
 
-        mStatus1 = (StatusIndicator) view.findViewById(R.id.linked_status_step1);
-        mStatus2 = (StatusIndicator) view.findViewById(R.id.linked_status_step2);
-        mStatus3 = (StatusIndicator) view.findViewById(R.id.linked_status_step3);
+        mStatus1 = view.findViewById(R.id.linked_status_step1);
+        mStatus2 = view.findViewById(R.id.linked_status_step2);
+        mStatus3 = view.findViewById(R.id.linked_status_step3);
 
-        mRetryButton = (Button) view.findViewById(R.id.button_retry);
+        mRetryButton = view.findViewById(R.id.button_retry);
 
         ((ImageView) view.findViewById(R.id.linked_id_type_icon)).setImageResource(R.drawable.linked_github);
         ((ImageView) view.findViewById(R.id.linked_id_certified_icon)).setImageResource(R.drawable.octo_link_24dp);
-        mLinkedIdTitle = (TextView) view.findViewById(R.id.linked_id_title);
-        mLinkedIdComment = (TextView) view.findViewById(R.id.linked_id_comment);
+        mLinkedIdTitle = view.findViewById(R.id.linked_id_title);
+        mLinkedIdComment = view.findViewById(R.id.linked_id_comment);
 
         view.findViewById(R.id.back_button).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -535,7 +535,7 @@ public class LinkedIdCreateGithubFragment extends CryptoOperationFragment<SaveKe
 
         final Dialog auth_dialog = new Dialog(activity);
         auth_dialog.setContentView(R.layout.oauth_webview);
-        WebView web = (WebView) auth_dialog.findViewById(R.id.web_view);
+        WebView web = auth_dialog.findViewById(R.id.web_view);
         web.getSettings().setSaveFormData(false);
         web.getSettings().setJavaScriptEnabled(true);
         web.getSettings().setUserAgentString("OpenKeychain " + BuildConfig.VERSION_NAME);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateHttpsStep1Fragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateHttpsStep1Fragment.java
@@ -86,7 +86,7 @@ public class LinkedIdCreateHttpsStep1Fragment extends Fragment {
             }
         });
 
-        mEditUri = (EditText) view.findViewById(R.id.linked_create_https_uri);
+        mEditUri = view.findViewById(R.id.linked_create_https_uri);
 
         mEditUri.addTextChangedListener(new TextWatcher() {
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateHttpsStep2Fragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateHttpsStep2Fragment.java
@@ -108,7 +108,7 @@ public class LinkedIdCreateHttpsStep2Fragment extends LinkedIdCreateFinalFragmen
                 }
             });
 
-            mEditUri = (EditText) view.findViewById(R.id.linked_create_https_uri);
+            mEditUri = view.findViewById(R.id.linked_create_https_uri);
             mEditUri.setText(mResourceUri.toString());
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateTwitterStep1Fragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/linked/LinkedIdCreateTwitterStep1Fragment.java
@@ -110,7 +110,7 @@ public class LinkedIdCreateTwitterStep1Fragment extends Fragment {
             }
         });
 
-        mEditHandle = (EditText) view.findViewById(R.id.linked_create_twitter_handle);
+        mEditHandle = view.findViewById(R.id.linked_create_twitter_handle);
 
         return view;
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ChangePinDialogHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ChangePinDialogHelper.java
@@ -43,9 +43,9 @@ class ChangePinDialogHelper {
 
         @SuppressLint("InflateParams") // it's a dialog, no root element
         View view = LayoutInflater.from(themedContext).inflate(R.layout.admin_pin_dialog, null, false);
-        final EditText adminPin = (EditText) view.findViewById(R.id.admin_pin_current);
-        final EditText newPin = (EditText) view.findViewById(R.id.pin_new);
-        final EditText newPinRepeat = (EditText) view.findViewById(R.id.pin_new_repeat);
+        final EditText adminPin = view.findViewById(R.id.admin_pin_current);
+        final EditText newPin = view.findViewById(R.id.pin_new);
+        final EditText newPinRepeat = view.findViewById(R.id.pin_new_repeat);
 
         AlertDialog dialog = new Builder(themedContext)
                 .setView(view)

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ManageSecurityTokenFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ManageSecurityTokenFragment.java
@@ -117,9 +117,9 @@ public class ManageSecurityTokenFragment extends Fragment implements ManageSecur
         this.layoutInflater = inflater;
         View view = inflater.inflate(R.layout.create_security_token_import_fragment, container, false);
 
-        statusLayoutGroup = (ViewGroup) view.findViewById(R.id.status_indicator_layout);
-        actionAnimator = (ToolableViewAnimator) view.findViewById(R.id.action_animator);
-        unlockSubtitle = (TextView) view.findViewById(R.id.button_unlock_subtitle);
+        statusLayoutGroup = view.findViewById(R.id.status_indicator_layout);
+        actionAnimator = view.findViewById(R.id.action_animator);
+        unlockSubtitle = view.findViewById(R.id.button_unlock_subtitle);
 
         view.findViewById(R.id.button_import).setOnClickListener(this);
         view.findViewById(R.id.button_view_key).setOnClickListener(this);
@@ -204,9 +204,9 @@ public class ManageSecurityTokenFragment extends Fragment implements ManageSecur
 
         View line = layoutInflater.inflate(R.layout.status_indicator_line, statusLayoutGroup, false);
 
-        latestStatusIndicator = (StatusIndicator) line.findViewById(R.id.status_indicator);
+        latestStatusIndicator = line.findViewById(R.id.status_indicator);
         latestStatusIndicator.setDisplayedChild(Status.PROGRESS);
-        TextView latestStatusText = (TextView) line.findViewById(R.id.status_text);
+        TextView latestStatusText = line.findViewById(R.id.status_text);
         latestStatusText.setText(statusLine.stringRes);
 
         statusLayoutGroup.addView(line);
@@ -401,7 +401,7 @@ public class ManageSecurityTokenFragment extends Fragment implements ManageSecur
             }
             case REQUEST_CODE_RESET: {
                 SecurityTokenInfo tokenInfo = data == null ? null :
-                        data.<SecurityTokenInfo>getParcelableExtra(SecurityTokenOperationActivity.RESULT_TOKEN_INFO);
+                        data.getParcelableExtra(SecurityTokenOperationActivity.RESULT_TOKEN_INFO);
                 if (resultCode == Activity.RESULT_OK) {
                     presenter.onSecurityTokenResetSuccess(tokenInfo);
                 } else {
@@ -411,7 +411,7 @@ public class ManageSecurityTokenFragment extends Fragment implements ManageSecur
             }
             case REQUEST_CODE_CHANGE_PIN: {
                 SecurityTokenInfo tokenInfo = data == null ? null :
-                        data.<SecurityTokenInfo>getParcelableExtra(SecurityTokenOperationActivity.RESULT_TOKEN_INFO);
+                        data.getParcelableExtra(SecurityTokenOperationActivity.RESULT_TOKEN_INFO);
                 if (resultCode == Activity.RESULT_OK) {
                     presenter.onSecurityTokenChangePinSuccess(tokenInfo);
                 } else {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ManageSecurityTokenPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ManageSecurityTokenPresenter.java
@@ -242,7 +242,7 @@ class ManageSecurityTokenPresenter implements ManageSecurityTokenMvpPresenter {
                     return new KeyserverRetrievalLoader(context, tokenInfo.getFingerprints());
                 case LOADER_CONTENT_URI:
                     return new ContentUriRetrievalLoader(context, tokenInfo.getFingerprints(),
-                            args.<Uri>getParcelable(ARG_CONTENT_URI));
+                            args.getParcelable(ARG_CONTENT_URI));
             }
             throw new IllegalArgumentException("called with unknown loader id!");
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/transfer/view/ReceivedSecretKeyList.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/transfer/view/ReceivedSecretKeyList.java
@@ -137,12 +137,12 @@ public class ReceivedSecretKeyList extends RecyclerView {
         ReceivedKeyViewHolder(View itemView) {
             super(itemView);
 
-            vName = (TextView) itemView.findViewById(R.id.key_list_item_name);
-            vEmail = (TextView) itemView.findViewById(R.id.key_list_item_email);
-            vCreation = (TextView) itemView.findViewById(R.id.key_list_item_creation);
+            vName = itemView.findViewById(R.id.key_list_item_name);
+            vEmail = itemView.findViewById(R.id.key_list_item_email);
+            vCreation = itemView.findViewById(R.id.key_list_item_creation);
 
             vImportButton = itemView.findViewById(R.id.button_import);
-            vState = (ViewAnimator) itemView.findViewById(R.id.transfer_state);
+            vState = itemView.findViewById(R.id.transfer_state);
         }
 
         private void bind(Context context, final ReceivedKeyItem item,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/transfer/view/TransferFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/transfer/view/TransferFragment.java
@@ -109,18 +109,18 @@ public class TransferFragment extends Fragment implements TransferMvpView {
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.transfer_fragment, container, false);
 
-        vTransferAnimator = (ToolableViewAnimator) view.findViewById(R.id.transfer_animator);
+        vTransferAnimator = view.findViewById(R.id.transfer_animator);
 
-        vConnectionStatusText1 = (TextView) view.findViewById(R.id.connection_status_1);
-        vConnectionStatusText2 = (TextView) view.findViewById(R.id.connection_status_2);
-        vConnectionStatusView1 = (ConnectionStatusView) view.findViewById(R.id.connection_status_icon_1);
-        vConnectionStatusView2 = (ConnectionStatusView) view.findViewById(R.id.connection_status_icon_2);
-        vTransferKeyList = (RecyclerView) view.findViewById(R.id.transfer_key_list);
+        vConnectionStatusText1 = view.findViewById(R.id.connection_status_1);
+        vConnectionStatusText2 = view.findViewById(R.id.connection_status_2);
+        vConnectionStatusView1 = view.findViewById(R.id.connection_status_icon_1);
+        vConnectionStatusView2 = view.findViewById(R.id.connection_status_icon_2);
+        vTransferKeyList = view.findViewById(R.id.transfer_key_list);
         vTransferKeyListEmptyView = view.findViewById(R.id.transfer_key_list_empty);
-        vReceivedKeyList = (RecyclerView) view.findViewById(R.id.received_key_list);
-        vWifiErrorInstructions = (TextView) view.findViewById(R.id.transfer_wifi_error_instructions);
+        vReceivedKeyList = view.findViewById(R.id.received_key_list);
+        vWifiErrorInstructions = view.findViewById(R.id.transfer_wifi_error_instructions);
 
-        vQrCodeImage = (ImageView) view.findViewById(R.id.qr_code_image);
+        vQrCodeImage = view.findViewById(R.id.qr_code_image);
 
         view.findViewById(R.id.button_scan).setOnClickListener(new OnClickListener() {
             @Override
@@ -157,7 +157,7 @@ public class TransferFragment extends Fragment implements TransferMvpView {
 
         Intent activityIntent = getActivity().getIntent();
         if (activityIntent != null && activityIntent.hasExtra(EXTRA_OPENPGP_SKT_INFO)) {
-            presenter.onUiInitFromIntentUri(activityIntent.<Uri>getParcelableExtra(EXTRA_OPENPGP_SKT_INFO));
+            presenter.onUiInitFromIntentUri(activityIntent.getParcelableExtra(EXTRA_OPENPGP_SKT_INFO));
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/transfer/view/TransferSecretKeyList.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/transfer/view/TransferSecretKeyList.java
@@ -149,12 +149,12 @@ public class TransferSecretKeyList extends RecyclerView {
         TransferKeyViewHolder(View itemView) {
             super(itemView);
 
-            vName = (TextView) itemView.findViewById(R.id.key_list_item_name);
-            vEmail = (TextView) itemView.findViewById(R.id.key_list_item_email);
-            vCreation = (TextView) itemView.findViewById(R.id.key_list_item_creation);
+            vName = itemView.findViewById(R.id.key_list_item_name);
+            vEmail = itemView.findViewById(R.id.key_list_item_email);
+            vCreation = itemView.findViewById(R.id.key_list_item_creation);
 
             vSendButton = itemView.findViewById(R.id.button_transfer);
-            vState = (ViewAnimator) itemView.findViewById(R.id.transfer_state);
+            vState = itemView.findViewById(R.id.transfer_state);
         }
 
         private void bind(Context context, final SecretKeyItem item,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertListWidget.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertListWidget.java
@@ -81,8 +81,8 @@ public class CertListWidget extends ViewAnimator
         super.onFinishInflate();
 
         View root = getRootView();
-        vCollapsed = (TextView) root.findViewById(R.id.cert_collapsed_list);
-        vExpanded = (ListView) root.findViewById(R.id.cert_expanded_list);
+        vCollapsed = root.findViewById(R.id.cert_collapsed_list);
+        vExpanded = root.findViewById(R.id.cert_expanded_list);
         vExpandButton = root.findViewById(R.id.cert_expand_button);
 
         // for now

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/FoldableLinearLayout.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/FoldableLinearLayout.java
@@ -134,7 +134,7 @@ public class FoldableLinearLayout extends LinearLayout {
                 Context.LAYOUT_INFLATER_SERVICE);
 
         mFoldableLayout = inflator.inflate(R.layout.foldable_linearlayout, this, true);
-        mFoldableContainer = (LinearLayout) mFoldableLayout.findViewById(R.id.foldableContainer);
+        mFoldableContainer = mFoldableLayout.findViewById(R.id.foldableContainer);
 
         // Push previously collected children into foldableContainer.
         for (int i = 0; i < childNum; i++) {
@@ -143,15 +143,15 @@ public class FoldableLinearLayout extends LinearLayout {
     }
 
     private void initialiseInnerViews() {
-        mFoldableIcon = (ImageView) mFoldableLayout.findViewById(R.id.foldableIcon);
+        mFoldableIcon = mFoldableLayout.findViewById(R.id.foldableIcon);
         mFoldableIcon.setImageResource(R.drawable.ic_expand_more_black_24dp);
-        mFoldableTextView = (TextView) mFoldableLayout.findViewById(R.id.foldableText);
+        mFoldableTextView = mFoldableLayout.findViewById(R.id.foldableText);
         mFoldableTextView.setText(mFoldedLabel);
 
         // retrieve and cache the system's short animation time
         mShortAnimationDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
 
-        LinearLayout foldableControl = (LinearLayout) mFoldableLayout.findViewById(R.id.foldableControl);
+        LinearLayout foldableControl = mFoldableLayout.findViewById(R.id.foldableControl);
         foldableControl.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/FileHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/FileHelper.java
@@ -218,7 +218,11 @@ public class FileHelper {
      */
     public static Bitmap getThumbnail(Context context, Uri uri, Point size) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            return DocumentsContract.getDocumentThumbnail(context.getContentResolver(), uri, size, null);
+            try {
+                return DocumentsContract.getDocumentThumbnail(context.getContentResolver(), uri, size, null);
+            } catch (FileNotFoundException e) {
+                return null;
+            }
         } else {
             return null;
         }

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/KeychainTestRunner.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/KeychainTestRunner.java
@@ -13,7 +13,7 @@ public class KeychainTestRunner extends RobolectricTestRunner {
     @Override
     protected Config buildGlobalConfig() {
         return new Config.Builder()
-                .setSdk(25)
+                .setSdk(27)
                 .setConstants(WorkaroundBuildConfig.class)
                 .build();
     }

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Development mailinglist at https://lists.riseup.net/www/subscribe/openkeychain
 2. Get all external submodules with ``git submodule update --init --recursive``
 3. Have Android SDK "tools", "platform-tools", and "build-tools" directories in your PATH (http://developer.android.com/sdk/index.html)
 4. Open the Android SDK Manager (shell command: ``android``).
-Expand the Tools directory and select "Android SDK Build-tools (Version 25.0.2)".
+Expand the Tools directory and select "Android SDK Build-tools (Version 27.0.3)".
 Expand the Extras directory and install "Android Support Library", as well as "Local Maven repository for Support Libraries"
-Select SDK Platform for API levels 25.
+Select SDK Platform for API levels 27.
 5. Export ANDROID_HOME pointing to your Android SDK
 6. Execute ``./gradlew assembleFdroidDebug``
 7. You can install the app with ``adb install -r OpenKeychain/build/outputs/apk/OpenKeychain-fdroid-debug.apk``

--- a/build.gradle
+++ b/build.gradle
@@ -51,5 +51,6 @@ project(':extern:bouncycastle') {
 // SDK Version and Build Tools used by all subprojects
 // See http://tools.android.com/tech-docs/new-build-system/tips#TOC-Controlling-Android-properties-of-all-your-modules-from-the-main-project.
 ext {
-    compileSdkVersion = 25
+    compileSdkVersion = 27
+    buildToolsVersion = '27.0.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,6 @@ allprojects {
     }
 }
 
-subprojects {
-    tasks.withType(Test) {
-        maxParallelForks = 1
-    }
-}
-
 // Ignore tests for external bouncycastle
 project(':extern:bouncycastle') {
     subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.github.ben-manes.versions'
-
 buildscript {
     repositories {
         jcenter()
@@ -12,13 +10,6 @@ buildscript {
         classpath files('gradle-witness.jar')
         // bintray dependency to satisfy dependency of openpgp-api lib
         classpath 'com.novoda:bintray-release:0.8.0'
-
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
-
-        // allows to check for lib updates with "./gradlew dependencyUpdates -Drevision=release"
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
-
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
 
@@ -27,10 +18,6 @@ allprojects {
         jcenter()
         google()
     }
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.3'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,15 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
         // NOTE: Always use fixed version codes not dynamic ones, e.g. 0.7.3 instead of 0.7.+, see README for more information
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath files('gradle-witness.jar')
         // bintray dependency to satisfy dependency of openpgp-api lib
-        classpath 'com.novoda:bintray-release:0.2.7'
+        classpath 'com.novoda:bintray-release:0.8.0'
 
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
 
@@ -24,6 +25,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 
@@ -50,5 +52,4 @@ project(':extern:bouncycastle') {
 // See http://tools.android.com/tech-docs/new-build-system/tips#TOC-Controlling-Android-properties-of-all-your-modules-from-the-main-project.
 ext {
     compileSdkVersion = 25
-    buildToolsVersion = '25.0.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionSha256Sum=dd9b24950dc4fca7d1ca5f1ccd57ca8c5b9eb407e3e6e0f48174fde4bb19ed06

--- a/libkeychain/build.gradle
+++ b/libkeychain/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // NOTE: libraries are pinned to a specific build, see below
 
     // from local Android SDK
-    compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:support-v4:27.0.2'
 
     // libs as submodules
     compile project(':openpgp-api-lib') // TODO: get rid of this dependency

--- a/sshauthentication-api/build.gradle
+++ b/sshauthentication-api/build.gradle
@@ -15,7 +15,7 @@ android {
     if (project.hasProperty('rootProject.ext.compileSdkVersion')) {
         compileSdkVersion rootProject.ext.compileSdkVersion
     } else {
-        compileSdkVersion 25
+        compileSdkVersion 27
     }
     if (project.hasProperty('rootProject.ext.buildToolsVersion')) {
         buildToolsVersion rootProject.ext.buildToolsVersion

--- a/sshauthentication-api/build.gradle
+++ b/sshauthentication-api/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.2'
-        classpath 'com.novoda:bintray-release:0.2.7'
+        classpath 'com.novoda:bintray-release:0.8.0'
     }
 }
 
@@ -20,8 +20,9 @@ android {
     if (project.hasProperty('rootProject.ext.buildToolsVersion')) {
         buildToolsVersion rootProject.ext.buildToolsVersion
     } else {
-        buildToolsVersion '25.0.2'
+        buildToolsVersion '27.0.3'
     }
+
 
     defaultConfig {
         minSdkVersion 9


### PR DESCRIPTION
Update to gradle 4.4.1, and build sdk 27. This greatly improves build times for me, but might introduce non-obvious incompatibilities.

This PR includes a hack to retain access to PresharedKeyManager. I think this should be fine, since conscrypt will likely not drop the class while apps can build against sdk 25 and use it legitimately. We are also not doing any reflection hacks ourselves, just rely on the duck typing (indeed) in conscrypt to do the right thing for us :)