### PR TITLE
Fix SCP11b (problem since merged pull request #2186)

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SCP11bSecureMessaging.java
@@ -537,8 +537,6 @@ class SCP11bSecureMessaging implements SecureMessaging {
                 System.arraycopy(data, 0, pdata, 0, data.length);
                 pdata[data.length] = (byte)0x80;
 
-                Arrays.fill(data, (byte)0);
-
                 data = cipher.doFinal(pdata);
 
                 Arrays.fill(pdata, (byte)0);
@@ -564,8 +562,6 @@ class SCP11bSecureMessaging implements SecureMessaging {
 
             System.arraycopy(data, 0, odata, ooff, data.length);
             ooff += data.length;
-
-            Arrays.fill(data, (byte)0);
 
             final Mac mac = Mac.getInstance(SCP11_MAC_ALGO, PROVIDER);
             mac.init(mSMac);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
SCP11b secure messaging is not working at all since pull request #2186 is merged.

## Description
<!--- Describe your changes in detail -->
Remove zeroization of the unencrypted command data buffer in SCP11.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the APDU command refactoring, the command data buffer is not systematically copied by the `create` method, so it can be an alias to (real/concrete) data holded by other class instances, so it must not be zeroized.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
SCP11b is completely functional with this modification.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
