### PR TITLE
Use Constants.DEBUG instead of BuildConfig.DEBUG

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainApplication.java
@@ -178,7 +178,7 @@ public class KeychainApplication extends Application {
 
     private void updateLoggingStatus() {
         Timber.uprootAll();
-        boolean enableDebugLogging = BuildConfig.DEBUG;
+        boolean enableDebugLogging = Constants.DEBUG;
         if (enableDebugLogging) {
             Timber.plant(new DebugTree());
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
@@ -33,7 +33,7 @@ import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import org.bouncycastle.util.encoders.Hex;
-import org.sufficientlysecure.keychain.BuildConfig;
+import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 
 
@@ -76,7 +76,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
     }
 
     public static SecurityTokenInfo newInstanceDebugKeyserver() {
-        if (!BuildConfig.DEBUG) {
+        if (!Constants.DEBUG) {
             throw new UnsupportedOperationException("This operation is only available in debug builds!");
         }
         return SecurityTokenInfo.create(TransportType.NFC, TokenType.UNKNOWN,
@@ -85,7 +85,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
     }
 
     public static SecurityTokenInfo newInstanceDebugUri() {
-        if (!BuildConfig.DEBUG) {
+        if (!Constants.DEBUG) {
             throw new UnsupportedOperationException("This operation is only available in debug builds!");
         }
         return SecurityTokenInfo.create(TransportType.NFC, TokenType.UNKNOWN,
@@ -94,7 +94,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
     }
 
     public static SecurityTokenInfo newInstanceDebugLocked() {
-        if (!BuildConfig.DEBUG) {
+        if (!Constants.DEBUG) {
             throw new UnsupportedOperationException("This operation is only available in debug builds!");
         }
         return SecurityTokenInfo.create(TransportType.NFC, TokenType.UNKNOWN,
@@ -103,7 +103,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
     }
 
     public static SecurityTokenInfo newInstanceDebugLockedHard() {
-        if (!BuildConfig.DEBUG) {
+        if (!Constants.DEBUG) {
             throw new UnsupportedOperationException("This operation is only available in debug builds!");
         }
         return SecurityTokenInfo.create(TransportType.NFC, TokenType.UNKNOWN,

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateSecurityTokenWaitFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/CreateSecurityTokenWaitFragment.java
@@ -33,7 +33,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 
-import org.sufficientlysecure.keychain.BuildConfig;
+import org.sufficientlysecure.keychain.Constants;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.securitytoken.SecurityTokenInfo;
 import org.sufficientlysecure.keychain.ui.CreateKeyActivity.FragAction;
@@ -57,7 +57,7 @@ public class CreateSecurityTokenWaitFragment extends Fragment {
             ((BaseSecurityTokenActivity) this.getActivity()).checkDeviceConnection();
         }
 
-        setHasOptionsMenu(BuildConfig.DEBUG);
+        setHasOptionsMenu(Constants.DEBUG);
     }
 
     @Override


### PR DESCRIPTION
Use Constants.DEBUG instead of BuildConfig.DEBUG to allow debugging of release builds

## Motivation and Context
Debugging a problem caused by ProGuard requires me building a release build but with logging enabled.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)