### PR TITLE
Last update fixes

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/CertifyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/CertifyOperation.java
@@ -41,6 +41,7 @@ import org.sufficientlysecure.keychain.pgp.exception.PgpGeneralException;
 import org.sufficientlysecure.keychain.provider.CachedPublicKeyRing;
 import org.sufficientlysecure.keychain.provider.KeyRepository.NotFoundException;
 import org.sufficientlysecure.keychain.provider.KeyWritableRepository;
+import org.sufficientlysecure.keychain.provider.LastUpdateInteractor;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel.CertifyAction;
 import org.sufficientlysecure.keychain.service.ContactSyncAdapterService;
@@ -61,10 +62,13 @@ import org.sufficientlysecure.keychain.util.Passphrase;
  * @see CertifyActionsParcel
  */
 public class CertifyOperation extends BaseReadWriteOperation<CertifyActionsParcel> {
+    private final LastUpdateInteractor lastUpdateInteractor;
 
     public CertifyOperation(Context context, KeyWritableRepository databaseInteractor, Progressable progressable, AtomicBoolean
             cancelled) {
         super(context, databaseInteractor, progressable, cancelled);
+
+        this.lastUpdateInteractor = LastUpdateInteractor.create(context);
     }
 
     @NonNull
@@ -230,6 +234,8 @@ public class CertifyOperation extends BaseReadWriteOperation<CertifyActionsParce
                 log.add(uploadResult, 2);
 
                 if (uploadResult.success()) {
+                    lastUpdateInteractor.renewKeyLastUpdatedTime(certifiedKey.getMasterKeyId(), true);
+
                     uploadOk += 1;
                 } else {
                     uploadError += 1;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/EditKeyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/EditKeyOperation.java
@@ -37,6 +37,7 @@ import org.sufficientlysecure.keychain.pgp.Progressable;
 import org.sufficientlysecure.keychain.pgp.UncachedKeyRing;
 import org.sufficientlysecure.keychain.provider.KeyRepository.NotFoundException;
 import org.sufficientlysecure.keychain.provider.KeyWritableRepository;
+import org.sufficientlysecure.keychain.provider.LastUpdateInteractor;
 import org.sufficientlysecure.keychain.service.ContactSyncAdapterService;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
 import org.sufficientlysecure.keychain.service.UploadKeyringParcel;
@@ -56,10 +57,14 @@ import org.sufficientlysecure.keychain.util.ProgressScaler;
  *
  */
 public class EditKeyOperation extends BaseReadWriteOperation<SaveKeyringParcel> {
+    private final LastUpdateInteractor lastUpdateInteractor;
+
 
     public EditKeyOperation(Context context, KeyWritableRepository databaseInteractor,
                             Progressable progressable, AtomicBoolean cancelled) {
         super(context, databaseInteractor, progressable, cancelled);
+
+        this.lastUpdateInteractor = LastUpdateInteractor.create(context);
     }
 
     /**
@@ -167,7 +172,7 @@ public class EditKeyOperation extends BaseReadWriteOperation<SaveKeyringParcel> 
         log.add(saveResult, 1);
 
         if (isNewKey) {
-            mKeyWritableRepository.renewKeyLastUpdatedTime(ring.getMasterKeyId(), saveParcel.isShouldUpload());
+            lastUpdateInteractor.renewKeyLastUpdatedTime(ring.getMasterKeyId(), saveParcel.isShouldUpload());
         }
 
         // If the save operation didn't succeed, exit here

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeyRepository.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeyRepository.java
@@ -304,32 +304,6 @@ public class KeyRepository {
         return lastUpdateTime;
     }
 
-    @Nullable
-    Boolean getSeenOnKeyservers(long masterKeyId) {
-        Cursor cursor = mContentResolver.query(
-                UpdatedKeys.CONTENT_URI,
-                new String[] { UpdatedKeys.SEEN_ON_KEYSERVERS },
-                UpdatedKeys.MASTER_KEY_ID + " = ?",
-                new String[] { "" + masterKeyId },
-                null
-        );
-        if (cursor == null) {
-            return null;
-        }
-
-        Boolean seenOnKeyservers;
-        try {
-            if (!cursor.moveToNext()) {
-                return null;
-            }
-            seenOnKeyservers = cursor.isNull(0) ? null : cursor.getInt(0) != 0;
-        } finally {
-            cursor.close();
-        }
-        return seenOnKeyservers;
-    }
-
-
     public final byte[] loadPublicKeyRingData(long masterKeyId) throws NotFoundException {
         byte[] data = (byte[]) getGenericDataOrNull(KeyRingData.buildPublicKeyRingUri(masterKeyId),
                 KeyRingData.KEY_RING_DATA, FIELD_TYPE_BLOB);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeyWritableRepository.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeyWritableRepository.java
@@ -1126,26 +1126,4 @@ public class KeyWritableRepository extends KeyRepository {
         return ContentProviderOperation.newInsert(uri).withValues(values).build();
     }
 
-    public Uri renewKeyLastUpdatedTime(long masterKeyId, boolean seenOnKeyservers) {
-        boolean isFirstKeyserverStatusCheck = getSeenOnKeyservers(masterKeyId) == null;
-
-        ContentValues values = new ContentValues();
-        values.put(UpdatedKeys.MASTER_KEY_ID, masterKeyId);
-        values.put(UpdatedKeys.LAST_UPDATED, GregorianCalendar.getInstance().getTimeInMillis() / 1000);
-        if (seenOnKeyservers || isFirstKeyserverStatusCheck) {
-            values.put(UpdatedKeys.SEEN_ON_KEYSERVERS, seenOnKeyservers);
-        }
-
-        // this will actually update/replace, doing the right thing™ for seenOnKeyservers value
-        // see `KeychainProvider.insert()`
-        return mContentResolver.insert(UpdatedKeys.CONTENT_URI, values);
-    }
-
-    public void resetAllLastUpdatedTimes() {
-        ContentValues values = new ContentValues();
-        values.putNull(UpdatedKeys.LAST_UPDATED);
-        values.putNull(UpdatedKeys.SEEN_ON_KEYSERVERS);
-        mContentResolver.update(UpdatedKeys.CONTENT_URI, values, null, null);
-    }
-
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/LastUpdateInteractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/LastUpdateInteractor.java
@@ -26,7 +26,7 @@ public class LastUpdateInteractor {
     }
 
     @Nullable
-    private Boolean getSeenOnKeyservers(long masterKeyId) {
+    public Boolean getSeenOnKeyservers(long masterKeyId) {
         Cursor cursor = contentResolver.query(
                 UpdatedKeys.CONTENT_URI,
                 new String[] { UpdatedKeys.SEEN_ON_KEYSERVERS },

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/LastUpdateInteractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/LastUpdateInteractor.java
@@ -1,0 +1,74 @@
+package org.sufficientlysecure.keychain.provider;
+
+
+import java.util.GregorianCalendar;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.Nullable;
+
+import org.sufficientlysecure.keychain.provider.KeychainContract.UpdatedKeys;
+
+
+public class LastUpdateInteractor {
+    private final ContentResolver contentResolver;
+
+
+    public static LastUpdateInteractor create(Context context) {
+        return new LastUpdateInteractor(context.getContentResolver());
+    }
+
+    private LastUpdateInteractor(ContentResolver contentResolver) {
+        this.contentResolver = contentResolver;
+    }
+
+    @Nullable
+    private Boolean getSeenOnKeyservers(long masterKeyId) {
+        Cursor cursor = contentResolver.query(
+                UpdatedKeys.CONTENT_URI,
+                new String[] { UpdatedKeys.SEEN_ON_KEYSERVERS },
+                UpdatedKeys.MASTER_KEY_ID + " = ?",
+                new String[] { "" + masterKeyId },
+                null
+        );
+        if (cursor == null) {
+            return null;
+        }
+
+        Boolean seenOnKeyservers;
+        try {
+            if (!cursor.moveToNext()) {
+                return null;
+            }
+            seenOnKeyservers = cursor.isNull(0) ? null : cursor.getInt(0) != 0;
+        } finally {
+            cursor.close();
+        }
+        return seenOnKeyservers;
+    }
+
+    public void resetAllLastUpdatedTimes() {
+        ContentValues values = new ContentValues();
+        values.putNull(UpdatedKeys.LAST_UPDATED);
+        values.putNull(UpdatedKeys.SEEN_ON_KEYSERVERS);
+        contentResolver.update(UpdatedKeys.CONTENT_URI, values, null, null);
+    }
+
+    public Uri renewKeyLastUpdatedTime(long masterKeyId, boolean seenOnKeyservers) {
+        boolean isFirstKeyserverStatusCheck = getSeenOnKeyservers(masterKeyId) == null;
+
+        ContentValues values = new ContentValues();
+        values.put(UpdatedKeys.MASTER_KEY_ID, masterKeyId);
+        values.put(UpdatedKeys.LAST_UPDATED, GregorianCalendar.getInstance().getTimeInMillis() / 1000);
+        if (seenOnKeyservers || isFirstKeyserverStatusCheck) {
+            values.put(UpdatedKeys.SEEN_ON_KEYSERVERS, seenOnKeyservers);
+        }
+
+        // this will actually update/replace, doing the right thing™ for seenOnKeyservers value
+        // see `KeychainProvider.insert()`
+        return contentResolver.insert(UpdatedKeys.CONTENT_URI, values);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/SettingsKeyserverFragment.java
@@ -43,7 +43,7 @@ import android.widget.TextView;
 
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.keyimport.HkpKeyserverAddress;
-import org.sufficientlysecure.keychain.provider.KeyWritableRepository;
+import org.sufficientlysecure.keychain.provider.LastUpdateInteractor;
 import org.sufficientlysecure.keychain.ui.dialog.AddEditKeyserverDialogFragment;
 import org.sufficientlysecure.keychain.ui.util.FormattingUtils;
 import org.sufficientlysecure.keychain.ui.util.Notify;
@@ -63,7 +63,7 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
     private List<HkpKeyserverAddress> mKeyservers;
     private KeyserverListAdapter mAdapter;
 
-    private KeyWritableRepository databaseReadWriteInteractor;
+    private LastUpdateInteractor lastUpdateInteractor;
 
     public static SettingsKeyserverFragment newInstance(ArrayList<HkpKeyserverAddress> keyservers) {
         Bundle args = new Bundle();
@@ -78,7 +78,7 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle
             savedInstanceState) {
-        databaseReadWriteInteractor = KeyWritableRepository.create(getContext());
+        lastUpdateInteractor = LastUpdateInteractor.create(getContext());
 
         return inflater.inflate(R.layout.settings_keyserver_fragment, null);
     }
@@ -230,7 +230,7 @@ public class SettingsKeyserverFragment extends Fragment implements RecyclerItemC
         Preferences.getPreferences(getActivity()).setKeyServers(mKeyserversMutable);
         mKeyservers = Collections.unmodifiableList(new ArrayList<>(mKeyserversMutable));
 
-        databaseReadWriteInteractor.resetAllLastUpdatedTimes();
+        lastUpdateInteractor.resetAllLastUpdatedTimes();
     }
 
     @Override

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/provider/InteropTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/provider/InteropTest.java
@@ -243,7 +243,8 @@ public class InteropTest {
                 KeyRings.buildUnifiedKeyRingsFindBySubkeyUri(verify.getMasterKeyId()) : null;
 
         KeyWritableRepository helper = new KeyWritableRepository(RuntimeEnvironment.application,
-                LocalPublicKeyStorage.getInstance(RuntimeEnvironment.application)) {
+                LocalPublicKeyStorage.getInstance(RuntimeEnvironment.application),
+                LastUpdateInteractor.create(RuntimeEnvironment.application)) {
 
             @Override
             public CachedPublicKeyRing getCachedPublicKeyRing(Uri queryUri) throws PgpKeyNotFoundException {


### PR DESCRIPTION
This adds a bunch of fixes for the "last updated" mechanism:
1) it actually doesn't forget the keyserver status when a key is saved (or updated) for some reason
2) when a key is certified and uploaded, it is remembered as such