### PR TITLE
Slight improvements to key list items

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/KeySectionedListAdapter.java
@@ -25,6 +25,7 @@ import android.database.MatrixCursor;
 import android.database.MergeCursor;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
@@ -387,16 +388,21 @@ public class KeySectionedListAdapter extends SectionCursorAdapter<KeySectionedLi
             { // set name and stuff, common to both key types
                 String name = keyItem.getName();
                 String email = keyItem.getEmail();
-                if (name != null) {
+                if (name == null) {
+                    if (email != null) {
+                        mMainUserId.setText(highlighter.highlight(email));
+                        mMainUserIdRest.setVisibility(View.GONE);
+                    } else {
+                        mMainUserId.setText(R.string.user_id_no_name);
+                    }
+                } else {
                     mMainUserId.setText(highlighter.highlight(name));
-                } else {
-                    mMainUserId.setText(R.string.user_id_no_name);
-                }
-                if (email != null) {
-                    mMainUserIdRest.setText(highlighter.highlight(email));
-                    mMainUserIdRest.setVisibility(View.VISIBLE);
-                } else {
-                    mMainUserIdRest.setVisibility(View.GONE);
+                    if (email != null) {
+                        mMainUserIdRest.setText(highlighter.highlight(email));
+                        mMainUserIdRest.setVisibility(View.VISIBLE);
+                    } else {
+                        mMainUserIdRest.setVisibility(View.GONE);
+                    }
                 }
             }
 

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -167,7 +167,8 @@
     <string name="label_keyservers">"Manage OpenPGP keyservers"</string>
     <string name="label_key_id">"Key ID"</string>
     <string name="label_key_id_colon">"Key ID:"</string>
-    <string name="label_key_created">"Key created %s"</string>
+    <string name="label_key_created">"Created %s"</string>
+    <string name="label_key_created_just_now">"Created just now"</string>
     <string name="label_key_type">"Type"</string>
     <string name="label_creation">"Creation"</string>
     <string name="label_creation_colon">"Creation:"</string>


### PR DESCRIPTION
This changes how keys are displayed a bit:

Most importantly, creation timestamps are now always shown for secret keys. Unlike public keys, the timestamps are reliable, and the user will have at least a rough intuition of when they created their keys. There also aren't as many so the list doesn't get too cluttered.

Secondly, a key that has only a mail address is shown as just that, rather than "<no name>" and the mail address below.