### PR TITLE
New identity chooser dialog for API

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -94,6 +94,9 @@ dependencies {
     annotationProcessor "com.google.auto.value:auto-value:1.5"
     annotationProcessor "com.ryanharter.auto.value:auto-value-parcel:0.2.5"
     compile 'com.ryanharter.auto.value:auto-value-parcel-adapter:0.2.5'
+
+    compile "android.arch.lifecycle:extensions:1.0.0"
+    annotationProcessor "android.arch.lifecycle:compiler:1.0.0"
 }
 
 // Output of ./gradlew -q calculateChecksums
@@ -144,6 +147,13 @@ dependencyVerification {
         'com.squareup.okio:okio:734269c3ebc5090e3b23566db558f421f0b4027277c79ad5d176b8ec168bb850',
         'com.fidesmo:nordpol-core:296e71b12884a9cd28cf00ab908973bbf776a90be1f23ac897380d91604e614d',
         'com.jakewharton.timber:timber:d553d3d3e883ce7d061f1b21b95d6ee0840f3bfbf6d3bd51c5671f0b0f0b0091',
+        'android.arch.lifecycle:runtime:d0b36278878c82b838acc4308595bec61a3b5f6e7f2acc34172d7e071b2cf26d',
+        'android.arch.lifecycle:common:ff0215b54e7cbaaa898f8fd00e265ed6ea198859e10604bc1c5e78477df48b5c',
+        'android.arch.core:common:5192934cd73df32e2c15722ed7fc488dde90baaec9ae030010dd1a80fb4e74e1',
+        'android.arch.lifecycle:runtime:d0b36278878c82b838acc4308595bec61a3b5f6e7f2acc34172d7e071b2cf26d',
+        'android.arch.core:runtime:9e08fc5c4d6e48f58c6865b55ba0e72a88f907009407767274187a873e524734',
+        'android.arch.core:common:5192934cd73df32e2c15722ed7fc488dde90baaec9ae030010dd1a80fb4e74e1',
+        'android.arch.lifecycle:common:ff0215b54e7cbaaa898f8fd00e265ed6ea198859e10604bc1c5e78477df48b5c',
     ]
 }
 

--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -874,6 +874,11 @@
             android:exported="false"
             android:label="@string/app_name" />
         <activity
+            android:name=".remote.ui.dialog.RemoteSelectIdKeyActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Keychain.Transparent"
+            android:label="@string/app_name" />
+        <activity
             android:name=".remote.ui.SelectSignKeyIdActivity"
             android:exported="false"
             android:label="@string/app_name" />

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -187,13 +187,11 @@ public final class Constants {
     }
 
     /**
-     * Default key configuration: 3072 bit RSA (certify, sign, encrypt)
+     * Default key configuration: 3072 bit RSA (certify + sign, encrypt)
      */
     public static void addDefaultSubkeys(SaveKeyringParcel.Builder builder) {
         builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(SaveKeyringParcel.Algorithm.RSA,
-                3072, null, KeyFlags.CERTIFY_OTHER, 0L));
-        builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(SaveKeyringParcel.Algorithm.RSA,
-                3072, null, KeyFlags.SIGN_DATA, 0L));
+                3072, null, KeyFlags.CERTIFY_OTHER | KeyFlags.SIGN_DATA, 0L));
         builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(SaveKeyringParcel.Algorithm.RSA,
                 3072, null, KeyFlags.ENCRYPT_COMMS | KeyFlags.ENCRYPT_STORAGE, 0L));
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/livedata/KeyInfoLiveData.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/livedata/KeyInfoLiveData.java
@@ -1,0 +1,38 @@
+package org.sufficientlysecure.keychain.livedata;
+
+
+import java.util.List;
+
+import android.content.ContentResolver;
+import android.content.Context;
+
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeySelector;
+import org.sufficientlysecure.keychain.ui.keyview.loader.AsyncTaskLiveData;
+
+
+public class KeyInfoLiveData extends AsyncTaskLiveData<List<KeyInfo>> {
+    private final KeyInfoInteractor keyInfoInteractor;
+
+    private KeySelector keySelector;
+
+    public KeyInfoLiveData(Context context, ContentResolver contentResolver) {
+        super(context, null);
+
+        this.keyInfoInteractor = new KeyInfoInteractor(contentResolver);
+    }
+
+    public void setKeySelector(KeySelector keySelector) {
+        this.keySelector = keySelector;
+
+        updateDataInBackground();
+    }
+
+    @Override
+    protected List<KeyInfo> asyncLoadData() {
+        if (keySelector == null) {
+            return null;
+        }
+        return keyInfoInteractor.loadKeyInfo(keySelector);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/livedata/PgpKeyGenerationLiveData.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/livedata/PgpKeyGenerationLiveData.java
@@ -1,0 +1,38 @@
+package org.sufficientlysecure.keychain.livedata;
+
+
+import android.content.Context;
+
+import org.sufficientlysecure.keychain.operations.results.PgpEditKeyResult;
+import org.sufficientlysecure.keychain.pgp.PgpKeyOperation;
+import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
+import org.sufficientlysecure.keychain.ui.keyview.loader.AsyncTaskLiveData;
+import org.sufficientlysecure.keychain.util.ProgressScaler;
+
+
+public class PgpKeyGenerationLiveData extends AsyncTaskLiveData<PgpEditKeyResult> {
+    private SaveKeyringParcel saveKeyringParcel;
+
+    public PgpKeyGenerationLiveData(Context context) {
+        super(context, null);
+    }
+
+    public void setSaveKeyringParcel(SaveKeyringParcel saveKeyringParcel) {
+        if (this.saveKeyringParcel == saveKeyringParcel) {
+            return;
+        }
+        this.saveKeyringParcel = saveKeyringParcel;
+
+        updateDataInBackground();
+    }
+
+    @Override
+    protected PgpEditKeyResult asyncLoadData() {
+        if (saveKeyringParcel == null) {
+            return null;
+        }
+
+        PgpKeyOperation keyOperations = new PgpKeyOperation(new ProgressScaler());
+        return keyOperations.createSecretKeyRing(saveKeyringParcel);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/ApiDataAccessObject.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/ApiDataAccessObject.java
@@ -99,8 +99,7 @@ public class ApiDataAccessObject {
     }
 
     public void insertApiApp(AppSettings appSettings) {
-        mQueryInterface.insert(ApiApps.CONTENT_URI,
-                contentValueForApiApps(appSettings));
+        mQueryInterface.insert(ApiApps.CONTENT_URI, contentValueForApiApps(appSettings));
     }
 
     public void deleteApiApp(String packageName) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/CachedPublicKeyRing.java
@@ -92,6 +92,16 @@ public class CachedPublicKeyRing extends KeyRing {
         }
     }
 
+    public long getCreationTime() throws PgpKeyNotFoundException {
+        try {
+            Object data = mKeyRepository.getGenericData(mUri,
+                    KeychainContract.KeyRings.CREATION, KeyRepository.FIELD_TYPE_INTEGER);
+            return (long) data;
+        } catch (KeyWritableRepository.NotFoundException e) {
+            throw new PgpKeyNotFoundException(e);
+        }
+    }
+
     @Override
     public String getPrimaryUserId() throws PgpKeyNotFoundException {
         try {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -944,7 +944,7 @@ public class KeychainProvider extends ContentProvider {
                     break;
                 }
                 case API_APPS: {
-                    db.insertOrThrow(Tables.API_APPS, null, values);
+                    db.insert(Tables.API_APPS, null, values);
                     break;
                 }
                 case API_ALLOWED_KEYS: {
@@ -953,7 +953,7 @@ public class KeychainProvider extends ContentProvider {
                     String packageName = uri.getPathSegments().get(1);
                     values.put(ApiAllowedKeys.PACKAGE_NAME, packageName);
 
-                    db.insertOrThrow(Tables.API_ALLOWED_KEYS, null, values);
+                    db.insert(Tables.API_ALLOWED_KEYS, null, values);
                     break;
                 }
                 default: {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
@@ -38,6 +38,7 @@ import org.sufficientlysecure.keychain.remote.ui.RequestKeyPermissionActivity;
 import org.sufficientlysecure.keychain.remote.ui.SelectSignKeyIdActivity;
 import org.sufficientlysecure.keychain.remote.ui.dialog.RemoteDeduplicateActivity;
 import org.sufficientlysecure.keychain.remote.ui.dialog.RemoteSelectAuthenticationKeyActivity;
+import org.sufficientlysecure.keychain.remote.ui.dialog.RemoteSelectIdKeyActivity;
 import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
 import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
 import org.sufficientlysecure.keychain.ui.keyview.ViewKeyActivity;
@@ -89,6 +90,16 @@ public class ApiPendingIntentFactory {
         return createInternal(data, intent);
     }
 
+    PendingIntent createSelectIdentityKeyPendingIntent(
+            String packageName, String apiIdentity, Long currentMasterKeyId) {
+        Intent intent = new Intent(mContext, RemoteSelectIdKeyActivity.class);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_NAME, packageName);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_USER_ID, apiIdentity);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_CURRENT_MASTER_KEY_ID, currentMasterKeyId);
+
+        return createInternal(null, intent);
+    }
+
     PendingIntent createSelectPublicKeyPendingIntent(Intent data, long[] keyIdsArray, ArrayList<String> missingEmails,
                                                      ArrayList<String> duplicateEmails, boolean noUserIdsCheck) {
         Intent intent = new Intent(mContext, RemoteSelectPubKeyActivity.class);
@@ -134,9 +145,10 @@ public class ApiPendingIntentFactory {
     }
 
     PendingIntent createSelectSignKeyIdPendingIntent(Intent data, String packageName, String preferredUserId) {
-        Intent intent = new Intent(mContext, SelectSignKeyIdActivity.class);
+        Intent intent = new Intent(mContext, RemoteSelectIdKeyActivity.class);
         intent.setData(KeychainContract.ApiApps.buildByPackageNameUri(packageName));
-        intent.putExtra(SelectSignKeyIdActivity.EXTRA_USER_ID, preferredUserId);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_NAME, packageName);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_USER_ID, preferredUserId);
 
         return createInternal(data, intent);
     }
@@ -182,7 +194,9 @@ public class ApiPendingIntentFactory {
 
     private PendingIntent createInternal(Intent data, Intent intent) {
         // re-attach "data" for pass through. It will be used later to repeat pgp operation
-        intent.putExtra(RemoteSecurityTokenOperationActivity.EXTRA_DATA, data);
+        if (data != null) {
+            intent.putExtra(RemoteSecurityTokenOperationActivity.EXTRA_DATA, data);
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             //noinspection ResourceType, looks like lint is missing FLAG_IMMUTABLE

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
@@ -90,16 +90,6 @@ public class ApiPendingIntentFactory {
         return createInternal(data, intent);
     }
 
-    PendingIntent createSelectIdentityKeyPendingIntent(
-            String packageName, String apiIdentity, Long currentMasterKeyId) {
-        Intent intent = new Intent(mContext, RemoteSelectIdKeyActivity.class);
-        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_NAME, packageName);
-        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_USER_ID, apiIdentity);
-        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_CURRENT_MASTER_KEY_ID, currentMasterKeyId);
-
-        return createInternal(null, intent);
-    }
-
     PendingIntent createSelectPublicKeyPendingIntent(Intent data, long[] keyIdsArray, ArrayList<String> missingEmails,
                                                      ArrayList<String> duplicateEmails, boolean noUserIdsCheck) {
         Intent intent = new Intent(mContext, RemoteSelectPubKeyActivity.class);
@@ -147,16 +137,17 @@ public class ApiPendingIntentFactory {
     PendingIntent createSelectSignKeyIdLegacyPendingIntent(Intent data, String packageName, String preferredUserId) {
         Intent intent = new Intent(mContext, SelectSignKeyIdActivity.class);
         intent.setData(KeychainContract.ApiApps.buildByPackageNameUri(packageName));
-        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_NAME, packageName);
-        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_USER_ID, preferredUserId);
+        intent.putExtra(SelectSignKeyIdActivity.EXTRA_USER_ID, preferredUserId);
 
         return createInternal(data, intent);
     }
 
-    PendingIntent createSelectSignKeyIdPendingIntent(Intent data, String packageName, String preferredUserId) {
+    PendingIntent createSelectSignKeyIdPendingIntent(Intent data, String packageName,
+            byte[] packageSignature, String preferredUserId) {
         Intent intent = new Intent(mContext, RemoteSelectIdKeyActivity.class);
         intent.setData(KeychainContract.ApiApps.buildByPackageNameUri(packageName));
         intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_NAME, packageName);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_SIGNATURE, packageSignature);
         intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_USER_ID, preferredUserId);
 
         return createInternal(data, intent);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
@@ -144,6 +144,15 @@ public class ApiPendingIntentFactory {
         return createInternal(data, intent);
     }
 
+    PendingIntent createSelectSignKeyIdLegacyPendingIntent(Intent data, String packageName, String preferredUserId) {
+        Intent intent = new Intent(mContext, SelectSignKeyIdActivity.class);
+        intent.setData(KeychainContract.ApiApps.buildByPackageNameUri(packageName));
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_NAME, packageName);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_USER_ID, preferredUserId);
+
+        return createInternal(data, intent);
+    }
+
     PendingIntent createSelectSignKeyIdPendingIntent(Intent data, String packageName, String preferredUserId) {
         Intent intent = new Intent(mContext, RemoteSelectIdKeyActivity.class);
         intent.setData(KeychainContract.ApiApps.buildByPackageNameUri(packageName));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPendingIntentFactory.java
@@ -143,12 +143,13 @@ public class ApiPendingIntentFactory {
     }
 
     PendingIntent createSelectSignKeyIdPendingIntent(Intent data, String packageName,
-            byte[] packageSignature, String preferredUserId) {
+            byte[] packageSignature, String preferredUserId, boolean showAutocryptHint) {
         Intent intent = new Intent(mContext, RemoteSelectIdKeyActivity.class);
         intent.setData(KeychainContract.ApiApps.buildByPackageNameUri(packageName));
         intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_NAME, packageName);
         intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_PACKAGE_SIGNATURE, packageSignature);
         intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_USER_ID, preferredUserId);
+        intent.putExtra(RemoteSelectIdKeyActivity.EXTRA_SHOW_AUTOCRYPT_HINT, showAutocryptHint);
 
         return createInternal(data, intent);
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPermissionHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPermissionHelper.java
@@ -124,6 +124,14 @@ public class ApiPermissionHelper {
         }
     }
 
+    byte[] getPackageCertificateOrError(String packageName) {
+        try {
+            return getPackageCertificate(packageName);
+        } catch (NameNotFoundException e) {
+            throw new AssertionError("Package signature must be retrievable");
+        }
+    }
+
     private byte[] getPackageCertificate(String packageName) throws NameNotFoundException {
         @SuppressLint("PackageManagerGetSignatures") // we do check the byte array of *all* signatures
         PackageInfo pkgInfo = mContext.getPackageManager().getPackageInfo(packageName, PackageManager.GET_SIGNATURES);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPermissionHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ApiPermissionHelper.java
@@ -65,7 +65,7 @@ public class ApiPermissionHelper {
     /** Returns true iff the caller is allowed, or false on any type of problem.
      * This method should only be used in cases where error handling is dealt with separately.
      */
-    protected boolean isAllowedIgnoreErrors() {
+    public boolean isAllowedIgnoreErrors() {
         try {
             return isCallerAllowed();
         } catch (WrongPackageCertificateException e) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -722,7 +722,9 @@ public class OpenPgpService extends Service {
             if (preferredUserId == null) {
                 pi = mApiPendingIntentFactory.createSelectSignKeyIdLegacyPendingIntent(data, currentPkg, null);
             } else {
-                pi = mApiPendingIntentFactory.createSelectSignKeyIdPendingIntent(data, currentPkg, preferredUserId);
+                byte[] packageSignature = mApiPermissionHelper.getPackageCertificateOrError(currentPkg);
+                pi = mApiPendingIntentFactory.createSelectSignKeyIdPendingIntent(
+                        data, currentPkg, packageSignature, preferredUserId);
             }
             result.putExtra(OpenPgpApi.RESULT_INTENT, pi);
         }
@@ -897,6 +899,11 @@ public class OpenPgpService extends Service {
             result.putExtra(OpenPgpApi.RESULT_ERROR, error);
             result.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
             return result;
+        }
+
+        // special exception: getting a sign key id will also register the app
+        if (OpenPgpApi.ACTION_GET_SIGN_KEY_ID.equals(data.getAction())) {
+            return null;
         }
 
         // check if caller is allowed to access OpenKeychain

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -39,6 +39,7 @@ import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.openintents.openpgp.AutocryptPeerUpdate;
@@ -719,7 +720,7 @@ public class OpenPgpService extends Service {
             String preferredUserId = data.getStringExtra(OpenPgpApi.EXTRA_USER_ID);
             PendingIntent pi;
             // the new dialog doesn't really work if we don't have a user id to work with. just show the old...
-            if (preferredUserId == null) {
+            if (TextUtils.isEmpty(preferredUserId)) {
                 pi = mApiPendingIntentFactory.createSelectSignKeyIdLegacyPendingIntent(data, currentPkg, null);
             } else {
                 byte[] packageSignature = mApiPermissionHelper.getPackageCertificateOrError(currentPkg);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/OpenPgpService.java
@@ -723,8 +723,9 @@ public class OpenPgpService extends Service {
                 pi = mApiPendingIntentFactory.createSelectSignKeyIdLegacyPendingIntent(data, currentPkg, null);
             } else {
                 byte[] packageSignature = mApiPermissionHelper.getPackageCertificateOrError(currentPkg);
+                boolean showAutocryptHint = data.getBooleanExtra(OpenPgpApi.EXTRA_SHOW_AUTOCRYPT_HINT, false);
                 pi = mApiPendingIntentFactory.createSelectSignKeyIdPendingIntent(
-                        data, currentPkg, packageSignature, preferredUserId);
+                        data, currentPkg, packageSignature, preferredUserId, showAutocryptHint);
             }
             result.putExtra(OpenPgpApi.RESULT_INTENT, pi);
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/SelectIdentityKeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/SelectIdentityKeyListFragment.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2015 Dominik Schürmann <dominik@dominikschuermann.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.remote.ui;
+
+
+import android.app.Activity;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.CursorLoader;
+import android.support.v4.content.Loader;
+import android.support.v7.widget.LinearLayoutManager;
+
+import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
+import org.sufficientlysecure.keychain.remote.ui.adapter.SelectIdentityKeyAdapter;
+import org.sufficientlysecure.keychain.ui.base.RecyclerFragment;
+import org.sufficientlysecure.keychain.ui.util.adapter.CursorAdapter;
+import org.sufficientlysecure.keychain.ui.util.recyclerview.DividerItemDecoration;
+
+
+public class SelectIdentityKeyListFragment extends RecyclerFragment<SelectIdentityKeyAdapter>
+        implements SelectIdentityKeyAdapter.SelectSignKeyListener, LoaderManager.LoaderCallbacks<Cursor> {
+    private static final String ARG_API_IDENTITY = "api_identity";
+    private String apiIdentity;
+    private boolean listAllKeys;
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.getString(ARG_API_IDENTITY, apiIdentity);
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState != null && apiIdentity == null) {
+            apiIdentity = getArguments().getString(ARG_API_IDENTITY);
+        }
+
+        SelectIdentityKeyAdapter adapter = new SelectIdentityKeyAdapter(getContext(), null);
+        adapter.setListener(this);
+
+        setAdapter(adapter);
+        LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
+        DividerItemDecoration dividerItemDecoration =
+                new DividerItemDecoration(getContext(), layoutManager.getOrientation(), true);
+        setLayoutManager(layoutManager);
+        getRecyclerView().addItemDecoration(dividerItemDecoration);
+
+        // Start out with a progress indicator.
+        hideList(false);
+
+        // Prepare the loader. Either re-connect with an existing one,
+        // or start a new one.
+        getLoaderManager().initLoader(0, null, this);
+    }
+
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        // These are the rows that we will retrieve.
+        String[] projection = new String[]{
+                KeyRings._ID,
+                KeyRings.MASTER_KEY_ID,
+                KeyRings.USER_ID,
+                KeyRings.IS_EXPIRED,
+                KeyRings.IS_REVOKED,
+                KeyRings.HAS_ENCRYPT,
+                KeyRings.VERIFIED,
+                KeyRings.HAS_ANY_SECRET,
+                KeyRings.HAS_DUPLICATE_USER_ID,
+                KeyRings.CREATION,
+                KeyRings.NAME,
+                KeyRings.EMAIL,
+                KeyRings.COMMENT,
+        };
+
+        String selection = KeyRings.HAS_ANY_SECRET + " != 0";
+        Uri baseUri = listAllKeys ? KeyRings.buildUnifiedKeyRingsUri() :
+                KeyRings.buildUnifiedKeyRingsFindByEmailUri(apiIdentity);
+
+        String orderBy = KeyRings.USER_ID + " ASC";
+        // Now create and return a CursorLoader that will take care of
+        // creating a Cursor for the data being displayed.
+        return new CursorLoader(getActivity(), baseUri, projection, selection, null, orderBy);
+    }
+
+    @Override
+    public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
+        // Swap the new cursor in. (The framework will take care of closing the
+        // old cursor once we return.)
+        getAdapter().swapCursor(CursorAdapter.KeyCursor.wrap(data));
+
+        // The list should now be shown.
+        if (isResumed()) {
+            showList(true);
+        } else {
+            showList(false);
+        }
+
+        boolean isEmpty = data.getCount() == 0;
+        getKeySelectFragmentListener().onChangeListEmptyStatus(isEmpty);
+    }
+
+    @Override
+    public void onLoaderReset(Loader<Cursor> loader) {
+        // This is called when the last Cursor provided to onLoadFinished()
+        // above is about to be closed. We need to make sure we are no
+        // longer using it.
+        getAdapter().swapCursor(null);
+    }
+
+    @Override
+    public void onDestroy() {
+        getAdapter().setListener(null);
+        super.onDestroy();
+    }
+
+    @Override
+    public void onSelectKeyItemClicked(long masterKeyId) {
+        getKeySelectFragmentListener().onKeySelected(masterKeyId);
+    }
+
+    SelectIdentityKeyFragmentListener getKeySelectFragmentListener() {
+        Activity activity = getActivity();
+        if (activity == null) {
+            return null;
+        }
+
+        if (!(activity instanceof SelectIdentityKeyFragmentListener)) {
+            throw new IllegalStateException("SelectIdentityKeyListFragment must be attached to KeySelectFragmentListener!");
+        }
+
+        return (SelectIdentityKeyFragmentListener) activity;
+    }
+
+    public void setApiIdentity(String apiIdentity) {
+        this.apiIdentity = apiIdentity;
+    }
+
+    public void setListAllKeys(boolean listAllKeys) {
+        this.listAllKeys = listAllKeys;
+        getLoaderManager().restartLoader(0, null, this);
+    }
+
+    public interface SelectIdentityKeyFragmentListener {
+        void onKeySelected(Long masterKeyId);
+        void onChangeListEmptyStatus(boolean isEmpty);
+    }
+
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectIdentityKeyAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/adapter/SelectIdentityKeyAdapter.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2016 Tobias Erthal
+ * Copyright (C) 2014-2016 Dominik Schürmann <dominik@dominikschuermann.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.remote.ui.adapter;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.RecyclerView;
+import android.text.format.DateUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import org.openintents.openpgp.util.OpenPgpUtils;
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.ui.adapter.KeyCursorAdapter;
+import org.sufficientlysecure.keychain.ui.util.FormattingUtils;
+import org.sufficientlysecure.keychain.ui.util.Highlighter;
+import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
+import org.sufficientlysecure.keychain.ui.util.adapter.CursorAdapter;
+
+
+public class SelectIdentityKeyAdapter extends KeyCursorAdapter<CursorAdapter.KeyCursor, RecyclerView.ViewHolder> {
+    private SelectSignKeyListener mListener;
+
+    public SelectIdentityKeyAdapter(Context context, Cursor cursor) {
+        super(context, KeyCursor.wrap(cursor));
+    }
+
+    public void setListener(SelectSignKeyListener listener) {
+        mListener = listener;
+    }
+
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        return new SignKeyItemHolder(LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.select_identity_key_item, parent, false));
+    }
+
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, KeyCursor cursor, String query) {
+        ((SignKeyItemHolder) holder).bind(cursor, query);
+    }
+
+    private class SignKeyItemHolder extends RecyclerView.ViewHolder
+            implements View.OnClickListener {
+
+        private TextView userIdText;
+        private TextView creationText;
+        private ImageView statusIcon;
+
+        SignKeyItemHolder(View itemView) {
+            super(itemView);
+            itemView.setClickable(true);
+            itemView.setOnClickListener(this);
+
+            userIdText = (TextView) itemView.findViewById(R.id.select_key_item_name);
+            creationText = (TextView) itemView.findViewById(R.id.select_key_item_creation);
+            statusIcon = (ImageView) itemView.findViewById(R.id.select_key_item_status_icon);
+        }
+
+        public void bind(KeyCursor cursor, String query) {
+            Context context = itemView.getContext();
+
+            { // set name and stuff, common to both key types
+                String name = cursor.getName();
+                if (name != null) {
+                    userIdText.setText(context.getString(R.string.use_key, name));
+                } else {
+                    String email = cursor.getEmail();
+                    userIdText.setText(context.getString(R.string.use_key, email));
+                }
+            }
+
+            { // set edit button and status, specific by key type. Note: order is important!
+                int textColor;
+                if (cursor.isRevoked()) {
+                    KeyFormattingUtils.setStatusImage(
+                            context,
+                            statusIcon,
+                            null,
+                            KeyFormattingUtils.State.REVOKED,
+                            R.color.key_flag_gray
+                    );
+
+                    itemView.setEnabled(false);
+                    statusIcon.setVisibility(View.VISIBLE);
+                    textColor = ContextCompat.getColor(context, R.color.key_flag_gray);
+                } else if (cursor.isExpired()) {
+                    KeyFormattingUtils.setStatusImage(
+                            context,
+                            statusIcon,
+                            null,
+                            KeyFormattingUtils.State.EXPIRED,
+                            R.color.key_flag_gray
+                    );
+
+                    itemView.setEnabled(false);
+                    statusIcon.setVisibility(View.VISIBLE);
+                    textColor = ContextCompat.getColor(context, R.color.key_flag_gray);
+                } else {
+                    itemView.setEnabled(true);
+                    statusIcon.setImageResource(R.drawable.ic_vpn_key_grey_24dp);
+                    textColor = FormattingUtils.getColorFromAttr(context, R.attr.colorText);
+                }
+
+                userIdText.setTextColor(textColor);
+
+                String dateTime = DateUtils.formatDateTime(context,
+                        cursor.getCreationTime(),
+                        DateUtils.FORMAT_SHOW_DATE
+                                | DateUtils.FORMAT_SHOW_TIME
+                                | DateUtils.FORMAT_SHOW_YEAR
+                                | DateUtils.FORMAT_ABBREV_MONTH);
+                creationText.setText(context.getString(R.string.label_key_created,
+                        dateTime));
+                creationText.setTextColor(textColor);
+                creationText.setVisibility(View.VISIBLE);
+            }
+
+        }
+
+        @Override
+        public void onClick(View v) {
+            if (mListener != null) {
+                mListener.onSelectKeyItemClicked(getItemId());
+            }
+        }
+    }
+
+    public interface SelectSignKeyListener {
+        void onSelectKeyItemClicked(long masterKeyId);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/KeyInfoLoader.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/KeyInfoLoader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2017 Schürmann & Breitmoser GbR
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.remote.ui.dialog;
+
+
+import java.util.List;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.support.v4.content.AsyncTaskLoader;
+
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeySelector;
+
+
+public class KeyInfoLoader extends AsyncTaskLoader<List<KeyInfo>> {
+    private final KeySelector keySelector;
+
+    private List<KeyInfo> cachedResult;
+    private KeyInfoInteractor keyInfoInteractor;
+
+    KeyInfoLoader(Context context, ContentResolver contentResolver, KeySelector keySelector) {
+        super(context);
+
+        this.keySelector = keySelector;
+        this.keyInfoInteractor = new KeyInfoInteractor(contentResolver);
+    }
+
+    @Override
+    public List<KeyInfo> loadInBackground() {
+        return keyInfoInteractor.loadKeyInfo(keySelector);
+    }
+
+    @Override
+    public void deliverResult(List<KeyInfo> keySubkeyStatus) {
+        cachedResult = keySubkeyStatus;
+
+        if (isStarted()) {
+            super.deliverResult(keySubkeyStatus);
+        }
+    }
+
+    @Override
+    protected void onStartLoading() {
+        if (cachedResult != null) {
+            deliverResult(cachedResult);
+        }
+
+        if (takeContentChanged() || cachedResult == null) {
+            forceLoad();
+        }
+    }
+
+    @Override
+    protected void onStopLoading() {
+        super.onStopLoading();
+
+        cachedResult = null;
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicateActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicateActivity.java
@@ -51,7 +51,7 @@ import android.widget.TextView;
 import com.mikepenz.materialdrawer.util.KeyboardUtil;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.remote.ui.RemoteSecurityTokenOperationActivity;
-import org.sufficientlysecure.keychain.remote.ui.dialog.KeyLoader.KeyInfo;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
 import org.sufficientlysecure.keychain.remote.ui.dialog.RemoteDeduplicatePresenter.RemoteDeduplicateView;
 import org.sufficientlysecure.keychain.ui.dialog.CustomAlertDialogBuilder;
 import org.sufficientlysecure.keychain.ui.util.ThemeChanger;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteDeduplicatePresenter.java
@@ -33,8 +33,8 @@ import android.support.v4.content.Loader;
 
 import org.sufficientlysecure.keychain.provider.AutocryptPeerDataAccessObject;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
-import org.sufficientlysecure.keychain.remote.ui.dialog.KeyLoader.KeyInfo;
-import org.sufficientlysecure.keychain.remote.ui.dialog.KeyLoader.KeySelector;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeySelector;
 import timber.log.Timber;
 
 
@@ -95,7 +95,7 @@ class RemoteDeduplicatePresenter implements LoaderCallbacks<List<KeyInfo>> {
         KeySelector keySelector = KeySelector.create(
                 KeyRings.buildUnifiedKeyRingsFindByEmailUri(duplicateAddress), null);
 
-        return new KeyLoader(context, context.getContentResolver(), keySelector);
+        return new KeyInfoLoader(context, context.getContentResolver(), keySelector);
     }
 
     @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyActivity.java
@@ -54,7 +54,7 @@ import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.provider.ApiDataAccessObject;
 import org.sufficientlysecure.keychain.provider.KeychainContract;
 import org.sufficientlysecure.keychain.remote.ui.RemoteSecurityTokenOperationActivity;
-import org.sufficientlysecure.keychain.remote.ui.dialog.KeyLoader.KeyInfo;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
 import org.sufficientlysecure.keychain.remote.ui.dialog.RemoteSelectAuthenticationKeyPresenter.RemoteSelectAuthenticationKeyView;
 import org.sufficientlysecure.keychain.ui.dialog.CustomAlertDialogBuilder;
 import org.sufficientlysecure.keychain.ui.util.ThemeChanger;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyPresenter.java
@@ -18,6 +18,8 @@
 package org.sufficientlysecure.keychain.remote.ui.dialog;
 
 
+import java.util.List;
+
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -29,11 +31,9 @@ import android.support.v4.app.LoaderManager.LoaderCallbacks;
 import android.support.v4.content.Loader;
 
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
-import org.sufficientlysecure.keychain.remote.ui.dialog.KeyLoader.KeyInfo;
-import org.sufficientlysecure.keychain.remote.ui.dialog.KeyLoader.KeySelector;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeySelector;
 import timber.log.Timber;
-
-import java.util.List;
 
 
 class RemoteSelectAuthenticationKeyPresenter implements LoaderCallbacks<List<KeyInfo>> {
@@ -84,7 +84,7 @@ class RemoteSelectAuthenticationKeyPresenter implements LoaderCallbacks<List<Key
         String selection = KeyRings.HAS_AUTHENTICATE_SECRET + " != 0";
         KeySelector keySelector = KeySelector.create(
                 KeyRings.buildUnifiedKeyRingsUri(), selection);
-        return new KeyLoader(context, context.getContentResolver(), keySelector);
+        return new KeyInfoLoader(context, context.getContentResolver(), keySelector);
     }
 
     @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
@@ -52,7 +52,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.PopupMenu;
-import android.widget.PopupMenu.OnDismissListener;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -261,31 +260,37 @@ public class RemoteSelectIdKeyActivity extends FragmentActivity {
                 @Override
                 public void showLayoutSelectNoKeys() {
                     layoutAnimator.setDisplayedChildId(R.id.select_key_layout_no_keys);
+                    buttonOverflow.setVisibility(View.GONE);
                 }
 
                 @Override
                 public void showLayoutSelectKeyList() {
                     layoutAnimator.setDisplayedChildId(R.id.select_key_layout_key_list);
+                    buttonOverflow.setVisibility(View.GONE);
                 }
 
                 @Override
                 public void showLayoutImportExplanation() {
                     layoutAnimator.setDisplayedChildId(R.id.select_key_layout_import_expl);
+                    buttonOverflow.setVisibility(View.VISIBLE);
                 }
 
                 @Override
                 public void showLayoutGenerateProgress() {
                     layoutAnimator.setDisplayedChildId(R.id.select_key_layout_generate_progress);
+                    buttonOverflow.setVisibility(View.GONE);
                 }
 
                 @Override
                 public void showLayoutGenerateOk() {
                     layoutAnimator.setDisplayedChildId(R.id.select_key_layout_generate_ok);
+                    buttonOverflow.setVisibility(View.GONE);
                 }
 
                 @Override
                 public void showLayoutGenerateSave() {
                     layoutAnimator.setDisplayedChildId(R.id.select_key_layout_generate_save);
+                    buttonOverflow.setVisibility(View.GONE);
                 }
 
                 @Override
@@ -324,11 +329,23 @@ public class RemoteSelectIdKeyActivity extends FragmentActivity {
                     }
                     activity.launchImportOperation(importKeyringParcel);
                 }
+
+                @Override
+                public void displayOverflowMenu() {
+                    ContextThemeWrapper theme = ThemeChanger.getDialogThemeWrapper(getActivity());
+                    PopupMenu menu = new PopupMenu(theme, buttonOverflow);
+                    menu.inflate(R.menu.select_identity_menu);
+                    menu.setOnMenuItemClickListener(item -> {
+                        presenter.onClickMenuListAllKeys();
+                        return false;
+                    });
+                    menu.show();
+                }
             };
         }
 
         private void setupListenersForPresenter() {
-            buttonOverflow.setOnClickListener(this::showContextMenu);
+            buttonOverflow.setOnClickListener(view -> presenter.onClickOverflowMenu());
 
             buttonKeyListOther.setOnClickListener(view -> presenter.onClickKeyListOther());
             buttonKeyListCancel.setOnClickListener(view -> presenter.onClickKeyListCancel());
@@ -345,13 +362,6 @@ public class RemoteSelectIdKeyActivity extends FragmentActivity {
 
             keyChoiceList.addOnItemTouchListener(new RecyclerItemClickListener(getContext(),
                     (view, position) -> presenter.onKeyItemClick(position)));
-        }
-
-        private void showContextMenu(View view) {
-            PopupMenu menu = new PopupMenu(getActivity(), view);
-            menu.inflate(R.menu.identity_context_menu);
-            // menu.setOnMenuItemClickListener(DecryptListFragment.this);
-            menu.show();
         }
     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
@@ -74,6 +74,7 @@ import timber.log.Timber;
 
 public class RemoteSelectIdKeyActivity extends FragmentActivity {
     public static final String EXTRA_PACKAGE_NAME = "package_name";
+    public static final String EXTRA_PACKAGE_SIGNATURE = "package_signature";
     public static final String EXTRA_USER_ID = "user_id";
     public static final String EXTRA_CURRENT_MASTER_KEY_ID = "current_master_key_id";
 
@@ -106,8 +107,9 @@ public class RemoteSelectIdKeyActivity extends FragmentActivity {
         Intent intent = getIntent();
         String userId = intent.getStringExtra(EXTRA_USER_ID);
         String packageName = intent.getStringExtra(EXTRA_PACKAGE_NAME);
+        byte[] packageSignature = intent.getByteArrayExtra(EXTRA_PACKAGE_SIGNATURE);
 
-        presenter.setupFromIntentData(packageName, userId);
+        presenter.setupFromIntentData(packageName, packageSignature, userId);
     }
 
     public static class RemoteSelectIdentityKeyDialogFragment extends DialogFragment {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
@@ -210,7 +210,7 @@ public class RemoteSelectIdKeyActivity extends FragmentActivity {
                     }
 
                     Intent resultData = new Intent();
-                    resultData.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, masterKeyId);
+                    resultData.putExtra(OpenPgpApi.RESULT_SIGN_KEY_ID, masterKeyId);
                     activity.setResult(RESULT_OK, resultData);
                     activity.finish();
                 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
@@ -444,12 +444,14 @@ public class RemoteSelectIdKeyActivity extends FragmentActivity {
         void bind(KeyInfo keyInfo, Drawable selectionIcon) {
             Context context = vCreation.getContext();
 
+            String email = keyInfo.getEmail();
             String name = keyInfo.getName();
-            if (name != null) {
+            if (email != null) {
+                vName.setText(context.getString(R.string.use_key, email));
+            } else if (name != null) {
                 vName.setText(context.getString(R.string.use_key, name));
             } else {
-                String email = keyInfo.getEmail();
-                vName.setText(context.getString(R.string.use_key, email));
+                vName.setText(context.getString(R.string.use_key_no_name));
             }
 
             String dateTime = DateUtils.formatDateTime(context, keyInfo.getCreationDate(),

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdKeyActivity.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright (C) 2017 Schürmann & Breitmoser GbR
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.remote.ui.dialog;
+
+
+import java.util.List;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Dialog;
+import android.arch.lifecycle.ViewModelProviders;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.Drawable.ConstantState;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.transition.Fade;
+import android.support.transition.Transition;
+import android.support.transition.TransitionListenerAdapter;
+import android.support.transition.TransitionManager;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.content.res.ResourcesCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.RecyclerView.Adapter;
+import android.text.format.DateUtils;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.mikepenz.materialdrawer.util.KeyboardUtil;
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.sufficientlysecure.keychain.R;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
+import org.sufficientlysecure.keychain.remote.ui.dialog.RemoteSelectIdentityKeyPresenter.RemoteSelectIdentityKeyView;
+import org.sufficientlysecure.keychain.ui.dialog.CustomAlertDialogBuilder;
+import org.sufficientlysecure.keychain.ui.util.ThemeChanger;
+import org.sufficientlysecure.keychain.ui.util.recyclerview.DividerItemDecoration;
+import org.sufficientlysecure.keychain.ui.util.recyclerview.RecyclerItemClickListener;
+import org.sufficientlysecure.keychain.ui.widget.ToolableViewAnimator;
+
+
+public class RemoteSelectIdKeyActivity extends FragmentActivity {
+    public static final String EXTRA_PACKAGE_NAME = "package_name";
+    public static final String EXTRA_USER_ID = "user_id";
+    public static final String EXTRA_CURRENT_MASTER_KEY_ID = "current_master_key_id";
+
+
+    private RemoteSelectIdentityKeyPresenter presenter;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        RemoteSelectIdViewModel viewModel =
+                ViewModelProviders.of(this).get(RemoteSelectIdViewModel.class);
+
+        presenter = new RemoteSelectIdentityKeyPresenter(getBaseContext(), viewModel, this);
+
+        KeyboardUtil.hideKeyboard(this);
+
+        if (savedInstanceState == null) {
+            RemoteSelectIdentityKeyDialogFragment frag = new RemoteSelectIdentityKeyDialogFragment();
+            frag.show(getSupportFragmentManager(), "requestKeyDialog");
+        }
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+        Intent intent = getIntent();
+        String userId = intent.getStringExtra(EXTRA_USER_ID);
+        String packageName = intent.getStringExtra(EXTRA_PACKAGE_NAME);
+
+        presenter.setupFromIntentData(packageName, userId);
+    }
+
+    public static class RemoteSelectIdentityKeyDialogFragment extends DialogFragment {
+        private RemoteSelectIdentityKeyPresenter presenter;
+        private RemoteSelectIdentityKeyView mvpView;
+
+        private RecyclerView keyChoiceList;
+        private View buttonKeyListCancel;
+        private View buttonNoKeysNew;
+        private View buttonExplBack;
+        private View buttonExplGotIt;
+        private View buttonGenOkBack;
+        private View buttonGenOkFinish;
+        private View buttonNoKeysCancel;
+        private View buttonNoKeysExisting;
+        private View buttonKeyListOther;
+
+        @NonNull
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            final Activity activity = getActivity();
+
+            ContextThemeWrapper theme = ThemeChanger.getDialogThemeWrapper(activity);
+            CustomAlertDialogBuilder alert = new CustomAlertDialogBuilder(theme);
+
+            LayoutInflater layoutInflater = LayoutInflater.from(theme);
+            @SuppressLint("InflateParams")
+            ViewGroup view = (ViewGroup) layoutInflater.inflate(R.layout.api_select_identity_key, null, false);
+            alert.setView(view);
+
+            buttonKeyListCancel = view.findViewById(R.id.button_key_list_cancel);
+            buttonKeyListOther = view.findViewById(R.id.button_key_list_other);
+
+            buttonNoKeysNew = view.findViewById(R.id.button_no_keys_new);
+            buttonNoKeysExisting = view.findViewById(R.id.button_no_keys_existing);
+            buttonNoKeysCancel = view.findViewById(R.id.button_no_keys_cancel);
+
+            buttonExplBack = view.findViewById(R.id.button_expl_back);
+            buttonExplGotIt = view.findViewById(R.id.button_expl_got_it);
+
+            buttonGenOkBack = view.findViewById(R.id.button_genok_back);
+            buttonGenOkFinish = view.findViewById(R.id.button_genok_finish);
+
+            keyChoiceList = view.findViewById(R.id.identity_key_list);
+            keyChoiceList.setLayoutManager(new LinearLayoutManager(activity));
+            keyChoiceList.addItemDecoration(
+                    new DividerItemDecoration(activity, DividerItemDecoration.VERTICAL_LIST, true));
+
+            setupListenersForPresenter();
+            mvpView = createMvpView(view, layoutInflater);
+
+            return alert.create();
+        }
+
+        @Override
+        public void onActivityCreated(Bundle savedInstanceState) {
+            super.onActivityCreated(savedInstanceState);
+
+            presenter = ((RemoteSelectIdKeyActivity) getActivity()).presenter;
+            presenter.setView(mvpView);
+        }
+
+        @Override
+        public void onCancel(DialogInterface dialog) {
+            super.onCancel(dialog);
+
+            if (presenter != null) {
+                presenter.onDialogCancel();
+            }
+        }
+
+        @Override
+        public void onDismiss(DialogInterface dialog) {
+            super.onDismiss(dialog);
+
+            if (presenter != null) {
+                presenter.setView(null);
+                presenter = null;
+            }
+        }
+
+        @NonNull
+        private RemoteSelectIdentityKeyView createMvpView(final ViewGroup rootView, LayoutInflater layoutInflater) {
+            final ImageView iconClientApp = rootView.findViewById(R.id.icon_client_app);
+            final KeyChoiceAdapter keyChoiceAdapter = new KeyChoiceAdapter(layoutInflater, getResources());
+            final TextView titleText = rootView.findViewById(R.id.text_title_select_key);
+            final TextView addressText = rootView.findViewById(R.id.text_user_id);
+            final ToolableViewAnimator layoutAnimator = rootView.findViewById(R.id.layout_animator);
+            keyChoiceList.setAdapter(keyChoiceAdapter);
+
+            return new RemoteSelectIdentityKeyView() {
+                @Override
+                public void finishAndReturn(long masterKeyId) {
+                    FragmentActivity activity = getActivity();
+                    if (activity == null) {
+                        return;
+                    }
+
+                    Intent resultData = new Intent();
+                    resultData.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, masterKeyId);
+                    activity.setResult(RESULT_OK, resultData);
+                    activity.finish();
+                }
+
+                @Override
+                public void finishAsCancelled() {
+                    FragmentActivity activity = getActivity();
+                    if (activity == null) {
+                        return;
+                    }
+
+                    activity.setResult(RESULT_CANCELED);
+                    activity.finish();
+                }
+
+                @Override
+                public void setTitleClientIconAndName(Drawable drawable, CharSequence name) {
+                    titleText.setText(getString(R.string.title_select_key, name));
+                    iconClientApp.setImageDrawable(drawable);
+                    setSelectionIcons(drawable);
+                }
+
+                private void setSelectionIcons(Drawable drawable) {
+                    ConstantState constantState = drawable.getConstantState();
+                    if (constantState == null) {
+                        return;
+                    }
+
+                    Resources resources = getResources();
+                    Drawable iconSelected = constantState.newDrawable(resources);
+                    Drawable iconUnselected = constantState.newDrawable(resources);
+                    DrawableCompat.setTint(iconUnselected.mutate(), ResourcesCompat.getColor(resources, R.color.md_grey_600, null));
+
+                    keyChoiceAdapter.setSelectionDrawables(iconSelected, iconUnselected);
+                }
+
+                @Override
+                public void setAddressText(String text) {
+                    addressText.setText(text);
+                }
+
+                @Override
+                public void showLayoutEmpty() {
+                    layoutAnimator.setDisplayedChildId(R.id.select_key_layout_empty);
+                }
+
+                @Override
+                public void showLayoutSelectNoKeys() {
+                    layoutAnimator.setDisplayedChildId(R.id.select_key_layout_no_keys);
+                }
+
+                @Override
+                public void showLayoutSelectKeyList() {
+                    layoutAnimator.setDisplayedChildId(R.id.select_key_layout_key_list);
+                }
+
+                @Override
+                public void showLayoutImportExplanation() {
+                    layoutAnimator.setDisplayedChildId(R.id.select_key_layout_import_expl);
+                }
+
+                @Override
+                public void showLayoutGenerateProgress() {
+                    layoutAnimator.setDisplayedChildId(R.id.select_key_layout_generate_progress);
+                }
+
+                @Override
+                public void showLayoutGenerateOk() {
+                    layoutAnimator.setDisplayedChildId(R.id.select_key_layout_generate_ok);
+                }
+
+                @Override
+                public void setKeyListData(List<KeyInfo> data) {
+                    keyChoiceAdapter.setData(data);
+                }
+
+                @Override
+                public void highlightKey(int position) {
+                    Transition transition = new Fade().setDuration(450)
+                            .addTarget(LinearLayout.class)
+                            .addTarget(ImageView.class)
+                            .addListener(new TransitionListenerAdapter() {
+                                @Override
+                                public void onTransitionEnd(@NonNull Transition transition) {
+                                    presenter.onHighlightFinished();
+                                }
+                            });
+                    TransitionManager.beginDelayedTransition(rootView, transition);
+
+                    buttonKeyListOther.setVisibility(View.INVISIBLE);
+                    buttonKeyListCancel.setVisibility(View.INVISIBLE);
+                    keyChoiceAdapter.setActiveItem(position);
+                }
+            };
+        }
+
+        private void setupListenersForPresenter() {
+            buttonKeyListOther.setOnClickListener(view -> presenter.onClickKeyListOther());
+            buttonKeyListCancel.setOnClickListener(view -> presenter.onClickKeyListCancel());
+
+            buttonNoKeysNew.setOnClickListener(view -> presenter.onClickNoKeysGenerate());
+            buttonNoKeysExisting.setOnClickListener(view -> presenter.onClickNoKeysExisting());
+            buttonNoKeysCancel.setOnClickListener(view -> presenter.onClickNoKeysCancel());
+
+            buttonExplBack.setOnClickListener(view -> presenter.onClickExplanationBack());
+            buttonExplGotIt.setOnClickListener(view -> presenter.onClickExplanationGotIt());
+
+            buttonGenOkBack.setOnClickListener(view -> presenter.onClickGenerateOkBack());
+            buttonGenOkFinish.setOnClickListener(view -> presenter.onClickGenerateOkFinish());
+
+            keyChoiceList.addOnItemTouchListener(new RecyclerItemClickListener(getContext(),
+                    (view, position) -> presenter.onKeyItemClick(position)));
+        }
+    }
+
+    private static class KeyChoiceAdapter extends Adapter<KeyChoiceViewHolder> {
+        private final LayoutInflater layoutInflater;
+        private final Resources resources;
+        private List<KeyInfo> data;
+        private Drawable iconUnselected;
+        private Drawable iconSelected;
+        private Integer activeItem;
+
+        KeyChoiceAdapter(LayoutInflater layoutInflater, Resources resources) {
+            this.layoutInflater = layoutInflater;
+            this.resources = resources;
+        }
+
+        @Override
+        public KeyChoiceViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View keyChoiceItemView = layoutInflater.inflate(R.layout.api_select_identity_item, parent, false);
+            return new KeyChoiceViewHolder(keyChoiceItemView);
+        }
+
+        public void setActiveItem(Integer activeItem) {
+            if (this.activeItem != null) {
+                notifyItemChanged(activeItem);
+            }
+            this.activeItem = activeItem;
+            if (this.activeItem != null) {
+                notifyItemChanged(activeItem);
+            }
+        }
+
+        @Override
+        public void onBindViewHolder(KeyChoiceViewHolder holder, int position) {
+            KeyInfo keyInfo = data.get(position);
+            Drawable icon = (activeItem != null && position == activeItem) ? iconSelected : iconUnselected;
+            holder.bind(keyInfo, icon);
+        }
+
+        @Override
+        public int getItemCount() {
+            return data != null ? data.size() : 0;
+        }
+
+        public void setData(List<KeyInfo> data) {
+            this.data = data;
+            notifyDataSetChanged();
+        }
+
+        void setSelectionDrawables(Drawable iconSelected, Drawable iconUnselected) {
+            this.iconSelected = iconSelected;
+            this.iconUnselected = iconUnselected;
+
+            notifyDataSetChanged();
+        }
+    }
+
+    private static class KeyChoiceViewHolder extends RecyclerView.ViewHolder {
+        private final TextView vName;
+        private final TextView vCreation = (TextView) itemView.findViewById(R.id.key_list_item_creation);
+        private final ImageView vIcon;
+
+        KeyChoiceViewHolder(View itemView) {
+            super(itemView);
+
+            vName = itemView.findViewById(R.id.key_list_item_name);
+            vIcon = itemView.findViewById(R.id.key_list_item_icon);
+        }
+
+        void bind(KeyInfo keyInfo, Drawable selectionIcon) {
+            Context context = vCreation.getContext();
+
+            String name = keyInfo.getName();
+            if (name != null) {
+                vName.setText(context.getString(R.string.use_key, name));
+            } else {
+                String email = keyInfo.getEmail();
+                vName.setText(context.getString(R.string.use_key, email));
+            }
+
+            String dateTime = DateUtils.formatDateTime(context, keyInfo.getCreationDate(),
+                    DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_SHOW_TIME |
+                            DateUtils.FORMAT_SHOW_YEAR | DateUtils.FORMAT_ABBREV_MONTH);
+            vCreation.setText(context.getString(R.string.label_key_created, dateTime));
+
+            vIcon.setImageDrawable(selectionIcon);
+        }
+    }
+
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdViewModel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdViewModel.java
@@ -12,6 +12,7 @@ public class RemoteSelectIdViewModel extends ViewModel {
 
     private KeyInfoLiveData keyInfo;
     private PgpKeyGenerationLiveData keyGenerationData;
+    private boolean listAllKeys;
 
     public KeyInfoLiveData getKeyInfo(Context context) {
         if (keyInfo == null) {
@@ -25,6 +26,14 @@ public class RemoteSelectIdViewModel extends ViewModel {
             keyGenerationData = new PgpKeyGenerationLiveData(context);
         }
         return keyGenerationData;
+    }
+
+    public boolean isListAllKeys() {
+        return listAllKeys;
+    }
+
+    public void setListAllKeys(boolean listAllKeys) {
+        this.listAllKeys = listAllKeys;
     }
 
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdViewModel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdViewModel.java
@@ -1,0 +1,31 @@
+package org.sufficientlysecure.keychain.remote.ui.dialog;
+
+
+import android.arch.lifecycle.ViewModel;
+import android.content.Context;
+
+import org.sufficientlysecure.keychain.livedata.KeyInfoLiveData;
+import org.sufficientlysecure.keychain.livedata.PgpKeyGenerationLiveData;
+
+
+public class RemoteSelectIdViewModel extends ViewModel {
+
+    private KeyInfoLiveData keyInfo;
+    private PgpKeyGenerationLiveData keyGenerationData;
+    public long selectedMasterKeyId;
+
+    public KeyInfoLiveData getKeyInfo(Context context) {
+        if (keyInfo == null) {
+            keyInfo = new KeyInfoLiveData(context, context.getContentResolver());
+        }
+        return keyInfo;
+    }
+
+    public PgpKeyGenerationLiveData getKeyGenerationLiveData(Context context) {
+        if (keyGenerationData == null) {
+            keyGenerationData = new PgpKeyGenerationLiveData(context);
+        }
+        return keyGenerationData;
+    }
+
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdViewModel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdViewModel.java
@@ -12,7 +12,6 @@ public class RemoteSelectIdViewModel extends ViewModel {
 
     private KeyInfoLiveData keyInfo;
     private PgpKeyGenerationLiveData keyGenerationData;
-    public long selectedMasterKeyId;
 
     public KeyInfoLiveData getKeyInfo(Context context) {
         if (keyInfo == null) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdentityKeyPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdentityKeyPresenter.java
@@ -27,6 +27,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 
 import org.openintents.openpgp.util.OpenPgpUtils;
 import org.openintents.openpgp.util.OpenPgpUtils.UserId;
@@ -39,7 +40,6 @@ import org.sufficientlysecure.keychain.pgp.UncachedKeyRing;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.service.ImportKeyringParcel;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
-import org.sufficientlysecure.keychain.ui.base.CryptoOperationHelper;
 import timber.log.Timber;
 
 
@@ -83,8 +83,13 @@ class RemoteSelectIdentityKeyPresenter {
         this.userId = OpenPgpUtils.splitUserId(rawUserId);
         view.setAddressText(userId.email);
 
-        viewModel.getKeyInfo(context).setKeySelector(KeySelector.createOnlySecret(
-                KeyRings.buildUnifiedKeyRingsFindByUserIdUri(userId.email), null));
+        loadKeyInfo();
+    }
+
+    private void loadKeyInfo() {
+        Uri listedKeyRingUri = viewModel.isListAllKeys() ?
+                KeyRings.buildUnifiedKeyRingsUri() : KeyRings.buildUnifiedKeyRingsFindByUserIdUri(userId.email);
+        viewModel.getKeyInfo(context).setKeySelector(KeySelector.createOnlySecret(listedKeyRingUri, null));
     }
 
     private void setPackageInfo(String packageName) throws NameNotFoundException {
@@ -199,6 +204,16 @@ class RemoteSelectIdentityKeyPresenter {
         view.showImportInternalError();
     }
 
+    public void onClickOverflowMenu() {
+        view.displayOverflowMenu();
+    }
+
+    public void onClickMenuListAllKeys() {
+        viewModel.setListAllKeys(true);
+        loadKeyInfo();
+        view.showLayoutSelectKeyList();
+    }
+
     interface RemoteSelectIdentityKeyView {
         void finishAndReturn(long masterKeyId);
         void finishAsCancelled();
@@ -221,5 +236,7 @@ class RemoteSelectIdentityKeyPresenter {
         void launchImportOperation(ImportKeyringParcel importKeyringParcel);
 
         void showImportInternalError();
+
+        void displayOverflowMenu();
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdentityKeyPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdentityKeyPresenter.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2017 Schürmann & Breitmoser GbR
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.remote.ui.dialog;
+
+
+import java.util.List;
+
+import android.arch.lifecycle.LifecycleOwner;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.graphics.drawable.Drawable;
+
+import org.openintents.openpgp.util.OpenPgpUtils;
+import org.openintents.openpgp.util.OpenPgpUtils.UserId;
+import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeyInfo;
+import org.sufficientlysecure.keychain.livedata.KeyInfoInteractor.KeySelector;
+import org.sufficientlysecure.keychain.operations.results.PgpEditKeyResult;
+import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
+import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
+import timber.log.Timber;
+
+
+class RemoteSelectIdentityKeyPresenter {
+    private final PackageManager packageManager;
+    private final Context context;
+    private final RemoteSelectIdViewModel viewModel;
+
+
+    private UserId userId;
+
+    private RemoteSelectIdentityKeyView view;
+    private List<KeyInfo> keyInfoData;
+    private long masterKeyId;
+
+
+    RemoteSelectIdentityKeyPresenter(Context context, RemoteSelectIdViewModel viewModel, LifecycleOwner lifecycleOwner) {
+        this.context = context;
+        this.viewModel = viewModel;
+
+        packageManager = context.getPackageManager();
+
+        viewModel.getKeyGenerationLiveData(context).observe(lifecycleOwner, this::onChangeKeyGeneration);
+        viewModel.getKeyInfo(context).observe(lifecycleOwner, this::onChangeKeyInfoData);
+    }
+
+    public void setView(RemoteSelectIdentityKeyView view) {
+        this.view = view;
+    }
+
+    void setupFromIntentData(String packageName, String rawUserId) {
+        try {
+            setPackageInfo(packageName);
+        } catch (NameNotFoundException e) {
+            Timber.e(e, "Unable to find info of calling app!");
+            view.finishAsCancelled();
+            return;
+        }
+
+        this.userId = OpenPgpUtils.splitUserId(rawUserId);
+        view.setAddressText(userId.email);
+
+        viewModel.getKeyInfo(context).setKeySelector(KeySelector.createOnlySecret(
+                KeyRings.buildUnifiedKeyRingsFindByUserIdUri(userId.email), null));
+    }
+
+    private void setPackageInfo(String packageName) throws NameNotFoundException {
+        ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, 0);
+        Drawable appIcon = packageManager.getApplicationIcon(applicationInfo);
+        CharSequence appLabel = packageManager.getApplicationLabel(applicationInfo);
+
+        view.setTitleClientIconAndName(appIcon, appLabel);
+    }
+
+    private void onChangeKeyInfoData(List<KeyInfo> data) {
+        keyInfoData = data;
+        goToSelectLayout();
+    }
+
+    private void goToSelectLayout() {
+        if (keyInfoData == null) {
+            view.showLayoutEmpty();
+        } else if (keyInfoData.isEmpty()) {
+            view.showLayoutSelectNoKeys();
+        } else {
+            view.setKeyListData(keyInfoData);
+            view.showLayoutSelectKeyList();
+        }
+    }
+
+    private void onChangeKeyGeneration(PgpEditKeyResult pgpEditKeyResult) {
+        viewModel.getKeyGenerationLiveData(context).setSaveKeyringParcel(null);
+        if (pgpEditKeyResult == null) {
+            return;
+        }
+
+        view.showLayoutGenerateOk();
+    }
+
+    void onDialogCancel() {
+        view.finishAsCancelled();
+    }
+
+    void onClickKeyListOther() {
+        view.showLayoutImportExplanation();
+    }
+
+    void onClickKeyListCancel() {
+        view.finishAndReturn(Constants.key.none);
+    }
+
+    void onClickNoKeysGenerate() {
+        view.showLayoutGenerateProgress();
+
+        SaveKeyringParcel.Builder builder = SaveKeyringParcel.buildNewKeyringParcel();
+        Constants.addDefaultSubkeys(builder);
+        builder.addUserId(userId.email);
+
+        viewModel.getKeyGenerationLiveData(context).setSaveKeyringParcel(builder.build());
+    }
+
+    void onClickNoKeysExisting() {
+        view.showLayoutImportExplanation();
+    }
+
+    void onClickNoKeysCancel() {
+        view.finishAndReturn(Constants.key.none);
+    }
+
+    void onKeyItemClick(int position) {
+        viewModel.selectedMasterKeyId = keyInfoData.get(position).getMasterKeyId();
+        view.highlightKey(position);
+    }
+
+    void onClickExplanationBack() {
+        goToSelectLayout();
+    }
+
+    void onClickExplanationGotIt() {
+        view.finishAsCancelled();
+    }
+
+    void onClickGenerateOkBack() {
+        view.showLayoutSelectNoKeys();
+    }
+
+    void onClickGenerateOkFinish() {
+        // saveKey
+        // view.finishAndReturn
+    }
+
+    void onHighlightFinished() {
+        view.finishAndReturn(viewModel.selectedMasterKeyId);
+    }
+
+    interface RemoteSelectIdentityKeyView {
+        void finishAndReturn(long masterKeyId);
+        void finishAsCancelled();
+
+        void setAddressText(String text);
+        void setTitleClientIconAndName(Drawable drawable, CharSequence name);
+
+        void showLayoutEmpty();
+        void showLayoutSelectNoKeys();
+        void showLayoutSelectKeyList();
+        void showLayoutImportExplanation();
+        void showLayoutGenerateProgress();
+        void showLayoutGenerateOk();
+
+        void setKeyListData(List<KeyInfo> data);
+
+        void highlightKey(int position);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdentityKeyPresenter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectIdentityKeyPresenter.java
@@ -76,7 +76,7 @@ class RemoteSelectIdentityKeyPresenter {
         this.view = view;
     }
 
-    void setupFromIntentData(String packageName, byte[] packageSignature, String rawUserId) {
+    void setupFromIntentData(String packageName, byte[] packageSignature, String rawUserId, boolean clientHasAutocryptSetupMsg) {
         try {
             setPackageInfo(packageName, packageSignature);
         } catch (NameNotFoundException e) {
@@ -87,6 +87,7 @@ class RemoteSelectIdentityKeyPresenter {
 
         this.userId = OpenPgpUtils.splitUserId(rawUserId);
         view.setAddressText(userId.email);
+        view.setShowAutocryptHint(clientHasAutocryptSetupMsg);
 
         loadKeyInfo();
     }
@@ -220,9 +221,13 @@ class RemoteSelectIdentityKeyPresenter {
     }
 
     public void onClickMenuListAllKeys() {
-        viewModel.setListAllKeys(true);
+        viewModel.setListAllKeys(!viewModel.isListAllKeys());
         loadKeyInfo();
         view.showLayoutSelectKeyList();
+    }
+
+    public void onClickGoToOpenKeychain() {
+        view.showOpenKeychainIntent();
     }
 
     interface RemoteSelectIdentityKeyView {
@@ -231,6 +236,7 @@ class RemoteSelectIdentityKeyPresenter {
 
         void setAddressText(String text);
         void setTitleClientIconAndName(Drawable drawable, CharSequence name);
+        void setShowAutocryptHint(boolean showAutocryptHint);
 
         void showLayoutEmpty();
         void showLayoutSelectNoKeys();
@@ -249,5 +255,7 @@ class RemoteSelectIdentityKeyPresenter {
         void showImportInternalError();
 
         void displayOverflowMenu();
+
+        void showOpenKeychainIntent();
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ImportKeyringParcel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/ImportKeyringParcel.java
@@ -50,6 +50,11 @@ public abstract class ImportKeyringParcel implements Parcelable {
         return new AutoValue_ImportKeyringParcel(Collections.singletonList(key), null, false);
     }
 
+    public static ImportKeyringParcel createFromBytes(byte[] keyData) {
+        ParcelableKeyRing keyRing = ParcelableKeyRing.createFromEncodedBytes(keyData);
+        return new AutoValue_ImportKeyringParcel(Collections.singletonList(keyRing), null, false);
+    }
+
     public static ImportKeyringParcel createFromFileCacheWithSkipSave() {
         return new AutoValue_ImportKeyringParcel(null, null, true);
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/RecyclerFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/RecyclerFragment.java
@@ -19,6 +19,7 @@ package org.sufficientlysecure.keychain.ui.base;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.LayoutRes;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.RecyclerView;
 import android.view.Gravity;
@@ -136,8 +137,6 @@ public class RecyclerFragment<A extends RecyclerView.Adapter> extends Fragment {
         RecyclerView listView = new RecyclerView(context);
         listView.setId(INTERNAL_LIST_VIEW_ID);
 
-        int padding = FormattingUtils.dpToPx(context, 8);
-        listView.setPadding(padding, 0, padding, 0);
         listView.setClipToPadding(false);
 
         listContainer.addView(listView, new FrameLayout.LayoutParams(

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/loader/AsyncTaskLiveData.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/loader/AsyncTaskLiveData.java
@@ -1,0 +1,112 @@
+package org.sufficientlysecure.keychain.ui.keyview.loader;
+
+
+import android.arch.lifecycle.LiveData;
+import android.content.Context;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.os.CancellationSignal;
+import android.support.v4.os.OperationCanceledException;
+
+public abstract class AsyncTaskLiveData<T> extends LiveData<T> {
+    @NonNull
+    private final Context context;
+    private Uri observedUri;
+
+    @NonNull
+    private final ForceLoadContentObserver observer;
+
+    @Nullable
+    private CancellationSignal cancellationSignal;
+
+    AsyncTaskLiveData(@NonNull Context context, @Nullable Uri observedUri) {
+        super();
+        this.context = context;
+        this.observedUri = observedUri;
+        this.observer = new ForceLoadContentObserver();
+    }
+
+    abstract T asyncLoadData();
+
+    private void loadDataInBackground() {
+        new AsyncTask<Void, Void, T>() {
+            @Override
+            protected T doInBackground(Void... params) {
+                try {
+                    synchronized (AsyncTaskLiveData.this) {
+                        cancellationSignal = new CancellationSignal();
+                    }
+                    try {
+                        return asyncLoadData();
+                    } finally {
+                        synchronized (AsyncTaskLiveData.this) {
+                            cancellationSignal = null;
+                        }
+                    }
+                } catch (OperationCanceledException e) {
+                    if (hasActiveObservers()) {
+                        throw e;
+                    }
+                    return null;
+                }
+            }
+
+            @Override
+            protected void onPostExecute(T value) {
+                setValue(value);
+            }
+        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    @Override
+    protected void onActive() {
+        T value = getValue();
+        if (value == null) {
+            loadDataInBackground();
+        }
+
+        if (observedUri != null) {
+            getContext().getContentResolver().registerContentObserver(observedUri, true, observer);
+        }
+    }
+
+    @Override
+    protected void onInactive() {
+        synchronized (AsyncTaskLiveData.this) {
+            if (cancellationSignal != null) {
+                cancellationSignal.cancel();
+            }
+        }
+
+        if (observedUri != null) {
+            getContext().getContentResolver().registerContentObserver(observedUri, true, observer);
+        }
+    }
+
+    @NonNull
+    public Context getContext() {
+        return context;
+    }
+
+    public final class ForceLoadContentObserver extends ContentObserver {
+
+        ForceLoadContentObserver() {
+            super(new Handler());
+        }
+
+        @Override
+        public boolean deliverSelfNotifications() {
+            return true;
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            loadDataInBackground();
+        }
+    }
+
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/loader/AsyncTaskLiveData.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/keyview/loader/AsyncTaskLiveData.java
@@ -23,16 +23,16 @@ public abstract class AsyncTaskLiveData<T> extends LiveData<T> {
     @Nullable
     private CancellationSignal cancellationSignal;
 
-    AsyncTaskLiveData(@NonNull Context context, @Nullable Uri observedUri) {
+    protected AsyncTaskLiveData(@NonNull Context context, @Nullable Uri observedUri) {
         super();
         this.context = context;
         this.observedUri = observedUri;
         this.observer = new ForceLoadContentObserver();
     }
 
-    abstract T asyncLoadData();
+    protected abstract T asyncLoadData();
 
-    private void loadDataInBackground() {
+    protected void updateDataInBackground() {
         new AsyncTask<Void, Void, T>() {
             @Override
             protected T doInBackground(Void... params) {
@@ -66,7 +66,7 @@ public abstract class AsyncTaskLiveData<T> extends LiveData<T> {
     protected void onActive() {
         T value = getValue();
         if (value == null) {
-            loadDataInBackground();
+            updateDataInBackground();
         }
 
         if (observedUri != null) {
@@ -105,7 +105,7 @@ public abstract class AsyncTaskLiveData<T> extends LiveData<T> {
 
         @Override
         public void onChange(boolean selfChange) {
-            loadDataInBackground();
+            updateDataInBackground();
         }
     }
 

--- a/OpenKeychain/src/main/res/layout/api_select_identity_item.xml
+++ b/OpenKeychain/src/main/res/layout/api_select_identity_item.xml
@@ -30,6 +30,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceMedium"
+            android:maxLines="1"
+            android:ellipsize="end"
             tools:text="Use key: look@my.amazin.horse"
             />
 

--- a/OpenKeychain/src/main/res/layout/api_select_identity_item.xml
+++ b/OpenKeychain/src/main/res/layout/api_select_identity_item.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?listPreferredItemHeight"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:background="?selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true">
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:id="@+id/key_list_item_icon"
+        tools:tint="@color/md_grey_600"
+        tools:src="@drawable/apps_k9"
+        />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/key_list_item_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            tools:text="Use key: look@my.amazin.horse"
+            />
+
+        <TextView
+            android:id="@+id/key_list_item_creation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            tools:visibility="visible"
+            tools:text="Created on 10/10/2010 10:00" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
+++ b/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
@@ -2,8 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:custom="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
     tools:layout_marginTop="24dp"
     >
@@ -13,30 +13,37 @@
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:elevation="4dp"
-        android:gravity="center_horizontal"
         android:padding="16dp"
+        android:gravity="center_vertical"
         tools:targetApi="lollipop">
 
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginLeft="8dp"
             android:src="@mipmap/ic_launcher"
             />
 
-        <ImageView
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginLeft="24dp"
-            android:layout_marginRight="24dp"
-            android:src="@drawable/link_24dp"
+            android:layout_marginLeft="16dp"
+            android:text="OpenKeychain"
+            style="?android:textAppearanceLarge"
+            />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
             />
 
         <ImageView
-            android:id="@+id/icon_client_app"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            tools:src="@drawable/apps_k9"
+            android:src="@drawable/ic_more_vert_black_24dp"
+            android:background="?selectableItemBackground"
+            android:id="@+id/overflow_menu"
             />
 
     </LinearLayout>
@@ -69,8 +76,8 @@
         android:layout_height="wrap_content"
         android:inAnimation="@anim/fade_in"
         android:outAnimation="@anim/fade_out"
-        android:measureAllChildren="true"
-        custom:initialView="05">
+        android:measureAllChildren="false"
+        custom:initialView="04">
 
         <Space
             android:layout_width="wrap_content"
@@ -138,7 +145,7 @@
                     android:layout_height="24dp"
                     android:layout_marginLeft="16dp"
                     android:layout_marginRight="16dp"
-                    android:src="@drawable/ic_save_black_24dp"
+                    android:src="@drawable/ic_help_black_24dp"
                     android:tint="@color/md_grey_600"
                     />
 
@@ -231,7 +238,7 @@
                     android:layout_height="24dp"
                     android:layout_marginLeft="16dp"
                     android:layout_marginRight="16dp"
-                    android:src="@drawable/ic_save_black_24dp"
+                    android:src="@drawable/ic_help_black_24dp"
                     android:tint="@color/md_grey_600"
                     />
 
@@ -285,7 +292,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
                 android:layout_marginRight="16dp"
-                android:text="To use an existing end-to-end key, you can either:\n\n①  Open Autocrypt Setup Message from another e-mail app in K-9 Mail\n\n②  Manually manage keys in OpenKeychain"
+                android:text="To import your key, you can either:\n\n①  Open Autocrypt Setup Message from another e-mail app in K-9 Mail\n\n②  Manually manage keys in OpenKeychain"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 />
 
@@ -330,35 +337,71 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?listPreferredItemHeight"
-            android:orientation="horizontal"
-            android:id="@+id/select_key_layout_generate_progress"
-            android:layout_marginTop="36dp"
+            android:orientation="vertical"
             android:paddingLeft="16dp"
-            android:paddingRight="16dp">
+            android:paddingRight="16dp"
+            android:id="@+id/select_key_layout_generate_progress">
 
-            <ProgressBar
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
-                android:layout_gravity="center_vertical"
-                android:indeterminate="true"
-                />
-
-            <TextView
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:text="Generating end-to-end key…"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                />
+                android:minHeight="?listPreferredItemHeight">
+
+                <ProgressBar
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:layout_gravity="center_vertical"
+                    android:indeterminate="true"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:text="Please wait…"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="?listPreferredItemHeight"
+                android:background="?selectableItemBackground"
+                android:orientation="horizontal"
+                style="?buttonBarStyle">
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:enabled="false"
+                    android:text="Back"
+                    style="?buttonBarButtonStyle"
+                    />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:enabled="false"
+                    android:text="Finish"
+                    style="?buttonBarButtonStyle"
+                    />
+
+            </LinearLayout>
 
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="36dp"
             android:orientation="vertical"
             android:id="@+id/select_key_layout_generate_ok"
             android:paddingLeft="16dp"
@@ -395,8 +438,7 @@
                 android:id="@+id/button_gen_back"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="bottom"
-                android:layout_marginBottom="8dp"
+                android:minHeight="?listPreferredItemHeight"
                 android:background="?selectableItemBackground"
                 android:orientation="horizontal"
                 style="?buttonBarStyle">
@@ -418,6 +460,73 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:id="@+id/button_genok_finish"
+                    android:text="Finish"
+                    style="?buttonBarButtonStyle"
+                    />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:id="@+id/select_key_layout_generate_save"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            >
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="?listPreferredItemHeight"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ProgressBar
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:indeterminate="true"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:text="Finishing setup…"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="?listPreferredItemHeight"
+                android:background="?selectableItemBackground"
+                android:orientation="horizontal"
+                style="?buttonBarStyle">
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:enabled="false"
+                    android:text="Back"
+                    style="?buttonBarButtonStyle"
+                    />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:enabled="false"
                     android:text="Finish"
                     style="?buttonBarButtonStyle"
                     />

--- a/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
+++ b/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
@@ -1,0 +1,431 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:layout_marginTop="24dp"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:gravity="center_horizontal"
+        android:padding="16dp"
+        tools:targetApi="lollipop">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@mipmap/ic_launcher"
+            />
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="24dp"
+            android:layout_marginRight="24dp"
+            android:src="@drawable/link_24dp"
+            />
+
+        <ImageView
+            android:id="@+id/icon_client_app"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:src="@drawable/apps_k9"
+            />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/text_title_select_key"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="22dp"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        tools:text="@string/title_select_key" />
+
+    <TextView
+        android:id="@+id/text_user_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:gravity="center_vertical"
+        android:minHeight="?listPreferredItemHeight"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textStyle="bold"
+        tools:text="look@my.amazin.horse"
+        />
+
+    <org.sufficientlysecure.keychain.ui.widget.ToolableViewAnimator
+        android:id="@+id/layout_animator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inAnimation="@anim/fade_in"
+        android:outAnimation="@anim/fade_out"
+        android:measureAllChildren="true"
+        custom:initialView="05">
+
+        <Space
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/select_key_layout_empty" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:id="@+id/select_key_layout_no_keys"
+            >
+
+            <LinearLayout
+                android:id="@+id/button_no_keys_new"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?selectableItemBackground"
+                android:gravity="center_vertical"
+                android:minHeight="?listPreferredItemHeight"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:src="@drawable/ic_key_plus_grey600_24dp"
+                    />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="?android:textAppearanceMedium"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="This is a new address"
+                        />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Create new end-to-end key in OpenKeychain"
+                        />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/button_no_keys_existing"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?selectableItemBackground"
+                android:gravity="center_vertical"
+                android:minHeight="?listPreferredItemHeight"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:src="@drawable/ic_save_black_24dp"
+                    android:tint="@color/md_grey_600"
+                    />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="?android:textAppearanceMedium"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="I already have a key"
+                        />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Import end-to-end key from other device"
+                        />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/button_no_keys_cancel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:background="?selectableItemBackground"
+                android:gravity="center_vertical"
+                android:minHeight="?listPreferredItemHeight"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:src="@drawable/ic_close_black_24dp"
+                    android:tint="@color/md_grey_600"
+                    />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="?android:textAppearanceMedium"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Cancel"
+                        />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/select_key_layout_key_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/identity_key_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:layout_height="?listPreferredItemHeight"
+                tools:listitem="@layout/api_select_identity_item"
+                />
+
+            <LinearLayout
+                android:id="@+id/button_key_list_other"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?selectableItemBackground"
+                android:gravity="center_vertical"
+                android:minHeight="?listPreferredItemHeight"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:src="@drawable/ic_save_black_24dp"
+                    android:tint="@color/md_grey_600"
+                    />
+
+                <TextView
+                    style="?android:textAppearanceMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Use a different key"
+                    />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/button_key_list_cancel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:background="?selectableItemBackground"
+                android:gravity="center_vertical"
+                android:minHeight="?listPreferredItemHeight"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:src="@drawable/ic_close_black_24dp"
+                    android:tint="@color/md_grey_600"
+                    />
+
+                <TextView
+                    style="?android:textAppearanceMedium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Cancel"
+                    />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/select_key_layout_import_expl"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:text="To use an existing end-to-end key, you can either:\n\n①  Open Autocrypt Setup Message from another e-mail app in K-9 Mail\n\n②  Manually manage keys in OpenKeychain"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                />
+
+            <LinearLayout
+                style="?buttonBarStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:layout_marginTop="12dp"
+                android:gravity="end"
+                android:orientation="horizontal"
+                android:padding="8dp">
+
+                <Button
+                    android:id="@+id/button_expl_back"
+                    style="?buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/button_back"
+                    />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    />
+
+                <Button
+                    android:id="@+id/button_expl_got_it"
+                    style="?buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:text="@string/button_got_it"
+                    />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?listPreferredItemHeight"
+            android:orientation="horizontal"
+            android:id="@+id/select_key_layout_generate_progress"
+            android:layout_marginTop="36dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp">
+
+            <ProgressBar
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_gravity="center_vertical"
+                android:indeterminate="true"
+                />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:text="Generating end-to-end key…"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="36dp"
+            android:orientation="vertical"
+            android:id="@+id/select_key_layout_generate_ok"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            >
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="?listPreferredItemHeight"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    android:src="@drawable/ic_check_black_24dp"
+                    android:tint="@color/android_green_light"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:text="Generated end-to-end key!"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/button_gen_back"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:layout_marginBottom="8dp"
+                android:background="?selectableItemBackground"
+                android:orientation="horizontal"
+                style="?buttonBarStyle">
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/button_genok_back"
+                    android:text="Back"
+                    style="?buttonBarButtonStyle"
+                    />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/button_genok_finish"
+                    android:text="Finish"
+                    style="?buttonBarButtonStyle"
+                    />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </org.sufficientlysecure.keychain.ui.widget.ToolableViewAnimator>
+
+</LinearLayout>

--- a/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
+++ b/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
@@ -78,7 +78,7 @@
         android:inAnimation="@anim/fade_in"
         android:outAnimation="@anim/fade_out"
         android:measureAllChildren="false"
-        custom:initialView="03">
+        custom:initialView="01">
 
         <Space
             android:layout_width="wrap_content"
@@ -202,7 +202,7 @@
                         style="?android:textAppearanceMedium"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@android:string/cancel"
+                        android:text="@string/select_identity_cancel"
                         />
 
                 </LinearLayout>

--- a/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
+++ b/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
@@ -298,6 +298,47 @@
                 />
 
             <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:layout_gravity="center_horizontal"
+                android:id="@+id/button_goto_openkeychain"
+                android:background="?selectableItemBackground"
+                android:paddingLeft="12dp"
+                android:paddingRight="12dp"
+                >
+
+                <ImageView
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:layout_marginRight="12dp"
+                    android:layout_gravity="center_vertical"
+                    android:src="@mipmap/ic_launcher"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="0dp"
+                    android:paddingRight="0dp"
+                    android:text="@string/button_goto_openkeychain"
+                    android:clickable="false"
+                    android:background="@android:color/transparent"
+                    style="?buttonBarButtonStyle"/>
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:id="@+id/key_import_autocrypt_hint"
+                android:text="@string/key_import_text_autocrypt_setup_msg"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                />
+
+            <LinearLayout
                 style="?buttonBarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
+++ b/OpenKeychain/src/main/res/layout/api_select_identity_key.xml
@@ -21,16 +21,18 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="8dp"
-            android:src="@mipmap/ic_launcher"
-            />
+            android:layout_marginStart="8dp"
+            android:src="@mipmap/ic_launcher"/>
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="16dp"
-            android:text="OpenKeychain"
-            style="?android:textAppearanceLarge"
-            />
+            android:layout_marginStart="16dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:text="@string/app_name"
+            style="?android:textAppearanceLarge"/>
 
         <Space
             android:layout_width="0dp"
@@ -43,8 +45,7 @@
             android:layout_height="wrap_content"
             android:src="@drawable/ic_more_vert_black_24dp"
             android:background="?selectableItemBackground"
-            android:id="@+id/overflow_menu"
-            />
+            android:id="@+id/overflow_menu" />
 
     </LinearLayout>
 
@@ -77,7 +78,7 @@
         android:inAnimation="@anim/fade_in"
         android:outAnimation="@anim/fade_out"
         android:measureAllChildren="false"
-        custom:initialView="04">
+        custom:initialView="03">
 
         <Space
             android:layout_width="wrap_content"
@@ -118,13 +119,13 @@
                         style="?android:textAppearanceMedium"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="This is a new address"
+                        android:text="@string/no_keys_gen_title"
                         />
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Create new end-to-end key in OpenKeychain"
+                        android:text="@string/no_keys_gen_subtitle"
                         />
 
                 </LinearLayout>
@@ -159,13 +160,13 @@
                         style="?android:textAppearanceMedium"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="I already have a key"
+                        android:text="@string/no_keys_import_title"
                         />
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Import end-to-end key from other device"
+                        android:text="@string/no_keys_import_subtitle"
                         />
 
                 </LinearLayout>
@@ -201,7 +202,7 @@
                         style="?android:textAppearanceMedium"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="Cancel"
+                        android:text="@android:string/cancel"
                         />
 
                 </LinearLayout>
@@ -246,7 +247,7 @@
                     style="?android:textAppearanceMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Use a different key"
+                    android:text="@string/key_list_import"
                     />
 
             </LinearLayout>
@@ -274,7 +275,7 @@
                     style="?android:textAppearanceMedium"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Cancel"
+                    android:text="@android:string/cancel"
                     />
 
             </LinearLayout>
@@ -292,7 +293,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
                 android:layout_marginRight="16dp"
-                android:text="To import your key, you can either:\n\n①  Open Autocrypt Setup Message from another e-mail app in K-9 Mail\n\n②  Manually manage keys in OpenKeychain"
+                android:text="@string/key_import_text"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 />
 
@@ -360,7 +361,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
-                    android:text="Please wait…"
+                    android:text="@string/key_gen_progress"
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     />
 
@@ -378,7 +379,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:enabled="false"
-                    android:text="Back"
+                    android:text="@string/key_gen_back"
                     style="?buttonBarButtonStyle"
                     />
 
@@ -391,7 +392,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:enabled="false"
-                    android:text="Finish"
+                    android:text="@string/key_gen_finish"
                     style="?buttonBarButtonStyle"
                     />
 
@@ -428,7 +429,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
-                    android:text="Generated end-to-end key!"
+                    android:text="@string/key_gen_done"
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     />
 
@@ -447,7 +448,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:id="@+id/button_genok_back"
-                    android:text="Back"
+                    android:text="@string/key_gen_back"
                     style="?buttonBarButtonStyle"
                     />
 
@@ -460,7 +461,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:id="@+id/button_genok_finish"
-                    android:text="Finish"
+                    android:text="@string/key_gen_finish"
                     style="?buttonBarButtonStyle"
                     />
 
@@ -496,7 +497,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
-                    android:text="Finishing setup…"
+                    android:text="@string/key_gen_finishing"
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     />
 
@@ -514,7 +515,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:enabled="false"
-                    android:text="Back"
+                    android:text="@string/key_gen_back"
                     style="?buttonBarButtonStyle"
                     />
 
@@ -527,7 +528,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:enabled="false"
-                    android:text="Finish"
+                    android:text="@string/key_gen_finish"
                     style="?buttonBarButtonStyle"
                     />
 

--- a/OpenKeychain/src/main/res/layout/select_encrypt_key_item.xml
+++ b/OpenKeychain/src/main/res/layout/select_encrypt_key_item.xml
@@ -2,13 +2,15 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:paddingLeft="4dp"
+    android:paddingStart="4dp"
     android:paddingRight="?android:attr/scrollbarSize"
-    android:maxLines="1">
+    android:paddingEnd="?android:attr/scrollbarSize"
+    android:maxLines="1"
+    tools:layout_marginTop="24dp">
 
     <CheckBox
         android:id="@+id/selected"

--- a/OpenKeychain/src/main/res/layout/select_identity_key_item.xml
+++ b/OpenKeychain/src/main/res/layout/select_identity_key_item.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:layout_alignParentLeft="true"
+    android:layout_alignParentStart="true"
+    android:background="?android:selectableItemBackground"
+    tools:layout_marginTop="24dp">
+
+    <ImageView
+        android:id="@+id/select_key_item_status_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="16dp"
+        tools:src="@drawable/ic_vpn_key_grey_24dp"
+        />
+
+    <LinearLayout
+        android:layout_width="0dip"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:layout_gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/select_key_item_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="Use Key: Alice"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <TextView
+            android:id="@+id/select_key_item_creation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="Key created Dec 16, 2005, 12:18 PM"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/OpenKeychain/src/main/res/menu/select_identity_menu.xml
+++ b/OpenKeychain/src/main/res/menu/select_identity_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/list_all_keys"
+        android:title="List all keys"
+        android:checkable="true"
+        android:orderInCategory="1" />
+</menu>

--- a/OpenKeychain/src/main/res/menu/select_identity_menu.xml
+++ b/OpenKeychain/src/main/res/menu/select_identity_menu.xml
@@ -2,7 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/list_all_keys"
-        android:title="List all keys"
-        android:checkable="true"
+        android:title="@string/menu_list_unrelated_keys"
         android:orderInCategory="1" />
 </menu>

--- a/OpenKeychain/src/main/res/values-v23/themes.xml
+++ b/OpenKeychain/src/main/res/values-v23/themes.xml
@@ -2,6 +2,13 @@
 <resources>
 
     <!-- see http://stackoverflow.com/questions/32169303/activity-did-not-call-finish-api-23 -->
-    <style name="Theme.Keychain.Transparent" parent="@android:style/Theme.Translucent.NoTitleBar" />
+    <style name="Theme.Keychain.Transparent" parent="@android:style/Theme.Translucent.NoTitleBar">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Translucent</item>
+    </style>
 
 </resources>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -2006,5 +2006,7 @@
     <string name="key_gen_finish">Finish</string>
     <string name="key_gen_done">Generated end-to-end key!</string>
     <string name="key_gen_finishing">Finishing setup…</string>
-    <string name="key_import_text">To import your key, you can either:\n\n① Open Autocrypt Setup Message from another e-mail app in K-9 Mail\n\n② Manually import in OpenKeychain</string>
+    <string name="key_import_text">To use an end-to-end key, it has to be imported into OpenKeychain.</string>
+    <string name="key_import_text_autocrypt_setup_msg">To import your existing setup from another device, you can also open an Autocrypt Setup Message in %s.</string>
+    <string name="button_goto_openkeychain">Go to OpenKeychain</string>
 </resources>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1995,4 +1995,5 @@
     <string name="select_identity_cancel">Cancel</string>
     <string name="select_identity_create">Create a key for me</string>
     <string name="error_save_key_internal">"Internal error saving key!"</string>
+    <string name="menu_list_unrelated_keys">List unrelated keys</string>
 </resources>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1996,4 +1996,15 @@
     <string name="select_identity_create">Create a key for me</string>
     <string name="error_save_key_internal">"Internal error saving key!"</string>
     <string name="menu_list_unrelated_keys">List unrelated keys</string>
+    <string name="no_keys_gen_title">This is a new address</string>
+    <string name="no_keys_gen_subtitle">Create new end-to-end key in OpenKeychain</string>
+    <string name="no_keys_import_title">I already have a key</string>
+    <string name="no_keys_import_subtitle">Import end-to-end key from other device</string>
+    <string name="key_list_import">Use a different key</string>
+    <string name="key_gen_progress">Please wait…</string>
+    <string name="key_gen_back">Back</string>
+    <string name="key_gen_finish">Finish</string>
+    <string name="key_gen_done">Generated end-to-end key!</string>
+    <string name="key_gen_finishing">Finishing setup…</string>
+    <string name="key_import_text">To import your key, you can either:\n\n① Open Autocrypt Setup Message from another e-mail app in K-9 Mail\n\n② Manually import in OpenKeychain</string>
 </resources>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1992,7 +1992,7 @@
     <string name="use_key">Use key: %s</string>
     <string name="use_key_no_name">Use key: <![CDATA[<no name>]]></string>
     <string name="title_select_key">%s wants to set up end-to-end encryption for this address:</string>
-    <string name="select_identity_cancel">Cancel</string>
+    <string name="select_identity_cancel">Disable</string>
     <string name="select_identity_create">Create a key for me</string>
     <string name="error_save_key_internal">"Internal error saving key!"</string>
     <string name="menu_list_unrelated_keys">List unrelated keys</string>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1991,7 +1991,8 @@
 
     <string name="use_key">Use key: %s</string>
     <string name="use_key_no_name">Use key: <![CDATA[<no name>]]></string>
-    <string name="title_select_key">%s wants to end-to-end encrypt with this address:</string>
+    <string name="title_select_key">%s wants to set up end-to-end encryption for this address:</string>
     <string name="select_identity_cancel">Cancel</string>
     <string name="select_identity_create">Create a key for me</string>
+    <string name="error_save_key_internal">"Internal error saving key!"</string>
 </resources>

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -1768,6 +1768,8 @@
     <string name="requested_key_unavailable_warning">This key is not available. To use it, you must import it as one of your own!</string>
     <string name="button_allow">Allow</string>
     <string name="button_cancel">Cancel</string>
+    <string name="button_back">Back</string>
+    <string name="button_got_it">Got it</string>
     <string name="requested_key_label">Requested key:</string>
     <string name="error_preselect_sign_key">Error selecting key %s for signing!</string>
     <string name="error_preselect_encrypt_key">Error selecting key %s for encryption!</string>
@@ -1987,4 +1989,9 @@
     <string name="label_usb_untested_summary">If enabled, USB Smartcard readers can be used that have not been properly tested.</string>
     <string name="label_usb_untested">Allow untested USB Devices</string>
 
+    <string name="use_key">Use key: %s</string>
+    <string name="use_key_no_name">Use key: <![CDATA[<no name>]]></string>
+    <string name="title_select_key">%s wants to end-to-end encrypt with this address:</string>
+    <string name="select_identity_cancel">Cancel</string>
+    <string name="select_identity_create">Create a key for me</string>
 </resources>

--- a/OpenKeychain/src/main/res/values/themes.xml
+++ b/OpenKeychain/src/main/res/values/themes.xml
@@ -133,18 +133,17 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="Theme.Keychain.AppCompat.Transparent" parent="Theme.AppCompat.NoActionBar">
+    <style name="Theme.Keychain.AppCompat.Transparent" parent="Theme.AppCompat.Light.Dialog">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowAnimationStyle">@style/Animation.AppCompat.Dialog</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Translucent</item>
     </style>
 
     <style name="Theme.Keychain.AppCompat.Transparent.Fullscreen" parent="Theme.Keychain.AppCompat.Transparent">
         <item name="android:windowFullscreen">true</item>
     </style>
 
-    <style name="Theme.Keychain.Transparent" parent="@android:style/Theme.NoDisplay" />
+    <style name="Theme.Keychain.Transparent" parent="Theme.Keychain.AppCompat.Transparent" />
 </resources>


### PR DESCRIPTION
This adds a new key id selection dialog:

* dialog theme, better preserves visual context of calling app
* immediate key generation, no further questions asked
* key generation can be backed out of
* reports name and creation to the api caller
* implicit app registration and permission when a key is selected

## How Has This Been Tested?
I tested combinations of new and old K-9 and OpenKeychain. It's pretty much just UI stuff, so no unit tests included :(

## Screenshots:

![screenshot_openkeychain_ debug _20180403-015408](https://user-images.githubusercontent.com/27813/38222633-3916951e-36e6-11e8-9087-312a6dbbbf65.png)

## Types of changes
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
