### PR TITLE
Add support for NDEF tags with `openpgp4fpr` URIs

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -743,6 +743,20 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
+            <!-- NFC: Handle NFC tags with "openpgp4fpr" scheme URIs detected from outside our application -->
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <!-- Android's scheme matcher is case-sensitive, so include most likely variations -->
+                <data android:scheme="openpgp4fpr" />
+                <data android:scheme="OPENPGP4FPR" />
+                <data android:scheme="OpenPGP4FPR" />
+                <data android:scheme="OpenPGP4Fpr" />
+                <data android:scheme="OpenPGP4fpr" />
+            </intent-filter>
+
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".ui.MainActivity" />

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysActivity.java
@@ -20,6 +20,7 @@ package org.sufficientlysecure.keychain.ui;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
+import android.nfc.NfcAdapter;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -123,7 +124,7 @@ public class ImportKeysActivity extends BaseActivity implements ImportKeysListen
                 action = ACTION_IMPORT_KEY_FROM_FACEBOOK;
             } else if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
                 action = ACTION_SEARCH_KEYSERVER_FROM_URL;
-            } else if ("openpgp4fpr".equalsIgnoreCase(scheme)) {
+            } else if (Constants.FINGERPRINT_SCHEME.equalsIgnoreCase(scheme)) {
                 action = ACTION_IMPORT_KEY_FROM_KEYSERVER;
                 extras.putString(EXTRA_FINGERPRINT, dataUri.getSchemeSpecificPart());
             } else {
@@ -131,7 +132,11 @@ public class ImportKeysActivity extends BaseActivity implements ImportKeysListen
                 // delegate action to ACTION_IMPORT_KEY
                 action = ACTION_IMPORT_KEY;
             }
+        } else if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action) && Constants.FINGERPRINT_SCHEME.equalsIgnoreCase(scheme)) {
+            action = ACTION_IMPORT_KEY_FROM_KEYSERVER;
+            extras.putString(EXTRA_FINGERPRINT, dataUri.getSchemeSpecificPart());
         }
+
         if (action == null) {
             // -> switch to default below
             action = "";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This change allows importing keys from NDEF tags that have fingerprint encoded as an `openpgp4fpr` URI when the application is in background.

After scanning a tag the `Import keys` activity is shown with results of the search for key fingerprint encoded in the tag.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cheap NFC tags can be used as an alternative to barcodes when exchanging public keys. They can also be used as a business card, that, when scanned, will open OpenKeychain and look for the key.

## How Has This Been Tested?
Built a fdroid variant, OpenKeychain moved to background (by pressing Android Home key), prepared and scanned NDEF tag with a sample URI (`openpgp4fpr:73EE2314F65FA92EC2390D3A718C070100012282`). Import keys window is shown.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
After scanning the tag only standard Import Keys window is shown.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)
