### PR TITLE
HKP server handling adopted to conform to draft-shaw-openpgp-hkp-00

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/KeyserverClient.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/KeyserverClient.java
@@ -18,9 +18,6 @@ package org.sufficientlysecure.keychain.keyimport;
 
 import org.sufficientlysecure.keychain.util.ParcelableProxy;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
 public interface KeyserverClient {
@@ -55,6 +52,10 @@ public interface KeyserverClient {
 
     class QueryNeedsRepairException extends CloudSearchFailureException {
         private static final long serialVersionUID = 2693768928624654512L;
+    }
+
+    class QueryNotImplementedException extends QueryNeedsRepairException {
+        private static final long serialVersionUID = 8126381739806854079L;
     }
 
     class TooManyResponsesException extends QueryNeedsRepairException {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/processing/ImportKeysListCloudLoader.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/keyimport/processing/ImportKeysListCloudLoader.java
@@ -20,11 +20,11 @@ package org.sufficientlysecure.keychain.keyimport.processing;
 import android.content.Context;
 import android.support.annotation.Nullable;
 import android.support.v4.content.AsyncTaskLoader;
-
 import org.sufficientlysecure.keychain.keyimport.CloudSearch;
 import org.sufficientlysecure.keychain.keyimport.ImportKeysListEntry;
 import org.sufficientlysecure.keychain.keyimport.KeyserverClient;
 import org.sufficientlysecure.keychain.keyimport.ParcelableKeyRing;
+import org.sufficientlysecure.keychain.network.orbot.OrbotHelper;
 import org.sufficientlysecure.keychain.operations.results.GetKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
@@ -32,7 +32,6 @@ import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.util.ParcelableProxy;
 import org.sufficientlysecure.keychain.util.Preferences;
-import org.sufficientlysecure.keychain.network.orbot.OrbotHelper;
 import timber.log.Timber;
 
 import java.util.ArrayList;
@@ -172,7 +171,10 @@ public class ImportKeysListCloudLoader
             // convert exception to result parcel
             int error = GetKeyResult.RESULT_ERROR;
             OperationResult.LogType logType = null;
-            if (e instanceof KeyserverClient.QueryFailedException) {
+            if (e instanceof  KeyserverClient.QueryNotImplementedException){
+                error = GetKeyResult.RESULT_ERROR_QUERY_NOT_IMPLEMENTED;
+                logType = OperationResult.LogType.MSG_GET_QUERY_NOT_IMPLEMENTED;
+            } else if (e instanceof KeyserverClient.QueryFailedException) {
                 error = GetKeyResult.RESULT_ERROR_QUERY_FAILED;
                 logType = OperationResult.LogType.MSG_GET_QUERY_FAILED;
             } else if (e instanceof KeyserverClient.TooManyResponsesException) {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/GetKeyResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/GetKeyResult.java
@@ -18,7 +18,6 @@
 package org.sufficientlysecure.keychain.operations.results;
 
 import android.os.Parcel;
-
 import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
 import org.sufficientlysecure.keychain.service.input.RequiredInputParcel;
 
@@ -51,6 +50,7 @@ public class GetKeyResult extends InputPendingResult {
     public static final int RESULT_ERROR_QUERY_FAILED = RESULT_ERROR + (6 << 4);
     public static final int RESULT_ERROR_FILE_NOT_FOUND = RESULT_ERROR + (7 << 4);
     public static final int RESULT_ERROR_NO_ENABLED_SOURCE = RESULT_ERROR + (8 << 4);
+    public static final int RESULT_ERROR_QUERY_NOT_IMPLEMENTED = RESULT_ERROR + (9 << 4);
 
     public GetKeyResult(Parcel source) {
         super(source);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
@@ -23,7 +23,6 @@ import android.content.res.Resources;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.ui.LogDisplayActivity;
 import org.sufficientlysecure.keychain.ui.LogDisplayFragment;
@@ -805,6 +804,7 @@ public abstract class OperationResult implements Parcelable {
         MSG_GET_TOO_MANY_RESPONSES (LogLevel.ERROR, R.string.msg_get_too_many_responses),
         MSG_GET_QUERY_TOO_SHORT_OR_TOO_MANY_RESPONSES (LogLevel.ERROR, R.string.msg_get_query_too_short_or_too_many_responses),
         MSG_GET_QUERY_FAILED (LogLevel.ERROR, R.string.msg_download_query_failed),
+        MSG_GET_QUERY_NOT_IMPLEMENTED (LogLevel.ERROR, R.string.msg_get_query_not_implemented),
         MSG_GET_FILE_NOT_FOUND (LogLevel.ERROR, R.string.msg_get_file_not_found),
         MSG_GET_NO_ENABLED_SOURCE (LogLevel.ERROR, R.string.msg_get_no_enabled_source),
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysAdapter.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/adapter/ImportKeysAdapter.java
@@ -18,11 +18,6 @@
 package org.sufficientlysecure.keychain.ui.adapter;
 
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.support.v4.app.FragmentActivity;
@@ -31,7 +26,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
-
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.databinding.ImportKeysListItemBinding;
 import org.sufficientlysecure.keychain.keyimport.HkpKeyserverAddress;
@@ -48,12 +42,17 @@ import org.sufficientlysecure.keychain.pgp.exception.PgpKeyNotFoundException;
 import org.sufficientlysecure.keychain.provider.KeyRepository;
 import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.service.ImportKeyringParcel;
-import org.sufficientlysecure.keychain.ui.keyview.ViewKeyActivity;
 import org.sufficientlysecure.keychain.ui.base.CryptoOperationHelper;
+import org.sufficientlysecure.keychain.ui.keyview.ViewKeyActivity;
 import org.sufficientlysecure.keychain.ui.util.KeyFormattingUtils;
 import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.util.ParcelableFileCache;
 import timber.log.Timber;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 
 public class ImportKeysAdapter extends RecyclerView.Adapter<ImportKeysAdapter.ViewHolder>
@@ -291,6 +290,15 @@ public class ImportKeysAdapter extends RecyclerView.Adapter<ImportKeysAdapter.Vi
         entry.setRevoked(keyRing.isRevoked());
         entry.setExpired(keyRing.isExpired());
         entry.setSecure(keyRing.isSecure());
+
+        int algorithmId = keyRing.getPublicKey().getAlgorithm();
+        int bitSize = keyRing.getPublicKey().getBitStrength();
+        String algoInfo = KeyFormattingUtils.getAlgorithmInfo(algorithmId, bitSize, null);
+        if(entry.getAlgorithm() == null){
+            entry.setAlgorithm(algoInfo);
+        } else if ( !entry.getAlgorithm().equalsIgnoreCase(algoInfo)){
+            // TODO: handle(?)
+        }
 
         Date expectedDate = entry.getDate();
         Date creationDate = keyRing.getCreationDate();

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -2019,4 +2019,5 @@
     <string name="key_import_text_autocrypt_setup_msg">To import your existing setup from another device, you can also open an Autocrypt Setup Message in %s.</string>
     <string name="button_goto_openkeychain">Go to OpenKeychain</string>
     <string name="backup_code_checkbox">I have written down this backup code. Without it, I will be unable to restore the backup.</string>
+    <string name="msg_get_query_not_implemented">The server does not support the current query! Some servers only accept mailaddresses. Please redefine or try a different server.</string>
 </resources>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This updates the handling of key queries with hkp servers by trying to conform to [OpenPGP HKP](https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00).

Any feedback is welcome!
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Partly fixes #2061 as the handling of hkp server responses did not respect valid results as defined in [OpenPGP HKP](https://tools.ietf.org/html/draft-shaw-openpgp-hkp-00), especially disrespecting empty field.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with hkps://keys.mailvelope.com and default hkp servers.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
