### PR TITLE
Support Ledger Nano S

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
@@ -90,6 +90,7 @@ public class SecurityTokenConnection {
 
     public void connectIfNecessary(Context context) throws IOException {
         if (isConnected()) {
+            refreshConnectionCapabilities();
             return;
         }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
@@ -128,7 +128,8 @@ public abstract class SecurityTokenInfo implements Parcelable {
             TokenType.NITROKEY_START_OLD,
             TokenType.NITROKEY_START_1_25_AND_NEWER,
             TokenType.GNUK_OLD,
-            TokenType.GNUK_1_25_AND_NEWER
+            TokenType.GNUK_1_25_AND_NEWER,
+            TokenType.LEDGER_NANO_S
     )));
 
     private static final Set<TokenType> SUPPORTED_USB_SETUP = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T0ShortApduProtocol.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T0ShortApduProtocol.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Schürmann & Breitmoser GbR
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.sufficientlysecure.keychain.securitytoken.usb.tpdu;
+
+
+import android.support.annotation.NonNull;
+
+import org.sufficientlysecure.keychain.securitytoken.usb.CcidTransceiver;
+import org.sufficientlysecure.keychain.securitytoken.usb.CcidTransceiver.CcidDataBlock;
+import org.sufficientlysecure.keychain.securitytoken.usb.CcidTransportProtocol;
+import org.sufficientlysecure.keychain.securitytoken.usb.UsbTransportException;
+
+
+public class T0ShortApduProtocol implements CcidTransportProtocol {
+    private CcidTransceiver ccidTransceiver;
+
+    public void connect(@NonNull CcidTransceiver transceiver) throws UsbTransportException {
+        ccidTransceiver = transceiver;
+        ccidTransceiver.iccPowerOn();
+    }
+
+    @Override
+    public byte[] transceive(@NonNull byte[] apdu) throws UsbTransportException {
+        CcidDataBlock response = ccidTransceiver.sendXfrBlock(apdu);
+        return response.getData();
+    }
+}


### PR DESCRIPTION
This PR adds rudimentary support for T=0 protocol with short APDUs. Honestly, it took me a bit by surprise that this just worked :) since I didn't have to add changes for any of the actual differences between T=0 and T=1, like tpdu mapping and procedure bytes. But - I don't wan to complain too much, this seems to work now with just these few changes.

Fixes #2135

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)
