### PR TITLE
Color navigation bar dark when using dark theme

### DIFF
--- a/OpenKeychain/src/main/res/values-v21/themes.xml
+++ b/OpenKeychain/src/main/res/values-v21/themes.xml
@@ -15,6 +15,7 @@
 
      <style name="Theme.Keychain.Dark" parent="Base.Theme.Keychain.Dark">
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:navigationBarColor">#33cccccc</item>
 
         <!-- enable window content transitions -->
         <item name="android:windowContentTransitions">true</item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Instructs Android System UI to color the navigation bar dark when using dark theme. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This avoids ugly white bars on dark theme.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build and tested on device.

## Screenshots (if appropriate):

Before:

![obraz](https://user-images.githubusercontent.com/1718963/41665603-a258e52c-74a8-11e8-9041-6597def0b7b0.png)

After (keys cleared):

![obraz](https://user-images.githubusercontent.com/1718963/41665619-ab5d0716-74a8-11e8-9643-4368f5e7cfb8.png)


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
