### PR TITLE
Add launcher shortcuts for encrypting text and files

### DIFF
--- a/OpenKeychain/src/debug/res/xml/shortcuts.xml
+++ b/OpenKeychain/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_comment_text_grey600_24dp"
+        android:shortcutId="encrypt_text"
+        android:shortcutLongLabel="@string/btn_encrypt_text"
+        android:shortcutShortLabel="@string/btn_encrypt_text">
+        <intent
+            android:action="org.sufficientlysecure.keychain.action.ENCRYPT_FILES"
+            android:targetClass="org.sufficientlysecure.keychain.ui.EncryptTextActivity"
+            android:targetPackage="org.sufficientlysecure.keychain.debug" />
+    </shortcut>
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_folder_grey_24dp"
+        android:shortcutId="encrypt_files"
+        android:shortcutLongLabel="@string/btn_encrypt_files"
+        android:shortcutShortLabel="@string/btn_encrypt_files">
+        <intent
+            android:action="org.sufficientlysecure.keychain.action.ENCRYPT_TEXT"
+            android:targetClass="org.sufficientlysecure.keychain.ui.EncryptFilesActivity"
+            android:targetPackage="org.sufficientlysecure.keychain.debug" />
+    </shortcut>
+</shortcuts>

--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -128,6 +128,8 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
         </activity>
         <!-- singleTop for NFC dispatch, see SecurityTokenOperationActivity -->
         <activity

--- a/OpenKeychain/src/main/res/xml/shortcuts.xml
+++ b/OpenKeychain/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_comment_text_grey600_24dp"
+        android:shortcutId="encrypt_text"
+        android:shortcutLongLabel="@string/btn_encrypt_text"
+        android:shortcutShortLabel="@string/btn_encrypt_text">
+        <intent
+            android:action="org.sufficientlysecure.keychain.action.ENCRYPT_TEXT"
+            android:targetClass="org.sufficientlysecure.keychain.ui.EncryptTextActivity"
+            android:targetPackage="org.sufficientlysecure.keychain" />
+    </shortcut>
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_folder_grey_24dp"
+        android:shortcutId="encrypt_files"
+        android:shortcutLongLabel="@string/btn_encrypt_files"
+        android:shortcutShortLabel="@string/btn_encrypt_files">
+        <intent
+            android:action="org.sufficientlysecure.keychain.action.ENCRYPT_FILES"
+            android:targetClass="org.sufficientlysecure.keychain.ui.EncryptFilesActivity"
+            android:targetPackage="org.sufficientlysecure.keychain" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Adds encrypt text and files shortcuts from the launcher icon. I used this in development, but it might make sense to have those? Didn't really think about what shortcuts could be useful to have, just opening this as a suggestion