### PR TITLE
Update android gradle plugin for sshauthentication-api 

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -226,7 +226,7 @@ android {
             minifyEnabled false
             //proguardFiles = buildTypes.release.proguardFiles
             //testProguardFiles 'proguard-rules-test.pro'
-            
+
             multiDexEnabled true
 
             applicationIdSuffix ".debug"

--- a/sshauthentication-api/build.gradle
+++ b/sshauthentication-api/build.gradle
@@ -4,9 +4,10 @@ apply plugin: 'bintray-release' // must be applied after your artifact generatin
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.novoda:bintray-release:0.8.0'
     }
 }


### PR DESCRIPTION
## Description
Update android gradle plugin for sshauthentication-api to 3.1.3, same as OpenKeychain.
Fix whitespace.

## How Has This Been Tested?
Built & tested with TermBot.
