### PR TITLE
Ditch keychain provider

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -880,13 +880,10 @@
             android:name=".service.KeychainService"
             android:exported="false" />
 
-        <!-- label is made to be "Keyserver Sync" since that is the only context in which
-        the user will see it-->
         <provider
             android:name=".provider.KeychainProvider"
             android:authorities="${applicationId}.provider"
-            android:exported="false"
-            android:label="@string/keyserver_sync_settings_title" />
+            android:exported="false" />
 
         <provider
             android:name=".remote.KeychainExternalProvider"

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainDatabase.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/KeychainDatabase.java
@@ -51,7 +51,7 @@ import timber.log.Timber;
  */
 public class KeychainDatabase {
     private static final String DATABASE_NAME = "openkeychain.db";
-    private static final int DATABASE_VERSION = 29;
+    private static final int DATABASE_VERSION = 30;
     private final SupportSQLiteOpenHelper supportSQLiteOpenHelper;
 
     private static KeychainDatabase sInstance;
@@ -133,6 +133,8 @@ public class KeychainDatabase {
         db.execSQL(AutocryptPeersModel.CREATE_TABLE);
         db.execSQL(ApiAllowedKeysModel.CREATE_TABLE);
         db.execSQL(KeysModel.UNIFIEDKEYVIEW);
+        db.execSQL(KeysModel.VALIDKEYSVIEW);
+        db.execSQL(UserPacketsModel.UIDSTATUS);
 
         db.execSQL("CREATE INDEX keys_by_rank ON keys (" + KeysColumns.RANK + ", " + KeysColumns.MASTER_KEY_ID + ");");
         db.execSQL("CREATE INDEX uids_by_rank ON user_packets (" + UserPacketsColumns.RANK + ", "
@@ -356,18 +358,28 @@ public class KeychainDatabase {
                 renameApiAutocryptPeersTable(db);
 
             case 28:
-                recreateUnifiedKeyView(db);
                 // drop old table from version 20
                 db.execSQL("DROP TABLE IF EXISTS api_accounts");
+
+            case 29:
+                recreateUnifiedKeyView(db);
         }
     }
 
     private void recreateUnifiedKeyView(SupportSQLiteDatabase db) {
         try {
             db.beginTransaction();
+
             // noinspection deprecation
             db.execSQL("DROP VIEW IF EXISTS " + KeysModel.UNIFIEDKEYVIEW_VIEW_NAME);
             db.execSQL(KeysModel.UNIFIEDKEYVIEW);
+            // noinspection deprecation
+            db.execSQL("DROP VIEW IF EXISTS " + KeysModel.VALIDMASTERKEYS_VIEW_NAME);
+            db.execSQL(KeysModel.VALIDKEYSVIEW);
+            // noinspection deprecation
+            db.execSQL("DROP VIEW IF EXISTS " + UserPacketsModel.UIDSTATUS_VIEW_NAME);
+            db.execSQL(UserPacketsModel.UIDSTATUS);
+
             db.setTransactionSuccessful();
         } finally {
             db.endTransaction();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/AbstractDao.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/AbstractDao.java
@@ -8,6 +8,7 @@ import android.arch.persistence.db.SupportSQLiteDatabase;
 import android.arch.persistence.db.SupportSQLiteQuery;
 import android.database.Cursor;
 
+import com.squareup.sqldelight.RowMapper;
 import org.sufficientlysecure.keychain.KeychainDatabase;
 import org.sufficientlysecure.keychain.daos.KeyRepository.NotFoundException;
 
@@ -33,7 +34,7 @@ class AbstractDao {
         return databaseNotifyManager;
     }
 
-    <T> List<T> mapAllRows(SupportSQLiteQuery query, Mapper<T> mapper) {
+    <T> List<T> mapAllRows(SupportSQLiteQuery query, RowMapper<T> mapper) {
         ArrayList<T> result = new ArrayList<>();
         try (Cursor cursor = getReadableDb().query(query)) {
             while (cursor.moveToNext()) {
@@ -44,7 +45,7 @@ class AbstractDao {
         return result;
     }
 
-    <T> T mapSingleRowOrThrow(SupportSQLiteQuery query, Mapper<T> mapper) throws NotFoundException {
+    <T> T mapSingleRowOrThrow(SupportSQLiteQuery query, RowMapper<T> mapper) throws NotFoundException {
         T result = mapSingleRow(query, mapper);
         if (result == null) {
             throw new NotFoundException();
@@ -52,16 +53,12 @@ class AbstractDao {
         return result;
     }
 
-    <T> T mapSingleRow(SupportSQLiteQuery query, Mapper<T> mapper) {
+    <T> T mapSingleRow(SupportSQLiteQuery query, RowMapper<T> mapper) {
         try (Cursor cursor = getReadableDb().query(query)) {
             if (cursor.moveToNext()) {
                 return mapper.map(cursor);
             }
         }
         return null;
-    }
-
-    interface Mapper<T> {
-        T map(Cursor cursor);
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/DatabaseBatchInteractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/DatabaseBatchInteractor.java
@@ -1,0 +1,100 @@
+package org.sufficientlysecure.keychain.daos;
+
+
+import java.util.List;
+
+import android.arch.persistence.db.SupportSQLiteDatabase;
+
+import org.sufficientlysecure.keychain.CertsModel.InsertCert;
+import org.sufficientlysecure.keychain.KeyRingsPublicModel.InsertKeyRingPublic;
+import org.sufficientlysecure.keychain.KeySignaturesModel.InsertKeySignature;
+import org.sufficientlysecure.keychain.KeysModel.InsertKey;
+import org.sufficientlysecure.keychain.UserPacketsModel.InsertUserPacket;
+import org.sufficientlysecure.keychain.model.Certification;
+import org.sufficientlysecure.keychain.model.KeyRingPublic;
+import org.sufficientlysecure.keychain.model.KeySignature;
+import org.sufficientlysecure.keychain.model.SubKey;
+import org.sufficientlysecure.keychain.model.UserPacket;
+
+
+public class DatabaseBatchInteractor {
+    private final SupportSQLiteDatabase db;
+
+    private final InsertKeyRingPublic insertKeyRingPublicStatement;
+    private final InsertKey insertSubKeyStatement;
+    private final InsertUserPacket insertUserPacketStatement;
+    private final InsertCert insertCertificationStatement;
+    private final InsertKeySignature insertKeySignerStatement;
+
+    DatabaseBatchInteractor(SupportSQLiteDatabase db) {
+        this.db = db;
+
+        insertKeyRingPublicStatement = KeyRingPublic.createInsertStatement(db);
+        insertSubKeyStatement = SubKey.createInsertStatement(db);
+        insertUserPacketStatement = UserPacket.createInsertStatement(db);
+        insertCertificationStatement = Certification.createInsertStatement(db);
+        insertKeySignerStatement = KeySignature.createInsertStatement(db);
+    }
+
+    public SupportSQLiteDatabase getDb() {
+        return db;
+    }
+
+    public void applyBatch(List<BatchOp> operations) {
+        for (BatchOp op : operations) {
+            if (op.keyRingPublic != null) {
+                op.keyRingPublic.bindTo(insertKeyRingPublicStatement);
+                insertKeyRingPublicStatement.executeInsert();
+            } else if (op.subKey != null) {
+                op.subKey.bindTo(insertSubKeyStatement);
+                insertSubKeyStatement.executeInsert();
+            } else if (op.userPacket != null) {
+                op.userPacket.bindTo(insertUserPacketStatement);
+                insertUserPacketStatement.executeInsert();
+            } else if (op.certification != null) {
+                op.certification.bindTo(insertCertificationStatement);
+                insertCertificationStatement.executeInsert();
+            } else if (op.keySignature != null) {
+                op.keySignature.bindTo(insertKeySignerStatement);
+                insertKeySignerStatement.executeInsert();
+            }
+        }
+    }
+
+    public static BatchOp createInsertKeyRingPublic(KeyRingPublic keyRingPublic) {
+        return new BatchOp(keyRingPublic, null, null, null, null);
+    }
+
+    static BatchOp createInsertSubKey(SubKey subKey) {
+        return new BatchOp(null, subKey, null, null, null);
+    }
+
+    public static BatchOp createInsertUserPacket(UserPacket userPacket) {
+        return new BatchOp(null, null, userPacket, null, null);
+    }
+
+    public static BatchOp createInsertCertification(Certification certification) {
+        return new BatchOp(null, null, null, certification, null);
+    }
+
+    static BatchOp createInsertSignerKey(KeySignature keySignature) {
+        return new BatchOp(null, null, null, null, keySignature);
+    }
+
+    static class BatchOp {
+        final KeyRingPublic keyRingPublic;
+        final SubKey subKey;
+        final UserPacket userPacket;
+        final Certification certification;
+        final KeySignature keySignature;
+
+        BatchOp(KeyRingPublic keyRingPublic, SubKey subKey, UserPacket userPacket,
+                Certification certification, KeySignature keySignature) {
+            this.subKey = subKey;
+            this.keyRingPublic = keyRingPublic;
+            this.userPacket = userPacket;
+            this.certification = certification;
+            this.keySignature = keySignature;
+        }
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/DatabaseNotifyManager.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/DatabaseNotifyManager.java
@@ -23,6 +23,11 @@ public class DatabaseNotifyManager {
         this.contentResolver = contentResolver;
     }
 
+    public void notifyAllKeysChange() {
+        Uri uri = getNotifyUriAllKeys();
+        contentResolver.notifyChange(uri, null);
+    }
+
     public void notifyKeyChange(long masterKeyId) {
         Uri uri = getNotifyUriMasterKeyId(masterKeyId);
         contentResolver.notifyChange(uri, null);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyRepository.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyRepository.java
@@ -20,6 +20,7 @@ package org.sufficientlysecure.keychain.daos;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import android.content.ContentResolver;
@@ -27,6 +28,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.support.annotation.WorkerThread;
 
+import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.sufficientlysecure.keychain.KeychainDatabase;
@@ -129,13 +131,27 @@ public class KeyRepository extends AbstractDao {
 
     public List<Long> getAllMasterKeyIds() {
         SqlDelightQuery query = KeyRingPublic.FACTORY.selectAllMasterKeyIds();
-        return mapAllRows(query, KeyRingPublic.FACTORY.selectAllMasterKeyIdsMapper());
+        ArrayList<Long> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                Long item = KeyRingPublic.FACTORY.selectAllMasterKeyIdsMapper().map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public List<Long> getMasterKeyIdsBySigner(List<Long> signerMasterKeyIds) {
         long[] signerKeyIds = getLongListAsArray(signerMasterKeyIds);
         SqlDelightQuery query = KeySignature.FACTORY.selectMasterKeyIdsBySigner(signerKeyIds);
-        return mapAllRows(query, KeySignature.FACTORY.selectMasterKeyIdsBySignerMapper());
+        ArrayList<Long> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                Long item = KeySignature.FACTORY.selectMasterKeyIdsBySignerMapper().map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public Long getMasterKeyIdBySubkeyId(long subKeyId) {
@@ -150,38 +166,88 @@ public class KeyRepository extends AbstractDao {
 
     public List<UnifiedKeyInfo> getUnifiedKeyInfo(long... masterKeyIds) {
         SqlDelightQuery query = SubKey.FACTORY.selectUnifiedKeyInfoByMasterKeyIds(masterKeyIds);
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
+        ArrayList<UnifiedKeyInfo> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                UnifiedKeyInfo item = SubKey.UNIFIED_KEY_INFO_MAPPER.map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public List<UnifiedKeyInfo> getUnifiedKeyInfosByMailAddress(String mailAddress) {
         SqlDelightQuery query = SubKey.FACTORY.selectUnifiedKeyInfoSearchMailAddress('%' + mailAddress + '%');
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
+        ArrayList<UnifiedKeyInfo> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                UnifiedKeyInfo item = SubKey.UNIFIED_KEY_INFO_MAPPER.map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public List<UnifiedKeyInfo> getAllUnifiedKeyInfo() {
         SqlDelightQuery query = SubKey.FACTORY.selectAllUnifiedKeyInfo();
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
+        ArrayList<UnifiedKeyInfo> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                UnifiedKeyInfo item = SubKey.UNIFIED_KEY_INFO_MAPPER.map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public List<UnifiedKeyInfo> getAllUnifiedKeyInfoWithSecret() {
         SqlDelightQuery query = SubKey.FACTORY.selectAllUnifiedKeyInfoWithSecret();
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
+        ArrayList<UnifiedKeyInfo> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                UnifiedKeyInfo item = SubKey.UNIFIED_KEY_INFO_MAPPER.map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public List<UserId> getUserIds(long... masterKeyIds) {
         SqlDelightQuery query = UserPacket.FACTORY.selectUserIdsByMasterKeyId(masterKeyIds);
-        return mapAllRows(query, UserPacket.USER_ID_MAPPER);
+        ArrayList<UserId> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                UserId item = UserPacket.USER_ID_MAPPER.map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public List<String> getConfirmedUserIds(long masterKeyId) {
         SqlDelightQuery query = UserPacket.FACTORY.selectUserIdsByMasterKeyIdAndVerification(
                 Certification.FACTORY, masterKeyId, VerificationStatus.VERIFIED_SECRET);
-        return mapAllRows(query, (cursor) -> UserPacket.USER_ID_MAPPER.map(cursor).user_id());
+        ArrayList<String> result = new ArrayList<>();
+        try (Cursor cursor1 = getReadableDb().query(query)) {
+            while (cursor1.moveToNext()) {
+                String item = ((RowMapper<String>) (cursor) -> UserPacket.USER_ID_MAPPER.map(cursor).user_id())
+                        .map(cursor1);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public List<SubKey> getSubKeysByMasterKeyId(long masterKeyId) {
         SqlDelightQuery query = SubKey.FACTORY.selectSubkeysByMasterKeyId(masterKeyId);
-        return mapAllRows(query, SubKey.SUBKEY_MAPPER);
+        ArrayList<SubKey> result = new ArrayList<>();
+        try (Cursor cursor = getReadableDb().query(query)) {
+            while (cursor.moveToNext()) {
+                SubKey item = SubKey.SUBKEY_MAPPER.map(cursor);
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     public SecretKeyType getSecretKeyType(long keyId) throws NotFoundException {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyRepository.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyRepository.java
@@ -129,48 +129,48 @@ public class KeyRepository extends AbstractDao {
 
     public List<Long> getAllMasterKeyIds() {
         SqlDelightQuery query = KeyRingPublic.FACTORY.selectAllMasterKeyIds();
-        return mapAllRows(query, KeyRingPublic.FACTORY.selectAllMasterKeyIdsMapper()::map);
+        return mapAllRows(query, KeyRingPublic.FACTORY.selectAllMasterKeyIdsMapper());
     }
 
     public List<Long> getMasterKeyIdsBySigner(List<Long> signerMasterKeyIds) {
         long[] signerKeyIds = getLongListAsArray(signerMasterKeyIds);
         SqlDelightQuery query = KeySignature.FACTORY.selectMasterKeyIdsBySigner(signerKeyIds);
-        return mapAllRows(query, KeySignature.FACTORY.selectMasterKeyIdsBySignerMapper()::map);
+        return mapAllRows(query, KeySignature.FACTORY.selectMasterKeyIdsBySignerMapper());
     }
 
     public Long getMasterKeyIdBySubkeyId(long subKeyId) {
         SqlDelightQuery query = SubKey.FACTORY.selectMasterKeyIdBySubkey(subKeyId);
-        return mapSingleRow(query, SubKey.FACTORY.selectMasterKeyIdBySubkeyMapper()::map);
+        return mapSingleRow(query, SubKey.FACTORY.selectMasterKeyIdBySubkeyMapper());
     }
 
     public UnifiedKeyInfo getUnifiedKeyInfo(long masterKeyId) {
         SqlDelightQuery query = SubKey.FACTORY.selectUnifiedKeyInfoByMasterKeyId(masterKeyId);
-        return mapSingleRow(query, SubKey.UNIFIED_KEY_INFO_MAPPER::map);
+        return mapSingleRow(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
     }
 
     public List<UnifiedKeyInfo> getUnifiedKeyInfo(long... masterKeyIds) {
         SqlDelightQuery query = SubKey.FACTORY.selectUnifiedKeyInfoByMasterKeyIds(masterKeyIds);
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER::map);
+        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
     }
 
     public List<UnifiedKeyInfo> getUnifiedKeyInfosByMailAddress(String mailAddress) {
         SqlDelightQuery query = SubKey.FACTORY.selectUnifiedKeyInfoSearchMailAddress('%' + mailAddress + '%');
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER::map);
+        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
     }
 
     public List<UnifiedKeyInfo> getAllUnifiedKeyInfo() {
         SqlDelightQuery query = SubKey.FACTORY.selectAllUnifiedKeyInfo();
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER::map);
+        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
     }
 
     public List<UnifiedKeyInfo> getAllUnifiedKeyInfoWithSecret() {
         SqlDelightQuery query = SubKey.FACTORY.selectAllUnifiedKeyInfoWithSecret();
-        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER::map);
+        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
     }
 
     public List<UserId> getUserIds(long... masterKeyIds) {
         SqlDelightQuery query = UserPacket.FACTORY.selectUserIdsByMasterKeyId(masterKeyIds);
-        return mapAllRows(query, UserPacket.USER_ID_MAPPER::map);
+        return mapAllRows(query, UserPacket.USER_ID_MAPPER);
     }
 
     public List<String> getConfirmedUserIds(long masterKeyId) {
@@ -181,17 +181,17 @@ public class KeyRepository extends AbstractDao {
 
     public List<SubKey> getSubKeysByMasterKeyId(long masterKeyId) {
         SqlDelightQuery query = SubKey.FACTORY.selectSubkeysByMasterKeyId(masterKeyId);
-        return mapAllRows(query, SubKey.SUBKEY_MAPPER::map);
+        return mapAllRows(query, SubKey.SUBKEY_MAPPER);
     }
 
     public SecretKeyType getSecretKeyType(long keyId) throws NotFoundException {
         SqlDelightQuery query = SubKey.FACTORY.selectSecretKeyType(keyId);
-        return mapSingleRowOrThrow(query, SubKey.SKT_MAPPER::map);
+        return mapSingleRowOrThrow(query, SubKey.SKT_MAPPER);
     }
 
     public byte[] getFingerprintByKeyId(long keyId) throws NotFoundException {
         SqlDelightQuery query = SubKey.FACTORY.selectFingerprintByKeyId(keyId);
-        return mapSingleRowOrThrow(query, SubKey.FACTORY.selectFingerprintByKeyIdMapper()::map);
+        return mapSingleRowOrThrow(query, SubKey.FACTORY.selectFingerprintByKeyIdMapper());
     }
 
     private byte[] getKeyRingAsArmoredData(byte[] data) throws IOException {
@@ -247,12 +247,12 @@ public class KeyRepository extends AbstractDao {
 
     public long getSecretSignId(long masterKeyId) throws NotFoundException {
         SqlDelightQuery query = SubKey.FACTORY.selectEffectiveSignKeyIdByMasterKeyId(masterKeyId);
-        return mapSingleRowOrThrow(query, SubKey.FACTORY.selectEffectiveSignKeyIdByMasterKeyIdMapper()::map);
+        return mapSingleRowOrThrow(query, SubKey.FACTORY.selectEffectiveSignKeyIdByMasterKeyIdMapper());
     }
 
     public long getSecretAuthenticationId(long masterKeyId) throws NotFoundException {
         SqlDelightQuery query = SubKey.FACTORY.selectEffectiveAuthKeyIdByMasterKeyId(masterKeyId);
-        return mapSingleRowOrThrow(query, SubKey.FACTORY.selectEffectiveAuthKeyIdByMasterKeyIdMapper()::map);
+        return mapSingleRowOrThrow(query, SubKey.FACTORY.selectEffectiveAuthKeyIdByMasterKeyIdMapper());
     }
 
     public static class NotFoundException extends Exception {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyWritableRepository.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyWritableRepository.java
@@ -1002,9 +1002,7 @@ public class KeyWritableRepository extends KeyRepository {
             }
         }
 
-        if (!isTrustDbInitialized) {
-            preferences.setKeySignaturesTableInitialized();
-        }
+        preferences.setKeySignaturesTableInitialized();
 
         log.add(LogType.MSG_TRUST_OK, 1);
         return new UpdateTrustResult(UpdateTrustResult.RESULT_OK, log);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
@@ -1,0 +1,26 @@
+package org.sufficientlysecure.keychain.daos;
+
+
+import java.util.List;
+
+import com.squareup.sqldelight.SqlDelightQuery;
+import org.sufficientlysecure.keychain.KeychainDatabase;
+import org.sufficientlysecure.keychain.model.UserPacket;
+import org.sufficientlysecure.keychain.model.UserPacket.UidStatus;
+
+
+public class UserIdDao extends AbstractDao {
+    public UserIdDao(KeychainDatabase db, DatabaseNotifyManager databaseNotifyManager) {
+        super(db, databaseNotifyManager);
+    }
+
+    public List<UidStatus> getUidStatusByEmailLike(String emailLike) {
+        SqlDelightQuery query = UserPacket.FACTORY.selectUserIdStatusByEmailLike(emailLike);
+        return mapAllRows(query, UserPacket.UID_STATUS_MAPPER);
+    }
+
+    public List<UidStatus> getUidStatusByEmail(String... emails) {
+        SqlDelightQuery query = UserPacket.FACTORY.selectUserIdStatusByEmail(emails);
+        return mapAllRows(query, UserPacket.UID_STATUS_MAPPER);
+    }
+}

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/Certification.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/Certification.java
@@ -1,8 +1,13 @@
 package org.sufficientlysecure.keychain.model;
 
 
+import java.util.Date;
+
+import android.arch.persistence.db.SupportSQLiteDatabase;
+
 import com.google.auto.value.AutoValue;
 import org.sufficientlysecure.keychain.CertsModel;
+import org.sufficientlysecure.keychain.pgp.CanonicalizedKeyRing.VerificationStatus;
 
 
 @AutoValue
@@ -12,6 +17,20 @@ public abstract class Certification implements CertsModel {
 
     public static final SelectVerifyingCertDetailsMapper<CertDetails> CERT_DETAILS_MAPPER =
             new SelectVerifyingCertDetailsMapper<>(AutoValue_Certification_CertDetails::new);
+
+    public static Certification create(long masterKeyId, long rank, long keyIdCertifier, long type,
+            VerificationStatus verified, Date creation, byte[] data) {
+        long creationUnixTime = creation.getTime() / 1000;
+        return new AutoValue_Certification(masterKeyId, rank, keyIdCertifier, type, verified, creationUnixTime, data);
+    }
+
+    public static InsertCert createInsertStatement(SupportSQLiteDatabase db) {
+        return new InsertCert(db, FACTORY);
+    }
+
+    public void bindTo(InsertCert statement) {
+        statement.bind(master_key_id(), rank(), key_id_certifier(), type(), verified(), creation(), data());
+    }
 
     @AutoValue
     public static abstract class CertDetails implements CertsModel.SelectVerifyingCertDetailsModel {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/KeyRingPublic.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/KeyRingPublic.java
@@ -1,12 +1,28 @@
 package org.sufficientlysecure.keychain.model;
 
 
+import android.arch.persistence.db.SupportSQLiteDatabase;
+
 import com.google.auto.value.AutoValue;
 import org.sufficientlysecure.keychain.KeyRingsPublicModel;
+import org.sufficientlysecure.keychain.KeysModel.InsertKey;
+
 
 @AutoValue
 public abstract class KeyRingPublic implements KeyRingsPublicModel {
     public static final Factory<KeyRingPublic> FACTORY = new Factory<>(AutoValue_KeyRingPublic::new);
 
     public static final Mapper<KeyRingPublic> MAPPER = new Mapper<>(FACTORY);
+
+    public static KeyRingPublic create(long masterKeyId, byte[] keyRingData) {
+        return new AutoValue_KeyRingPublic(masterKeyId, keyRingData);
+    }
+
+    public static InsertKeyRingPublic createInsertStatement(SupportSQLiteDatabase db) {
+        return new InsertKeyRingPublic(db);
+    }
+
+    public void bindTo(InsertKeyRingPublic statement) {
+        statement.bind(master_key_id(), key_ring_data());
+    }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/KeySignature.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/KeySignature.java
@@ -1,6 +1,8 @@
 package org.sufficientlysecure.keychain.model;
 
 
+import android.arch.persistence.db.SupportSQLiteDatabase;
+
 import com.google.auto.value.AutoValue;
 import org.sufficientlysecure.keychain.KeySignaturesModel;
 
@@ -10,4 +12,16 @@ public abstract class KeySignature implements KeySignaturesModel {
     public static final Factory<KeySignature> FACTORY = new Factory<>(AutoValue_KeySignature::new);
 
     public static final Mapper<KeySignature> MAPPER = new Mapper<>(FACTORY);
+
+    public static InsertKeySignature createInsertStatement(SupportSQLiteDatabase db) {
+        return new InsertKeySignature(db);
+    }
+
+    public void bindTo(InsertKeySignature statement) {
+        statement.bind(master_key_id(), signer_key_id());
+    }
+
+    public static KeySignature create(long masterKeyId, long certId) {
+        return null;
+    }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/SubKey.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/SubKey.java
@@ -3,7 +3,10 @@ package org.sufficientlysecure.keychain.model;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+
+import android.arch.persistence.db.SupportSQLiteDatabase;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.sqldelight.RowMapper;
@@ -24,6 +27,33 @@ public abstract class SubKey implements KeysModel {
 
     public boolean expires() {
         return expiry() != null;
+    }
+
+    public static SubKey create(long masterKeyId, long rank, long keyId, Integer keySize, String keyCurveOid,
+            int algorithm, byte[] fingerprint, boolean canCertify, boolean canSign, boolean canEncrypt, boolean canAuth,
+            boolean isRevoked, SecretKeyType hasSecret, boolean isSecure, Date creation, Date expiry) {
+        long creationUnixTime = creation.getTime() / 1000;
+        Long expiryUnixTime = expiry != null ? expiry.getTime() / 1000 : null;
+        return new AutoValue_SubKey(masterKeyId, rank, keyId, keySize, keyCurveOid, algorithm, fingerprint, canCertify,
+                canSign, canEncrypt, canAuth, isRevoked, hasSecret, isSecure, creationUnixTime, expiryUnixTime);
+    }
+
+    public static InsertKey createInsertStatement(SupportSQLiteDatabase db) {
+        return new InsertKey(db, FACTORY);
+    }
+
+    public static UpdateHasSecretByMasterKeyId createUpdateHasSecretByMasterKeyIdStatement(SupportSQLiteDatabase db) {
+        return new UpdateHasSecretByMasterKeyId(db, FACTORY);
+    }
+
+    public static UpdateHasSecretByKeyId createUpdateHasSecretByKeyId(SupportSQLiteDatabase db) {
+        return new UpdateHasSecretByKeyId(db, FACTORY);
+    }
+
+    public void bindTo(InsertKey statement) {
+        statement.bind(master_key_id(), rank(), key_id(), key_size(), key_curve_oid(), algorithm(), fingerprint(),
+                can_certify(), can_sign(), can_encrypt(), can_authenticate(), is_revoked(), has_secret(), is_secure(),
+                creation(), expiry());
     }
 
     @AutoValue

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/UserPacket.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/UserPacket.java
@@ -16,6 +16,8 @@ public abstract class UserPacket implements UserPacketsModel {
             FACTORY.selectUserIdsByMasterKeyIdMapper(AutoValue_UserPacket_UserId::new);
     public static final SelectUserAttributesByTypeAndMasterKeyIdMapper<UserAttribute> USER_ATTRIBUTE_MAPPER =
             FACTORY.selectUserAttributesByTypeAndMasterKeyIdMapper(AutoValue_UserPacket_UserAttribute::new);
+    public static final UidStatusMapper<UidStatus> UID_STATUS_MAPPER =
+            FACTORY.selectUserIdStatusByEmailMapper(AutoValue_UserPacket_UidStatus::new);
 
     public static UserPacket create(long masterKeyId, int rank, Long type, String userId, String name, String email,
             String comment, byte[] attribute_data, boolean isPrimary, boolean isRevoked) {
@@ -53,6 +55,13 @@ public abstract class UserPacket implements UserPacketsModel {
         @NonNull
         public VerificationStatus verified() {
             return CustomColumnAdapters.VERIFICATON_STATUS_ADAPTER.decode(verified_int());
+        }
+    }
+
+    @AutoValue
+    public static abstract class UidStatus implements UidStatusModel {
+        public VerificationStatus keyStatus() {
+            return CustomColumnAdapters.VERIFICATON_STATUS_ADAPTER.decode(key_status_int());
         }
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/UserPacket.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/model/UserPacket.java
@@ -1,12 +1,12 @@
 package org.sufficientlysecure.keychain.model;
 
 
+import android.arch.persistence.db.SupportSQLiteDatabase;
 import android.support.annotation.NonNull;
 
 import com.google.auto.value.AutoValue;
 import org.sufficientlysecure.keychain.UserPacketsModel;
 import org.sufficientlysecure.keychain.pgp.CanonicalizedKeyRing.VerificationStatus;
-import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
 
 
 @AutoValue
@@ -16,6 +16,21 @@ public abstract class UserPacket implements UserPacketsModel {
             FACTORY.selectUserIdsByMasterKeyIdMapper(AutoValue_UserPacket_UserId::new);
     public static final SelectUserAttributesByTypeAndMasterKeyIdMapper<UserAttribute> USER_ATTRIBUTE_MAPPER =
             FACTORY.selectUserAttributesByTypeAndMasterKeyIdMapper(AutoValue_UserPacket_UserAttribute::new);
+
+    public static UserPacket create(long masterKeyId, int rank, Long type, String userId, String name, String email,
+            String comment, byte[] attribute_data, boolean isPrimary, boolean isRevoked) {
+        return new AutoValue_UserPacket(masterKeyId, rank, type,
+                userId, name, email, comment, attribute_data, isPrimary, isRevoked);
+    }
+
+    public static InsertUserPacket createInsertStatement(SupportSQLiteDatabase db) {
+        return new InsertUserPacket(db);
+    }
+
+    public void bindTo(InsertUserPacket statement) {
+        statement.bind(master_key_id(), rank(), type(), user_id(), name(), email(), comment(), attribute_data(),
+                is_primary(), is_revoked());
+    }
 
     @AutoValue
     public static abstract class UserId implements SelectUserIdsByMasterKeyIdModel {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/operations/results/OperationResult.java
@@ -339,7 +339,6 @@ public abstract class OperationResult implements Parcelable {
         MSG_IP_ENCODE_FAIL (LogLevel.DEBUG, R.string.msg_ip_encode_fail),
         MSG_IP_ERROR_IO_EXC (LogLevel.ERROR, R.string.msg_ip_error_io_exc),
         MSG_IP_ERROR_OP_EXC (LogLevel.ERROR, R.string.msg_ip_error_op_exc),
-        MSG_IP_ERROR_REMOTE_EX (LogLevel.ERROR, R.string.msg_ip_error_remote_ex),
         MSG_IP_FINGERPRINT_ERROR (LogLevel.ERROR, R.string.msg_ip_fingerprint_error),
         MSG_IP_FINGERPRINT_OK (LogLevel.INFO, R.string.msg_ip_fingerprint_ok),
         MSG_IP_INSERT_KEYRING (LogLevel.DEBUG, R.string.msg_ip_insert_keyring),

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainContract.java
@@ -17,17 +17,10 @@
 
 package org.sufficientlysecure.keychain.provider;
 
-import android.net.Uri;
+
 import android.provider.BaseColumns;
 
-import org.sufficientlysecure.keychain.Constants;
-
 public class KeychainContract {
-
-    public interface KeyRingsColumns {
-        String MASTER_KEY_ID = "master_key_id"; // not a database id
-        String KEY_RING_DATA = "key_ring_data"; // PGPPublicKeyRing / PGPSecretKeyRing blob
-    }
 
     public interface KeysColumns {
         String MASTER_KEY_ID = "master_key_id"; // not a database id
@@ -49,11 +42,6 @@ public class KeychainContract {
 
         String CREATION = "creation";
         String EXPIRY = "expiry";
-    }
-
-    public interface KeySignaturesColumns {
-        String MASTER_KEY_ID = "master_key_id"; // not a database id
-        String SIGNER_KEY_ID = "signer_key_id";
     }
 
     public interface UserPacketsColumns {
@@ -79,78 +67,15 @@ public class KeychainContract {
         String DATA = "data";
     }
 
-    public interface ApiAppsAllowedKeysColumns {
-        String KEY_ID = "key_id"; // not a database id
-        String PACKAGE_NAME = "package_name"; // foreign key to api_apps.package_name
-    }
-
-    public interface OverriddenWarnings {
-        String IDENTIFIER = "identifier";
-    }
-
-    public static final String CONTENT_AUTHORITY = Constants.PROVIDER_AUTHORITY;
-
-    private static final Uri BASE_CONTENT_URI_INTERNAL = Uri
-            .parse("content://" + CONTENT_AUTHORITY);
-
-    public static final String BASE_KEY_RINGS = "key_rings";
-
-    public static final String BASE_KEY_SIGNATURES = "key_signatures";
-
-    public static final String PATH_PUBLIC = "public";
-    public static final String PATH_USER_IDS = "user_ids";
-    public static final String PATH_KEYS = "keys";
-    public static final String PATH_CERTS = "certs";
-
-    public static class KeyRings implements BaseColumns, KeysColumns, UserPacketsColumns {
-        public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
-                .appendPath(BASE_KEY_RINGS).build();
-    }
-
-    public static class KeyRingData implements KeyRingsColumns, BaseColumns {
-        public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
-                .appendPath(BASE_KEY_RINGS).build();
-
-        public static Uri buildPublicKeyRingUri(long masterKeyId) {
-            return CONTENT_URI.buildUpon().appendPath(Long.toString(masterKeyId)).appendPath(PATH_PUBLIC).build();
-        }
-    }
-
     public static class Keys implements KeysColumns, BaseColumns {
-        public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
-                .appendPath(BASE_KEY_RINGS).build();
-
-        public static Uri buildKeysUri(long masterKeyId) {
-            return CONTENT_URI.buildUpon().appendPath(Long.toString(masterKeyId)).appendPath(PATH_KEYS).build();
-        }
-
-    }
-
-    public static class KeySignatures implements KeySignaturesColumns, BaseColumns {
-        public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
-                .appendPath(BASE_KEY_SIGNATURES).build();
     }
 
     public static class UserPackets implements UserPacketsColumns, BaseColumns {
-        public static final String VERIFIED = "verified";
-        public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
-                .appendPath(BASE_KEY_RINGS).build();
-
-        public static Uri buildUserIdsUri(long masterKeyId) {
-            return CONTENT_URI.buildUpon().appendPath(Long.toString(masterKeyId)).appendPath(PATH_USER_IDS).build();
-        }
     }
 
     public static class Certs implements CertsColumns, BaseColumns {
         public static final int VERIFIED_SECRET = 1;
         public static final int VERIFIED_SELF = 2;
-
-        public static final Uri CONTENT_URI = BASE_CONTENT_URI_INTERNAL.buildUpon()
-                .appendPath(BASE_KEY_RINGS).build();
-
-        public static Uri buildCertsUri(long masterKeyId) {
-            return CONTENT_URI.buildUpon().appendPath(Long.toString(masterKeyId)).appendPath(PATH_CERTS).build();
-        }
     }
 
     private KeychainContract() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainExternalContract.java
@@ -38,19 +38,6 @@ public class KeychainExternalContract {
     public static final int KEY_STATUS_UNVERIFIED = 1;
     public static final int KEY_STATUS_VERIFIED = 2;
 
-    public static class EmailStatus implements BaseColumns {
-        public static final String EMAIL_ADDRESS = "email_address";
-        public static final String USER_ID = "user_id";
-        public static final String USER_ID_STATUS = "email_status";
-        public static final String MASTER_KEY_ID = "master_key_id";
-
-        public static final Uri CONTENT_URI = BASE_CONTENT_URI_EXTERNAL.buildUpon()
-                .appendPath(BASE_EMAIL_STATUS).build();
-
-        public static final String CONTENT_TYPE
-                = "vnd.android.cursor.dir/vnd.org.sufficientlysecure.keychain.provider.email_status";
-    }
-
     public static class AutocryptStatus implements BaseColumns {
         public static final String ADDRESS = "address";
 
@@ -72,9 +59,6 @@ public class KeychainExternalContract {
 
         public static final Uri CONTENT_URI = BASE_CONTENT_URI_EXTERNAL.buildUpon()
                 .appendPath(BASE_AUTOCRYPT_STATUS).build();
-
-        public static final String CONTENT_TYPE =
-                "vnd.android.cursor.dir/vnd.org.sufficientlysecure.keychain.provider.email_status";
     }
 
     private KeychainExternalContract() {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/provider/KeychainProvider.java
@@ -1,225 +1,48 @@
-/*
- * Copyright (C) 2017 Schürmann & Breitmoser GbR
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package org.sufficientlysecure.keychain.provider;
 
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
 import android.content.ContentProvider;
 import android.content.ContentValues;
-import android.content.UriMatcher;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteConstraintException;
-import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
-
-import org.sufficientlysecure.keychain.KeychainDatabase;
-import org.sufficientlysecure.keychain.daos.DatabaseNotifyManager;
-import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
-import org.sufficientlysecure.keychain.provider.KeychainContract.KeySignatures;
-import org.sufficientlysecure.keychain.provider.KeychainContract.Keys;
-import org.sufficientlysecure.keychain.provider.KeychainContract.UserPackets;
-import org.sufficientlysecure.keychain.provider.KeychainContract.UserPacketsColumns;
-import org.sufficientlysecure.keychain.KeychainDatabase.Tables;
-import timber.log.Timber;
+import android.support.annotation.Nullable;
 
 
 public class KeychainProvider extends ContentProvider {
-    private static final int KEY_RING_KEYS = 201;
-    private static final int KEY_RING_USER_IDS = 202;
-    private static final int KEY_RING_PUBLIC = 203;
-    private static final int KEY_RING_CERTS = 205;
-
-    private static final int KEY_SIGNATURES = 700;
-
-    protected UriMatcher mUriMatcher;
-
-    /**
-     * Build and return a {@link UriMatcher} that catches all {@link Uri} variations supported by
-     * this {@link ContentProvider}.
-     */
-    protected UriMatcher buildUriMatcher() {
-        final UriMatcher matcher = new UriMatcher(UriMatcher.NO_MATCH);
-
-        String authority = KeychainContract.CONTENT_AUTHORITY;
-
-        /*
-         * list key_ring specifics
-         *
-         * <pre>
-         * key_rings/_/keys
-         * key_rings/_/user_ids
-         * key_rings/_/public
-         * key_rings/_/certs
-         * </pre>
-         */
-        matcher.addURI(authority, KeychainContract.BASE_KEY_RINGS + "/*/"
-                + KeychainContract.PATH_KEYS,
-                KEY_RING_KEYS);
-        matcher.addURI(authority, KeychainContract.BASE_KEY_RINGS + "/*/"
-                + KeychainContract.PATH_USER_IDS,
-                KEY_RING_USER_IDS);
-        matcher.addURI(authority, KeychainContract.BASE_KEY_RINGS + "/*/"
-                + KeychainContract.PATH_PUBLIC,
-                KEY_RING_PUBLIC);
-        matcher.addURI(authority, KeychainContract.BASE_KEY_RINGS + "/*/"
-                + KeychainContract.PATH_CERTS,
-                KEY_RING_CERTS);
-
-        matcher.addURI(authority, KeychainContract.BASE_KEY_SIGNATURES, KEY_SIGNATURES);
-
-
-        return matcher;
-    }
-
-    private KeychainDatabase mKeychainDatabase;
 
     @Override
     public boolean onCreate() {
-        mUriMatcher = buildUriMatcher();
-        return true;
+        return false;
     }
 
-    public KeychainDatabase getDb() {
-        if(mKeychainDatabase == null) {
-            mKeychainDatabase = KeychainDatabase.getInstance(getContext());
-        }
-        return mKeychainDatabase;
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection,
+            @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        throw new UnsupportedOperationException();
     }
 
+    @Nullable
     @Override
     public String getType(@NonNull Uri uri) {
         throw new UnsupportedOperationException();
     }
 
+    @Nullable
     @Override
-    public Cursor query(
-            @NonNull Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Uri insert(@NonNull Uri uri, ContentValues values) {
-        Timber.d("insert(uri=" + uri + ", values=" + values.toString() + ")");
-
-        final SupportSQLiteDatabase db = getDb().getWritableDatabase();
-
-        Uri rowUri = null;
-        Long keyId = null;
-        try {
-            final int match = mUriMatcher.match(uri);
-
-            switch (match) {
-                case KEY_RING_PUBLIC: {
-                    db.insert(Tables.KEY_RINGS_PUBLIC, SQLiteDatabase.CONFLICT_FAIL, values);
-                    keyId = values.getAsLong(Keys.MASTER_KEY_ID);
-                    break;
-                }
-                case KEY_RING_KEYS: {
-                    db.insert(Tables.KEYS, SQLiteDatabase.CONFLICT_FAIL, values);
-                    keyId = values.getAsLong(Keys.MASTER_KEY_ID);
-                    break;
-                }
-                case KEY_RING_USER_IDS: {
-                    // iff TYPE is null, user_id MUST be null as well
-                    if (!(values.get(UserPacketsColumns.TYPE) == null
-                            ? (values.get(UserPacketsColumns.USER_ID) != null && values.get(UserPacketsColumns.ATTRIBUTE_DATA) == null)
-                            : (values.get(UserPacketsColumns.ATTRIBUTE_DATA) != null && values.get(UserPacketsColumns.USER_ID) == null)
-                    )) {
-                        throw new AssertionError("Incorrect type for user packet! This is a bug!");
-                    }
-                    if (((Number) values.get(UserPacketsColumns.RANK)).intValue() == 0 && values.get(UserPacketsColumns.USER_ID) == null) {
-                        throw new AssertionError("Rank 0 user packet must be a user id!");
-                    }
-                    db.insert(Tables.USER_PACKETS, SQLiteDatabase.CONFLICT_FAIL, values);
-                    keyId = values.getAsLong(UserPackets.MASTER_KEY_ID);
-                    break;
-                }
-                case KEY_RING_CERTS: {
-                    // we replace here, keeping only the latest signature
-                    // TODO this would be better handled in savePublicKeyRing directly!
-                    db.insert(Tables.CERTS, SQLiteDatabase.CONFLICT_FAIL, values);
-                    keyId = values.getAsLong(Certs.MASTER_KEY_ID);
-                    break;
-                }
-                case KEY_SIGNATURES: {
-                    db.insert(Tables.KEY_SIGNATURES, SQLiteDatabase.CONFLICT_FAIL, values);
-                    rowUri = KeySignatures.CONTENT_URI;
-                    break;
-                }
-                default: {
-                    throw new UnsupportedOperationException("Unknown uri: " + uri);
-                }
-            }
-
-            if (keyId != null) {
-                uri = DatabaseNotifyManager.getNotifyUriMasterKeyId(keyId);
-                rowUri = uri;
-            }
-
-        } catch (SQLiteConstraintException e) {
-            Timber.d(e, "Constraint exception on insert! Entry already existing?");
-        }
-
-        return rowUri;
-    }
-
-    @Override
-    public int delete(@NonNull Uri uri, String additionalSelection, String[] selectionArgs) {
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int update(@NonNull Uri uri, ContentValues values, String selection, String[] selectionArgs) {
-        Timber.v("update(uri=" + uri + ", values=" + values.toString() + ")");
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        throw new UnsupportedOperationException();
+    }
 
-        final SupportSQLiteDatabase db = getDb().getWritableDatabase();
-
-        int count = 0;
-        try {
-            final int match = mUriMatcher.match(uri);
-            switch (match) {
-                case KEY_RING_KEYS: {
-                    if (values.size() != 1 || !values.containsKey(Keys.HAS_SECRET)) {
-                        throw new UnsupportedOperationException(
-                                "Only has_secret column may be updated!");
-                    }
-                    // make sure we get a long value here
-                    Long mkid = Long.parseLong(uri.getPathSegments().get(1));
-                    String actualSelection = Keys.MASTER_KEY_ID + " = " + Long.toString(mkid);
-                    if (!TextUtils.isEmpty(selection)) {
-                        actualSelection += " AND (" + selection + ")";
-                    }
-                    count = db.update(Tables.KEYS, SQLiteDatabase.CONFLICT_FAIL, values, actualSelection, selectionArgs);
-                    break;
-                }
-                default: {
-                    throw new UnsupportedOperationException("Unknown uri: " + uri);
-                }
-            }
-        } catch (SQLiteConstraintException e) {
-            Timber.d(e, "Constraint exception on update! Entry already existing?");
-        }
-
-        return count;
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection,
+            @Nullable String[] selectionArgs) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/AutocryptInteractor.java
@@ -3,8 +3,11 @@ package org.sufficientlysecure.keychain.remote;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import android.content.Context;
 import android.support.annotation.Nullable;
@@ -146,15 +149,15 @@ public class AutocryptInteractor {
         return uncachedKeyRing;
     }
 
-    public List<AutocryptRecommendationResult> determineAutocryptRecommendations(String... autocryptIds) {
-        List<AutocryptRecommendationResult> result = new ArrayList<>(autocryptIds.length);
+    public Map<String,AutocryptRecommendationResult> determineAutocryptRecommendations(String... autocryptIds) {
+        Map<String,AutocryptRecommendationResult> result = new HashMap<>(autocryptIds.length);
 
         for (AutocryptKeyStatus autocryptKeyStatus : autocryptPeerDao.getAutocryptKeyStatus(packageName, autocryptIds)) {
             AutocryptRecommendationResult peerResult = determineAutocryptRecommendation(autocryptKeyStatus);
-            result.add(peerResult);
+            result.put(peerResult.peerId, peerResult);
         }
 
-        return result;
+        return Collections.unmodifiableMap(result);
     }
 
     /** Determines Autocrypt "ui-recommendation", according to spec.

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/KeychainExternalProvider.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/KeychainExternalProvider.java
@@ -38,13 +38,13 @@ import android.text.TextUtils;
 
 import org.sufficientlysecure.keychain.BuildConfig;
 import org.sufficientlysecure.keychain.Constants;
-import org.sufficientlysecure.keychain.daos.ApiAppDao;
-import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
-import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
-import org.sufficientlysecure.keychain.provider.KeychainContract.Keys;
-import org.sufficientlysecure.keychain.provider.KeychainContract.UserPackets;
 import org.sufficientlysecure.keychain.KeychainDatabase;
 import org.sufficientlysecure.keychain.KeychainDatabase.Tables;
+import org.sufficientlysecure.keychain.daos.ApiAppDao;
+import org.sufficientlysecure.keychain.daos.DatabaseNotifyManager;
+import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
+import org.sufficientlysecure.keychain.provider.KeychainContract.Keys;
+import org.sufficientlysecure.keychain.provider.KeychainContract.UserPackets;
 import org.sufficientlysecure.keychain.provider.KeychainExternalContract;
 import org.sufficientlysecure.keychain.provider.KeychainExternalContract.AutocryptStatus;
 import org.sufficientlysecure.keychain.provider.KeychainExternalContract.EmailStatus;
@@ -200,7 +200,7 @@ public class KeychainExternalProvider extends ContentProvider {
                 }
 
                 // uri to watch is all /key_rings/
-                uri = KeyRings.CONTENT_URI;
+                uri = DatabaseNotifyManager.getNotifyUriAllKeys();
 
                 break;
             }
@@ -281,7 +281,7 @@ public class KeychainExternalProvider extends ContentProvider {
                 }
 
                 // uri to watch is all /key_rings/
-                uri = KeyRings.CONTENT_URI;
+                uri = DatabaseNotifyManager.getNotifyUriAllKeys();
                 break;
             }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/KeyListFragment.java
@@ -52,8 +52,11 @@ import eu.davidea.flexibleadapter.FlexibleAdapter.OnItemClickListener;
 import eu.davidea.flexibleadapter.FlexibleAdapter.OnItemLongClickListener;
 import eu.davidea.flexibleadapter.SelectableAdapter.Mode;
 import org.sufficientlysecure.keychain.Constants;
+import org.sufficientlysecure.keychain.KeychainDatabase;
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.compatibility.ClipboardReflection;
+import org.sufficientlysecure.keychain.daos.DatabaseNotifyManager;
+import org.sufficientlysecure.keychain.daos.KeyRepository;
 import org.sufficientlysecure.keychain.keysync.KeyserverSyncManager;
 import org.sufficientlysecure.keychain.model.SubKey.UnifiedKeyInfo;
 import org.sufficientlysecure.keychain.operations.KeySyncParcel;
@@ -61,9 +64,6 @@ import org.sufficientlysecure.keychain.operations.results.BenchmarkResult;
 import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.pgp.PgpHelper;
-import org.sufficientlysecure.keychain.daos.KeyRepository;
-import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
-import org.sufficientlysecure.keychain.KeychainDatabase;
 import org.sufficientlysecure.keychain.service.BenchmarkInputParcel;
 import org.sufficientlysecure.keychain.ui.adapter.FlexibleKeyDetailsItem;
 import org.sufficientlysecure.keychain.ui.adapter.FlexibleKeyDummyItem;
@@ -492,7 +492,7 @@ public class KeyListFragment extends RecyclerFragment<FlexibleAdapter<FlexibleKe
                 try {
                     KeychainDatabase.debugBackup(getActivity(), true);
                     Notify.create(getActivity(), "Restored debug_backup.db", Notify.Style.OK).show();
-                    getActivity().getContentResolver().notifyChange(KeyRings.CONTENT_URI, null);
+                    DatabaseNotifyManager.create(requireContext()).notifyAllKeysChange();
                 } catch (IOException e) {
                     Timber.e(e, "IO Error");
                     Notify.create(getActivity(), "IO Error " + e.getMessage(), Notify.Style.ERROR).show();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvUserIdsFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ViewKeyAdvUserIdsFragment.java
@@ -44,7 +44,6 @@ import org.sufficientlysecure.keychain.model.SubKey.UnifiedKeyInfo;
 import org.sufficientlysecure.keychain.model.UserPacket.UserId;
 import org.sufficientlysecure.keychain.operations.results.EditKeyResult;
 import org.sufficientlysecure.keychain.pgp.CanonicalizedKeyRing.VerificationStatus;
-import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
 import org.sufficientlysecure.keychain.service.SaveKeyringParcel;
 import org.sufficientlysecure.keychain.ui.ViewKeyAdvActivity.ViewKeyAdvViewModel;
 import org.sufficientlysecure.keychain.ui.adapter.UserIdsAdapter;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ManageSecurityTokenFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/token/ManageSecurityTokenFragment.java
@@ -49,7 +49,6 @@ import org.sufficientlysecure.keychain.keyimport.ParcelableKeyRing;
 import org.sufficientlysecure.keychain.operations.results.ImportKeyResult;
 import org.sufficientlysecure.keychain.operations.results.OperationResult;
 import org.sufficientlysecure.keychain.operations.results.PromoteKeyResult;
-import org.sufficientlysecure.keychain.provider.KeychainContract.KeyRings;
 import org.sufficientlysecure.keychain.securitytoken.SecurityTokenInfo;
 import org.sufficientlysecure.keychain.service.ImportKeyringParcel;
 import org.sufficientlysecure.keychain.service.PromoteKeyringParcel;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertListWidget.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/widget/CertListWidget.java
@@ -19,12 +19,6 @@ package org.sufficientlysecure.keychain.ui.widget;
 
 
 import android.content.Context;
-import android.database.Cursor;
-import android.net.Uri;
-import android.os.Bundle;
-import android.support.v4.app.LoaderManager;
-import android.support.v4.content.CursorLoader;
-import android.support.v4.content.Loader;
 import android.text.format.DateUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -34,8 +28,6 @@ import android.widget.ViewAnimator;
 
 import org.sufficientlysecure.keychain.R;
 import org.sufficientlysecure.keychain.model.Certification.CertDetails;
-import org.sufficientlysecure.keychain.provider.KeychainContract;
-import org.sufficientlysecure.keychain.provider.KeychainContract.Certs;
 
 public class CertListWidget extends ViewAnimator {
     private TextView vCollapsed;

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Certs.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Certs.sq
@@ -14,6 +14,9 @@ CREATE TABLE IF NOT EXISTS certs(
     FOREIGN KEY(master_key_id, rank) REFERENCES user_packets(master_key_id, rank) ON DELETE CASCADE
 );
 
+insertCert:
+INSERT INTO certs VALUES (?, ?, ?, ?, ?, ?, ?);
+
 selectVerifyingCertDetails:
 SELECT master_key_id AS masterKeyId, key_id_certifier AS signerMasterKeyId, creation * 1000 AS creation
     FROM certs

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/KeyRingsPublic.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/KeyRingsPublic.sq
@@ -3,6 +3,9 @@ CREATE TABLE IF NOT EXISTS keyrings_public (
     key_ring_data BLOB NULL
 );
 
+insertKeyRingPublic:
+INSERT INTO keyrings_public VALUES (?, ?);
+
 selectAllMasterKeyIds:
 SELECT master_key_id
     FROM keyrings_public;

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/KeySignatures.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/KeySignatures.sq
@@ -5,6 +5,9 @@ CREATE TABLE IF NOT EXISTS key_signatures (
     FOREIGN KEY(master_key_id) REFERENCES keyrings_public(master_key_id) ON DELETE CASCADE
 );
 
+insertKeySignature:
+INSERT INTO key_signatures VALUES (?, ?);
+
 selectMasterKeyIdsBySigner:
 SELECT master_key_id
    FROM key_signatures WHERE signer_key_id IN ?;

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
@@ -99,11 +99,11 @@ SELECT fingerprint
 selectEffectiveSignKeyIdByMasterKeyId:
 SELECT key_id
     FROM keys
-    WHERE is_revoked = 0 AND is_secure = 1 AND has_secret > 1 AND ( expiry IS NULL OR expiry >= date('now') )
+    WHERE is_revoked = 0 AND is_secure = 1 AND has_secret > 1 AND ( expiry IS NULL OR expiry >= strftime('%s', 'now') )
         AND can_sign = 1 AND master_key_id = ?;
 
 selectEffectiveAuthKeyIdByMasterKeyId:
 SELECT key_id
     FROM keys
-    WHERE is_revoked = 0 AND is_secure = 1 AND has_secret > 1 AND ( expiry IS NULL OR expiry >= date('now') )
+    WHERE is_revoked = 0 AND is_secure = 1 AND has_secret > 1 AND ( expiry IS NULL OR expiry >= strftime('%s', 'now') )
         AND can_authenticate = 1 AND master_key_id = ?;

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
@@ -23,6 +23,19 @@ CREATE TABLE IF NOT EXISTS keys (
     keyrings_public(master_key_id) ON DELETE CASCADE
 );
 
+insertKey:
+INSERT INTO keys VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+updateHasSecretByMasterKeyId:
+UPDATE keys
+    SET has_secret = ?2
+    WHERE master_key_id = ?1;
+
+updateHasSecretByKeyId:
+UPDATE keys
+    SET has_secret = ?2
+    WHERE key_id = ?1;
+
 unifiedKeyView:
 CREATE VIEW unifiedKeyView AS
     SELECT keys.master_key_id, keys.fingerprint, MIN(user_packets.rank), user_packets.user_id, user_packets.name, user_packets.email, user_packets.comment, keys.creation, keys.expiry, keys.is_revoked, keys.is_secure, keys.can_certify, certs.verified,

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
@@ -36,6 +36,12 @@ UPDATE keys
     SET has_secret = ?2
     WHERE key_id = ?1;
 
+validKeysView:
+CREATE VIEW validMasterKeys AS
+SELECT *
+    FROM keys
+    WHERE rank = 0 AND is_revoked = 0 AND is_secure = 1 AND (expiry IS NULL OR expiry >= strftime('%s', 'now'));
+
 unifiedKeyView:
 CREATE VIEW unifiedKeyView AS
     SELECT keys.master_key_id, keys.fingerprint, MIN(user_packets.rank), user_packets.user_id, user_packets.name, user_packets.email, user_packets.comment, keys.creation, keys.expiry, keys.is_revoked, keys.is_secure, keys.can_certify, certs.verified,

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/UserPackets.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/UserPackets.sq
@@ -49,3 +49,23 @@ SELECT user_packets.master_key_id, user_packets.rank, attribute_data, is_primary
         LEFT JOIN certs ON ( user_packets.master_key_id = certs.master_key_id AND user_packets.rank = certs.rank AND certs.verified > 0 )
     WHERE user_packets.type = ? AND user_packets.master_key_id = ? AND user_packets.rank = ?
     GROUP BY user_packets.master_key_id, user_packets.rank;
+
+
+uidStatus:
+CREATE VIEW uidStatus AS
+    SELECT user_packets.email, MIN(certs.verified) AS key_status_int, user_packets.user_id, user_packets.master_key_id, COUNT(DISTINCT user_packets.master_key_id) AS candidates
+    FROM user_packets
+        JOIN validMasterKeys USING (master_key_id)
+        LEFT JOIN certs ON (certs.master_key_id = user_packets.master_key_id AND certs.rank = user_packets.rank AND certs.verified > 0)
+    WHERE user_packets.email IS NOT NULL
+    GROUP BY user_packets.email;
+
+selectUserIdStatusByEmail:
+SELECT *
+FROM uidStatus
+    WHERE email IN ?;
+
+selectUserIdStatusByEmailLike:
+SELECT *
+FROM uidStatus
+    WHERE email LIKE ?;

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/UserPackets.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/UserPackets.sq
@@ -16,6 +16,9 @@ CREATE TABLE IF NOT EXISTS user_packets(
     keyrings_public(master_key_id) ON DELETE CASCADE
 );
 
+insertUserPacket:
+INSERT INTO user_packets VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
 selectUserIdsByMasterKeyId:
 SELECT user_packets.master_key_id, user_packets.rank, user_id, name, email, comment, is_primary, is_revoked, MIN(certs.verified) AS verified_int
     FROM user_packets

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/remote/KeychainExternalProviderTest.java
@@ -18,19 +18,18 @@ import org.robolectric.shadows.ShadowBinder;
 import org.robolectric.shadows.ShadowLog;
 import org.robolectric.shadows.ShadowPackageManager;
 import org.sufficientlysecure.keychain.KeychainTestRunner;
+import org.sufficientlysecure.keychain.daos.ApiAppDao;
+import org.sufficientlysecure.keychain.daos.AutocryptPeerDao;
+import org.sufficientlysecure.keychain.daos.KeyWritableRepository;
 import org.sufficientlysecure.keychain.model.ApiApp;
 import org.sufficientlysecure.keychain.model.AutocryptPeer.GossipOrigin;
 import org.sufficientlysecure.keychain.operations.CertifyOperation;
 import org.sufficientlysecure.keychain.operations.results.CertifyResult;
 import org.sufficientlysecure.keychain.operations.results.SaveKeyringResult;
 import org.sufficientlysecure.keychain.pgp.UncachedKeyRing;
-import org.sufficientlysecure.keychain.daos.ApiAppDao;
-import org.sufficientlysecure.keychain.daos.AutocryptPeerDao;
 import org.sufficientlysecure.keychain.provider.KeyRepositorySaveTest;
-import org.sufficientlysecure.keychain.daos.KeyWritableRepository;
 import org.sufficientlysecure.keychain.provider.KeychainExternalContract;
 import org.sufficientlysecure.keychain.provider.KeychainExternalContract.AutocryptStatus;
-import org.sufficientlysecure.keychain.provider.KeychainExternalContract.EmailStatus;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel;
 import org.sufficientlysecure.keychain.service.CertifyActionsParcel.CertifyAction;
 import org.sufficientlysecure.keychain.service.input.CryptoInputParcel;
@@ -49,10 +48,7 @@ public class KeychainExternalProviderTest {
     static final String PACKAGE_NAME = "test.package";
     static final byte[] PACKAGE_SIGNATURE = new byte[] { 1, 2, 3 };
     static final String MAIL_ADDRESS_1 = "twi@openkeychain.org";
-    static final String MAIL_ADDRESS_2 = "pink@openkeychain.org";
-    static final String MAIL_ADDRESS_SEC_1 = "twi-sec@openkeychain.org";
     static final String USER_ID_1 = "twi <twi@openkeychain.org>";
-    static final String USER_ID_SEC_1 = "twi <twi-sec@openkeychain.org>";
     static final long KEY_ID_SECRET = 0x5D4DA4423C39122FL;
     static final long KEY_ID_PUBLIC = 0x9A282CE2AB44A382L;
     public static final String AUTOCRYPT_PEER = "tid";
@@ -92,8 +88,8 @@ public class KeychainExternalProviderTest {
         apiAppDao.deleteApiApp(PACKAGE_NAME);
 
         contentResolver.query(
-                EmailStatus.CONTENT_URI,
-                new String[] { EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID },
+                AutocryptStatus.CONTENT_URI,
+                new String[] { AutocryptStatus.ADDRESS },
                 null, new String [] { }, null
         );
     }
@@ -104,104 +100,10 @@ public class KeychainExternalProviderTest {
         apiAppDao.insertApiApp(ApiApp.create(PACKAGE_NAME, new byte[] { 1, 2, 4 }));
 
         contentResolver.query(
-                EmailStatus.CONTENT_URI,
-                new String[] { EmailStatus.EMAIL_ADDRESS, EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID },
+                AutocryptStatus.CONTENT_URI,
+                new String[] { AutocryptStatus.ADDRESS },
                 null, new String [] { }, null
         );
-    }
-
-    @Test
-    public void testEmailStatus_withNonExistentAddress() throws Exception {
-        Cursor cursor = contentResolver.query(
-                EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
-                null, new String [] { MAIL_ADDRESS_1 }, null
-        );
-
-        assertNotNull(cursor);
-        assertTrue(cursor.moveToFirst());
-        assertEquals(MAIL_ADDRESS_1, cursor.getString(0));
-        assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(1));
-        assertTrue(cursor.isNull(2));
-    }
-
-    @Test
-    public void testEmailStatus() throws Exception {
-        insertPublicKeyringFrom("/test-keys/testring.pub");
-
-        Cursor cursor = contentResolver.query(
-                EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
-                null, new String [] { MAIL_ADDRESS_1 }, null
-        );
-
-        assertNotNull(cursor);
-        assertTrue(cursor.moveToFirst());
-        assertEquals(MAIL_ADDRESS_1, cursor.getString(0));
-        assertEquals(KeychainExternalContract.KEY_STATUS_UNVERIFIED, cursor.getInt(1));
-        assertEquals("twi <twi@openkeychain.org>", cursor.getString(2));
-        assertFalse(cursor.moveToNext());
-    }
-
-    @Test
-    public void testEmailStatus_multiple() throws Exception {
-        insertPublicKeyringFrom("/test-keys/testring.pub");
-
-        Cursor cursor = contentResolver.query(
-                EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
-                null, new String [] { MAIL_ADDRESS_1, MAIL_ADDRESS_2 }, null
-        );
-
-        assertNotNull(cursor);
-        assertTrue(cursor.moveToNext());
-        assertEquals(MAIL_ADDRESS_2, cursor.getString(0));
-        assertEquals(KeychainExternalContract.KEY_STATUS_UNAVAILABLE, cursor.getInt(1));
-        assertTrue(cursor.isNull(2));
-        assertTrue(cursor.moveToNext());
-        assertEquals(MAIL_ADDRESS_1, cursor.getString(0));
-        assertEquals(KeychainExternalContract.KEY_STATUS_UNVERIFIED, cursor.getInt(1));
-        assertEquals("twi <twi@openkeychain.org>", cursor.getString(2));
-        assertFalse(cursor.moveToNext());
-    }
-
-    @Test
-    public void testEmailStatus_withSecretKey() throws Exception {
-        insertSecretKeyringFrom("/test-keys/testring.sec");
-
-        Cursor cursor = contentResolver.query(
-                EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID_STATUS, EmailStatus.USER_ID },
-                null, new String [] { MAIL_ADDRESS_SEC_1 }, null
-        );
-
-        assertNotNull(cursor);
-        assertTrue(cursor.moveToFirst());
-        assertEquals(MAIL_ADDRESS_SEC_1, cursor.getString(0));
-        assertEquals(USER_ID_SEC_1, cursor.getString(2));
-        assertEquals(2, cursor.getInt(1));
-        assertFalse(cursor.moveToNext());
-    }
-
-    @Test
-    public void testEmailStatus_withConfirmedKey() throws Exception {
-        insertSecretKeyringFrom("/test-keys/testring.sec");
-        insertPublicKeyringFrom("/test-keys/testring.pub");
-
-        certifyKey(KEY_ID_SECRET, KEY_ID_PUBLIC, USER_ID_1);
-
-        Cursor cursor = contentResolver.query(
-                EmailStatus.CONTENT_URI, new String[] {
-                        EmailStatus.EMAIL_ADDRESS, EmailStatus.USER_ID, EmailStatus.USER_ID_STATUS},
-                null, new String [] { MAIL_ADDRESS_1 }, null
-        );
-
-        assertNotNull(cursor);
-        assertTrue(cursor.moveToFirst());
-        assertEquals(MAIL_ADDRESS_1, cursor.getString(0));
-        assertEquals(USER_ID_1, cursor.getString(1));
-        assertEquals(KeychainExternalContract.KEY_STATUS_VERIFIED, cursor.getInt(2));
-        assertFalse(cursor.moveToNext());
     }
 
     @Test


### PR DESCRIPTION
This is a follow-up to #2351. It does a couple of things:

- removes remaining functionality from KeychainProvider, specifically insert operations
- Uses MatrixCursor fed from DAOs instead of a temporary SQLite DB in KeychainExternalProvider