### PR TITLE
WIP: Use static passphrases in tests

### DIFF
--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/BackupOperationTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/BackupOperationTest.java
@@ -79,11 +79,9 @@ import static org.mockito.Mockito.when;
 @RunWith(KeychainTestRunner.class)
 public class BackupOperationTest {
 
-    static Passphrase mPassphrase = TestingUtils.genPassphrase(true);
+    static Passphrase mPassphrase = TestingUtils.testPassphrase0;
 
     static UncachedKeyRing mStaticRing1, mStaticRing2;
-    static Passphrase mKeyPhrase1 = TestingUtils.genPassphrase(true);
-    static Passphrase mKeyPhrase2 = TestingUtils.genPassphrase(true);
 
     static PrintStream oldShadowStream;
 
@@ -104,7 +102,7 @@ public class BackupOperationTest {
             builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(
                     Algorithm.ECDH, 0, SaveKeyringParcel.Curve.NIST_P256, KeyFlags.ENCRYPT_COMMS, 0L));
             builder.addUserId("snips");
-            builder.setNewUnlock(ChangeUnlockParcel.createUnLockParcelForNewKey(mKeyPhrase1));
+            builder.setNewUnlock(ChangeUnlockParcel.createUnLockParcelForNewKey(mPassphrase));
 
             PgpEditKeyResult result = op.createSecretKeyRing(builder.build());
             assertTrue("initial test key creation must succeed", result.success());

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/CertifyOperationTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/CertifyOperationTest.java
@@ -57,8 +57,8 @@ import org.sufficientlysecure.keychain.util.TestingUtils;
 public class CertifyOperationTest {
 
     static UncachedKeyRing mStaticRing1, mStaticRing2;
-    static Passphrase mKeyPhrase1 = TestingUtils.genPassphrase(true);
-    static Passphrase mKeyPhrase2 = TestingUtils.genPassphrase(true);
+    static Passphrase mKeyPhrase1 = TestingUtils.testPassphrase1;
+    static Passphrase mKeyPhrase2 = TestingUtils.testPassphrase2;
 
     static PrintStream oldShadowStream;
 

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/PromoteKeyOperationTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/operations/PromoteKeyOperationTest.java
@@ -57,7 +57,7 @@ import org.sufficientlysecure.keychain.util.TestingUtils;
 public class PromoteKeyOperationTest {
 
     static UncachedKeyRing mStaticRing;
-    static Passphrase mKeyPhrase1 = TestingUtils.genPassphrase(true);
+    static Passphrase mKeyPhrase1 = TestingUtils.testPassphrase1;
 
     static PrintStream oldShadowStream;
 

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpEncryptDecryptTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpEncryptDecryptTest.java
@@ -73,7 +73,7 @@ import static org.hamcrest.core.Is.is;
 @RunWith(KeychainTestRunner.class)
 public class PgpEncryptDecryptTest {
 
-    static Passphrase mSymmetricPassphrase = TestingUtils.genPassphrase(true);
+    static Passphrase mSymmetricPassphrase = TestingUtils.testPassphrase0;
 
     static UncachedKeyRing mStaticRing1, mStaticRing2, mStaticRingInsecure;
     static Passphrase mKeyPhrase1, mKeyPhrase2;
@@ -165,7 +165,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testSymmetricEncryptDecrypt() {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
         byte[] ciphertext;
 
         { // encrypt data with a given passphrase
@@ -291,7 +291,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testAsymmetricSignLiteral() {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
         byte[] ciphertext;
 
         { // encrypt data with key
@@ -346,7 +346,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testAsymmetricSignCleartext() {
 
-        String plaintext = "dies ist ein\r\nplaintext\n ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein\r\nplaintext\n ☭";
         byte[] ciphertext;
 
         { // encrypt data with key
@@ -407,7 +407,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testAsymmetricSignDetached() {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
         byte[] detachedSignature;
 
         { // encrypt data with key
@@ -464,7 +464,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testAsymmetricEncryptDecrypt() {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
         byte[] ciphertext;
 
         { // encrypt data with key
@@ -563,7 +563,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testMultiSubkeyEncryptSkipStripOrBadFlag() throws Exception {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
 
         byte[] ciphertext;
         long encKeyId1;
@@ -670,7 +670,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testMultiSubkeyEncryptSkipRevoked() throws Exception {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
 
         { // revoke first encryption subkey of keyring in database
             SaveKeyringParcel.Builder builder = SaveKeyringParcel.buildChangeKeyringParcel(
@@ -727,7 +727,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testMultiAsymmetricEncryptDecrypt() {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
         byte[] ciphertext;
 
         { // encrypt data with a given passphrase
@@ -855,7 +855,7 @@ public class PgpEncryptDecryptTest {
     @Test
     public void testMultiAsymmetricSignEncryptDecryptVerify() {
 
-        String plaintext = "dies ist ein plaintext ☭" + TestingUtils.genPassphrase(true);
+        String plaintext = "dies ist ein plaintext ☭";
         byte[] ciphertext;
 
         { // encrypt data with a given passphrase

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpKeyOperationTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/PgpKeyOperationTest.java
@@ -88,7 +88,7 @@ import static org.sufficientlysecure.keychain.service.SaveKeyringParcel.buildCha
 public class PgpKeyOperationTest {
 
     static UncachedKeyRing staticRing;
-    final static Passphrase passphrase = new Passphrase("passphrase");
+    final static Passphrase passphrase = TestingUtils.testPassphrase0;
 
     UncachedKeyRing ring;
     PgpKeyOperation op;
@@ -321,9 +321,6 @@ public class PgpKeyOperationTest {
 
         {
             Passphrase badphrase = new Passphrase();
-            if (badphrase.equals(passphrase)) {
-                badphrase = new Passphrase("a");
-            }
             builder.addUserId("allure");
 
             assertModifyFailure("keyring modification with bad passphrase should fail",
@@ -1152,7 +1149,7 @@ public class PgpKeyOperationTest {
                 PacketTags.SECRET_SUBKEY, sKeyNoPassphrase.tag);
 
         // modify keyring, change to non-empty passphrase
-        Passphrase otherPassphrase = TestingUtils.genPassphrase(true);
+        Passphrase otherPassphrase = TestingUtils.testPassphrase1;
         CryptoInputParcel otherCryptoInput = CryptoInputParcel.createCryptoInputParcel(otherPassphrase);
         builder.setNewUnlock(ChangeUnlockParcel.createUnLockParcelForNewKey(otherPassphrase));
         modified = applyModificationWithChecks(builder.build(), modified, onlyA, onlyB,
@@ -1179,7 +1176,7 @@ public class PgpKeyOperationTest {
         Assert.assertEquals("extracted packet should be a secret subkey",
                 PacketTags.SECRET_SUBKEY, sKeyNoPassphrase.tag);
 
-        Passphrase otherPassphrase2 = TestingUtils.genPassphrase(true);
+        Passphrase otherPassphrase2 = TestingUtils.testPassphrase2;
         builder.setNewUnlock(ChangeUnlockParcel.createUnLockParcelForNewKey(otherPassphrase2));
         {
             // if we replace a secret key with one without passphrase

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/util/TestingUtils.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/util/TestingUtils.java
@@ -23,6 +23,11 @@ import junit.framework.Assert;
 
 
 public class TestingUtils {
+
+    public static Passphrase testPassphrase0 = new Passphrase("This is a passphrase ☢☣☠☤☮☭⚗⚛⚿∰ℹ℻ ∇∙B=0 |ℕ|=ℵ₀");
+    public static Passphrase testPassphrase1 = new Passphrase("This is a different passphrase ☢☣☠☤☮☭⚗⚛⚿∰ℹ℻ |ℕ|=ℵ₀");
+    public static Passphrase testPassphrase2 = new Passphrase("This is a yet another passphrase ☢☣☠☤☮☭⚗⚛⚿∰ℹ℻");
+
     public static Passphrase genPassphrase(boolean noEmpty) {
         String chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789!@#$%^&*()-_=";
         Random r = new Random();


### PR DESCRIPTION
## Description
Remove all usage of `genPassphrase` and use common, static passphrases instead. 

## Motivation and Context
Fix https://github.com/open-keychain/open-keychain/issues/1881

## How Has This Been Tested?
Passes several test suite runs.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)