### PR TITLE
Update gradle wrapper to 4.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
-distributionSha256Sum=da9600da2a28a43f5f77364deecbb9b01c1ddb7d3ecafe1d5c93bcd8a8059ab1
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionSha256Sum=39e2d5803bbd5eaf6c8efe07067b0e5a00235e8c71318642b2ed262920b27721


### PR DESCRIPTION
## Description
Update gradle wrapper to 4.9.

The [release notes](https://docs.gradle.org/4.9/release-notes.html) do not mention anything that should be relevant to us.

## How Has This Been Tested?
Test suite completes without error.

## Types of changes
- ✅ update