### PR TITLE
PassPhraseDialog: confirm password on enter key

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -651,7 +651,11 @@ public class PassphraseDialogActivity extends FragmentActivity {
         @Override
         public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
             // Associate the "done" button on the soft keyboard with the okay button in the view
-            if (EditorInfo.IME_ACTION_DONE == actionId) {
+            // and the Enter Key, in case a hard keyboard is used
+            if (EditorInfo.IME_ACTION_DONE == actionId ||
+                    (actionId == EditorInfo.IME_ACTION_UNSPECIFIED &&
+                            event.getAction() == KeyEvent.ACTION_DOWN &&
+                            event.getKeyCode() == KeyEvent.KEYCODE_ENTER)) {
                 AlertDialog dialog = ((AlertDialog) getDialog());
                 Button bt = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
 


### PR DESCRIPTION
I often use a hardware keyboard with my tablet.

Before:
When entering the password and pressing enter, by default the cursor moves to the next visible element in the ui.

Now: On enter the password will be confirmed, like with a software keyboard