### PR TITLE
Fix crash on DialogKeyChoice with Spanish locales

### DIFF
--- a/OpenKeychain/src/main/res/values-es/strings.xml
+++ b/OpenKeychain/src/main/res/values-es/strings.xml
@@ -1849,7 +1849,7 @@
   <string name="button_locate_nfc">¿Dónde está mi lector NFC?</string>
   <string name="label_usb_untested_summary">Si se habilita, se pueden usar lectores de smartcard USB que no han sido adecuadamente testados.</string>
   <string name="label_usb_untested">Permitir dispositivos USB no testados</string>
-  <string name="use_key">Usar clave: 1%</string>
+  <string name="use_key">Usar clave: %s</string>
   <string name="use_key_no_name">Usar clave: <![CDATA[]]></string>
   <string name="title_select_key">1%s quiere configurar el cifrado de extremo a extremo para esta dirección:</string>
   <string name="select_identity_cancel">Deshabilitar</string>


### PR DESCRIPTION
This PR fixes a crash on the DialogKeyChoice with Spanish locales.

## Description
An incorrectly formatted string was causing the DialogKeyChoice to crash when using Spanish locales. In order to reproduce it you'd have to:

1. Set your phone's language to Spanish.
2. Invoke the DialogKeyChoice (for example: download AndOtp, then go to Settings > Select OpenPGP key)
3. Tap "I already have a key"
4. Tap "List unrelated keys" at the top right
5. OpenKeychain will crash

## Motivation and Context
I believe this should be obvious.

## How Has This Been Tested?
I have not ran any tests nor added test cases. I have simply followed the steps above and verified that it now works as intended.

## Screenshots (if appropriate):

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
