### PR TITLE
Make sure auth key selection dialog lists only keys with auth subkey available.

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyRepository.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/KeyRepository.java
@@ -164,6 +164,11 @@ public class KeyRepository extends AbstractDao {
         return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
     }
 
+    public List<UnifiedKeyInfo> getAllUnifiedKeyInfoWithAuthKeySecret() {
+        SqlDelightQuery query = SubKey.FACTORY.selectAllUnifiedKeyInfoWithAuthKeySecret();
+        return mapAllRows(query, SubKey.UNIFIED_KEY_INFO_MAPPER);
+    }
+
     public List<UserId> getUserIds(long... masterKeyIds) {
         SqlDelightQuery query = UserPacket.FACTORY.selectUserIdsByMasterKeyId(masterKeyIds);
         return mapAllRows(query, UserPacket.USER_ID_MAPPER);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/remote/ui/dialog/RemoteSelectAuthenticationKeyActivity.java
@@ -104,7 +104,7 @@ public class RemoteSelectAuthenticationKeyActivity extends FragmentActivity {
             if (keyInfoLiveData == null) {
                 keyInfoLiveData = new GenericLiveData<>(context, () -> {
                     KeyRepository keyRepository = KeyRepository.create(context);
-                    return keyRepository.getAllUnifiedKeyInfoWithSecret();
+                    return keyRepository.getAllUnifiedKeyInfoWithAuthKeySecret();
                 });
             }
             return keyInfoLiveData;

--- a/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
+++ b/OpenKeychain/src/main/sqldelight/org/sufficientlysecure/keychain/Keys.sq
@@ -92,6 +92,11 @@ SELECT * FROM unifiedKeyView
     WHERE has_any_secret_int = 1
    ORDER BY creation DESC;
 
+selectAllUnifiedKeyInfoWithAuthKeySecret:
+SELECT * FROM unifiedKeyView
+    WHERE has_any_secret_int = 1 AND has_auth_key_int IS NOT NULL
+   ORDER BY creation DESC;
+
 selectMasterKeyIdBySubkey:
 SELECT master_key_id
     FROM keys


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Presently the dialog lists all master keys, and keys without auth subkeys are not marked in any way. Selecting one of those via SSH authentication API will result in cryptic "Could not create description: null" message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran a debug build of OpenKeychain in emulator, created 2 keys - one with auth subkey, and one without. Opened key selection dialog from termbot, there's only the key with auth subkey in the list.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
