### PR TITLE
Fix Spanish translation to resolve a crashing issue

### DIFF
--- a/OpenKeychain/src/main/res/values-es/strings.xml
+++ b/OpenKeychain/src/main/res/values-es/strings.xml
@@ -1853,7 +1853,7 @@
   <string name="label_usb_untested_summary">Si se habilita, se pueden usar lectores de smartcard USB que no han sido adecuadamente testados.</string>
   <string name="label_usb_untested">Permitir dispositivos USB no testados</string>
   <string name="use_key">Usar clave: %s</string>
-  <string name="use_key_no_name">Usar clave: <![CDATA[]]></string>
+  <string name="use_key_no_name">Usar clave: <![CDATA[<no name>]]></string>
   <string name="title_select_key">%s quiere configurar el cifrado de extremo a extremo para esta dirección:</string>
   <string name="select_identity_cancel">Deshabilitar</string>
   <string name="select_identity_create">Crear clave para mi</string>


### PR DESCRIPTION
Fix #2433

## Description


## Motivation and Context
An empty CDATA field was responsible of crashing OpenKeychain on every attempt to add a key to an account in K9-Mail, but only if the system language is Spanish.
Fixes #2433

## How Has This Been Tested?
I'm sorry, I'm not able to compile and test the change, but it's very minimal and basically modified it accordingly to the rest of translations.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
