### PR TITLE
Switch order of repositories, search Google Maven repo first

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -16,8 +16,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
## Description
Trying to build OpenKeychain with Android Studio 3.4.1 I get the following error:
```
A problem occurred configuring project ':OpenKeychain'.
> Could not find support-media-compat.aar (com.android.support:support-media-compat:27.1.1).
  Searched in the following locations:
      https://jcenter.bintray.com/com/android/support/support-media-compat/27.1.1/support-media-compat-27.1.1.aar
```
I have no idea why this happens or why the order is important (yet).

[Gradle Userguide: dependency resolution](https://docs.gradle.org/current/userguide/userguide_single.html#sec:dependency_resolution)

## How Has This Been Tested?
Builds & works.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)