### PR TITLE
Adding support for WKD Advanced method

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtil.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtil.java
@@ -23,12 +23,12 @@ public class WebKeyDirectoryUtil {
      * @see <a href="https://tools.ietf.org/html/draft-koch-openpgp-webkey-service-05#section-3.1">Key Discovery</a>
      */
     @Nullable
-    public static URL toWebKeyDirectoryURL(String name) {
+    public static URL toWebKeyDirectoryURL(String name, Boolean wkdMethodAdvanced) {
         if (name == null) {
             return null;
         }
 
-        if (name.startsWith("https://") && name.contains("/.well-known/openpgpkey/hu/")) {
+        if (name.startsWith("https://") && name.contains("/.well-known/openpgpkey/"))  {
             try {
                 return new URL(name);
             } catch (MalformedURLException e) {
@@ -47,10 +47,18 @@ public class WebKeyDirectoryUtil {
         String domain = matcher.group(2);
 
         try {
-            return new URL("https://" + domain + "/.well-known/openpgpkey/hu/" + encodedPart);
+
+            if(wkdMethodAdvanced) {
+                // Advanced method
+                return new URL("https://openpgpkey." + domain + "/.well-known/openpgpkey/" + domain + "/hu/" + encodedPart);
+            }else{
+                // Direct method
+                return new URL("https://" + domain + "/.well-known/openpgpkey/hu/" + encodedPart);
+            }
         } catch (MalformedURLException e) {
             return null;
         }
+        
     }
 
     private static byte[] toSHA1(byte[] input) {

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtilTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtilTest.java
@@ -11,16 +11,25 @@ public class WebKeyDirectoryUtilTest {
 
     @Test
     public void testWkd() {
-        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("test-wkd@openkeychain.org");
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("test-wkd@openkeychain.org", false);
         assertNotNull(url);
         assertEquals("openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+    }
+
+    @Test
+    public void testAdvancedWkd() {
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("test-wkd@openkeychain.org", true);
+        assertNotNull(url);
+        assertEquals("openpgpkey.openkeychain.org", url.getHost());
+        assertEquals("https", url.getProtocol());
+        assertEquals("/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
     }
 
     @Test
     public void testWkdWithSpaces() {
-        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL(" test-wkd@openkeychain.org ");
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL(" test-wkd@openkeychain.org ", false);
         assertNotNull(url);
         assertEquals("openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
@@ -28,12 +37,30 @@ public class WebKeyDirectoryUtilTest {
     }
 
     @Test
+    public void testWkdAdvancedWithSpaces() {
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL(" test-wkd@openkeychain.org ", true);
+        assertNotNull(url);
+        assertEquals("openpgpkey.openkeychain.org", url.getHost());
+        assertEquals("https", url.getProtocol());
+        assertEquals("/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+    }
+
+    @Test
     public void testWkdDirectUrl() {
-        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("https://openkeychain.org/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1");
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("https://openkeychain.org/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1", false);
         assertNotNull(url);
         assertEquals("openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+    }
+
+    @Test
+    public void testWkdAdvancedURL() {
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("https://openpgpkey.openkeychain.org/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", false);
+        assertNotNull(url);
+        assertEquals("openpgpkey.openkeychain.org", url.getHost());
+        assertEquals("https", url.getProtocol());
+        assertEquals("/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
     }
 
 }


### PR DESCRIPTION
This change extends the WKD support with Advanced mode stated in
RFC Draft: draft-koch-openpgp-webkey-service-08 section 3.1

Advanced mode shall be queried first and use direct mode as fallback
this implements the design from the draft. 
Notice: This might change in future
versions of RFC Draft draft-koch-openpgp-webkey-service

## Description
Added advanced method advanced method URI lookup and previous 
direct mode as fallback. 

## Motivation and Context
When bigger providers or WKD providers are available they would
probably go with advanced mode for custom domains. 
Key owners which cannot add .well-known folder on web service due
to services provider limitation needs an other method for publish keys
on WKD with subdomain openpgpkey a WKD provider or own http
server can be used.

## How Has This Been Tested?
Adding unit tests. Tested in emulator, WKD Direct mode tested and WKD Advanced mode
with real domains. 

## Types of changes
Added Boolean variable wkdMethodAdvanced  parameter on function WebKeyDirectoryUtil.toWebKeyDirectoryURL()

- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to change)
