### PR TITLE
workaround for NullPointerException for some document thumbnails

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/FileHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/FileHelper.java
@@ -220,7 +220,7 @@ public class FileHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             try {
                 return DocumentsContract.getDocumentThumbnail(context.getContentResolver(), uri, size, null);
-            } catch (FileNotFoundException e) {
+            } catch (Exception e) {
                 return null;
             }
         } else {


### PR DESCRIPTION
Fixing a crash when selecting some files for encryption (such as small text files or extensionless files).

## Description
Broadened exceptions caught when calling `DocumentsContract.getDocumentThumbnail`.

## Motivation and Context
Android 8.0.0, security patch level June 1, 2019

```
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.graphics.Bitmap.compress(android.graphics.Bitmap$CompressFormat, int, java.io.OutputStream)' on a null object reference
        at android.os.Parcel.readException(Parcel.java:1973)
        at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:183)
        at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:146)
        at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:698)
        at android.content.ContentProviderClient.openTypedAssetFileDescriptor(ContentProviderClient.java:445)
        at android.provider.DocumentsContract.getDocumentThumbnail(DocumentsContract.java:1067)
        at android.provider.DocumentsContract.getDocumentThumbnail(DocumentsContract.java:1045)
        at org.sufficientlysecure.keychain.util.FileHelper.getThumbnail(FileHelper.java:222)
```

## How Has This Been Tested?
Tested on phone.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
