### PR TITLE
Add an advertisement for autocrypt thunderbird plugin to navigation drawer

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MainActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/MainActivity.java
@@ -19,6 +19,7 @@ package org.sufficientlysecure.keychain.ui;
 
 import android.content.Intent;
 import android.graphics.Typeface;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
@@ -58,6 +59,7 @@ public class MainActivity extends BaseSecurityTokenActivity implements FabContai
     static final int ID_SETTINGS = 6;
     static final int ID_HELP = 7;
     static final int ID_SHOP = 8;
+    static final int ID_AUTOCRYPT = 9;
 
     // both of these are used for instrumentation testing only
     public static final String EXTRA_SKIP_FIRST_TIME = "skip_first_time";
@@ -100,7 +102,10 @@ public class MainActivity extends BaseSecurityTokenActivity implements FabContai
                                 .withIdentifier(ID_TRANSFER).withSelectable(false),
                         new DividerDrawerItem(),
                         new PrimaryDrawerItem().withName(R.string.menu_preferences).withIcon(GoogleMaterial.Icon.gmd_settings).withIdentifier(ID_SETTINGS).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.menu_help).withIcon(CommunityMaterial.Icon.cmd_help_circle).withIdentifier(ID_HELP).withSelectable(false)
+                        new PrimaryDrawerItem().withName(R.string.menu_help).withIcon(CommunityMaterial.Icon.cmd_help_circle).withIdentifier(ID_HELP).withSelectable(false),
+                        new DividerDrawerItem(),
+                        new PrimaryDrawerItem().withName(R.string.nav_autocrypt).withIcon(GoogleMaterial.Icon.gmd_blur_on)
+                                .withTypeface(Typeface.DEFAULT_BOLD).withSelectable(false).withIdentifier(ID_AUTOCRYPT)
                 )
                 .withOnDrawerItemClickListener(new Drawer.OnDrawerItemClickListener() {
                     @Override
@@ -132,6 +137,9 @@ public class MainActivity extends BaseSecurityTokenActivity implements FabContai
                                     break;
                                 case ID_SHOP:
                                     onShopSelected();
+                                    break;
+                                case ID_AUTOCRYPT:
+                                    onAutocryptSelected();
                                     break;
                             }
                             if (intent != null) {
@@ -264,6 +272,13 @@ public class MainActivity extends BaseSecurityTokenActivity implements FabContai
         mDrawer.setSelection(ID_SHOP, false);
         Fragment frag = new SecurityKeyShopFragment();
         setFragment(frag);
+    }
+
+    private void onAutocryptSelected() {
+        String url = "https://addons.thunderbird.net/en-US/thunderbird/addon/autocrypt/";
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse(url));
+        startActivity(intent);
     }
 
     @Override

--- a/OpenKeychain/src/main/res/values/strings.xml
+++ b/OpenKeychain/src/main/res/values/strings.xml
@@ -858,6 +858,7 @@
     <string name="nav_backup">"Backup/Restore"</string>
     <string name="nav_transfer">"Secure Wifi Transfer"</string>
     <string name="nav_shop">Shop</string>
+    <string name="nav_autocrypt">Try Autocrypt Thunderbird</string>
 
     <!-- hints -->
     <string name="encrypt_content_edit_text_hint">"Type text"</string>


### PR DESCRIPTION
The navigation drawer gets a new entry labeled "Try Autocrypt Thunderbird".
A click calls an uri activity with "https://addons.thunderbird.net/en-US/thunderbird/addon/autocrypt/" as destination.

## Description
DrawerItem with name and blur icon and a bold typeface was added.

## Motivation and Context
It helps users to get in touch with frictionless OpenPGP experience at Thunderbird.

## How Has This Been Tested?
Pixel 2 XL plugged in and run the app.

## Screenshots (if appropriate):
![Screenshot_1572952440](https://user-images.githubusercontent.com/14747825/68203313-d47b4780-ffc5-11e9-91b9-7c4c09c18766.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)
