### PR TITLE
Fix decryption from clipboard on Android 10

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/DecryptActivity.java
@@ -47,6 +47,8 @@ public class DecryptActivity extends BaseActivity {
     /* Intents */
     public static final String ACTION_DECRYPT_FROM_CLIPBOARD = "DECRYPT_DATA_CLIPBOARD";
 
+    public static final String EXTRA_CLIPDATA = "DECRYPT_DATA_CLIPBOARD_DATA";
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -123,12 +125,10 @@ public class DecryptActivity extends BaseActivity {
                 }
 
                 case ACTION_DECRYPT_FROM_CLIPBOARD: {
-                    ClipboardManager clipMan = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
-                    if (clipMan == null) {
-                        break;
+                    ClipData clip = null;
+                    if (intent.hasExtra(EXTRA_CLIPDATA)) {
+                        clip = intent.getParcelableExtra(EXTRA_CLIPDATA);
                     }
-
-                    ClipData clip = clipMan.getPrimaryClip();
                     if (clip == null) {
                         break;
                     }
@@ -149,6 +149,7 @@ public class DecryptActivity extends BaseActivity {
                         String text = clip.getItemAt(0).coerceToText(this).toString();
                         uri = readToTempFile(text);
                     }
+
                     if (uri != null) {
                         uris.add(uri);
                     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptDecryptFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/EncryptDecryptFragment.java
@@ -21,6 +21,9 @@ package org.sufficientlysecure.keychain.ui;
 import java.util.regex.Matcher;
 
 import android.app.Activity;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -39,6 +42,7 @@ import org.sufficientlysecure.keychain.ui.util.Notify;
 import org.sufficientlysecure.keychain.ui.util.Notify.Style;
 import org.sufficientlysecure.keychain.ui.util.SubtleAttentionSeeker;
 import org.sufficientlysecure.keychain.util.FileHelper;
+import timber.log.Timber;
 
 public class EncryptDecryptFragment extends Fragment {
 
@@ -108,7 +112,20 @@ public class EncryptDecryptFragment extends Fragment {
             return;
         }
 
+        ClipboardManager clipMan = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipMan == null) {
+            Timber.e("Couldn't get ClipboardManager instance!");
+            return;
+        }
+
+        ClipData clip = clipMan.getPrimaryClip();
+        if (clip == null) {
+            Timber.e("Couldn't get clipboard data!");
+            return;
+        }
+
         Intent clipboardDecrypt = new Intent(getActivity(), DecryptActivity.class);
+        clipboardDecrypt.putExtra(DecryptActivity.EXTRA_CLIPDATA, clip);
         clipboardDecrypt.setAction(DecryptActivity.ACTION_DECRYPT_FROM_CLIPBOARD);
         startActivityForResult(clipboardDecrypt, 0);
     }


### PR DESCRIPTION
## Description
Move clipboard access from DecryptActivity to EncryptDecryptFragment since the clipboard access is only possible from a window in focus in Android 10.

## Motivation and Context
Fix #2492 #2464 

## How Has This Been Tested?
Tested by encrypting & decrypting an example text fragment to & from the clipboard on an Android 10 device.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
