### PR TITLE
Add query parameter to WKD URLs

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtil.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtil.java
@@ -2,8 +2,10 @@ package org.sufficientlysecure.keychain.util;
 
 import android.support.annotation.Nullable;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.regex.Matcher;
@@ -50,12 +52,14 @@ public class WebKeyDirectoryUtil {
 
             if(wkdMethodAdvanced) {
                 // Advanced method
-                return new URL("https://openpgpkey." + domain + "/.well-known/openpgpkey/" + domain + "/hu/" + encodedPart);
+                return new URL("https://openpgpkey." + domain + "/.well-known/openpgpkey/" + domain + "/hu/" + encodedPart + "?l=" + URLEncoder.encode(localPart, "UTF-8"));
             }else{
                 // Direct method
-                return new URL("https://" + domain + "/.well-known/openpgpkey/hu/" + encodedPart);
+                return new URL("https://" + domain + "/.well-known/openpgpkey/hu/" + encodedPart + "?l=" + URLEncoder.encode(localPart, "UTF-8"));
             }
         } catch (MalformedURLException e) {
+            return null;
+        } catch (UnsupportedEncodingException e) {
             return null;
         }
         

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtilTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/util/WebKeyDirectoryUtilTest.java
@@ -16,6 +16,7 @@ public class WebKeyDirectoryUtilTest {
         assertEquals("openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+        assertEquals("l=test-wkd", url.getQuery());
     }
 
     @Test
@@ -25,6 +26,7 @@ public class WebKeyDirectoryUtilTest {
         assertEquals("openpgpkey.openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+        assertEquals("l=test-wkd", url.getQuery());
     }
 
     @Test
@@ -34,6 +36,7 @@ public class WebKeyDirectoryUtilTest {
         assertEquals("openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+        assertEquals("l=test-wkd", url.getQuery());
     }
 
     @Test
@@ -43,24 +46,47 @@ public class WebKeyDirectoryUtilTest {
         assertEquals("openpgpkey.openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+        assertEquals("l=test-wkd", url.getQuery());
+    }
+
+    @Test
+    public void testWkdWithUnicode() {
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("test\u2013wkd@openkeychain.org", false);
+        assertNotNull(url);
+        assertEquals("openkeychain.org", url.getHost());
+        assertEquals("https", url.getProtocol());
+        assertEquals("/.well-known/openpgpkey/hu/nb7e5p4jhz3i3micncnfy5dfkp1ug53i", url.getPath());
+        assertEquals("l=test%E2%80%93wkd", url.getQuery());
+    }
+
+    @Test
+    public void testWkdAdvancedWithUnicode() {
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("test\u2013wkd@openkeychain.org", true);
+        assertNotNull(url);
+        assertEquals("openpgpkey.openkeychain.org", url.getHost());
+        assertEquals("https", url.getProtocol());
+        assertEquals("/.well-known/openpgpkey/openkeychain.org/hu/nb7e5p4jhz3i3micncnfy5dfkp1ug53i", url.getPath());
+        assertEquals("l=test%E2%80%93wkd", url.getQuery());
     }
 
     @Test
     public void testWkdDirectUrl() {
-        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("https://openkeychain.org/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1", false);
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("https://openkeychain.org/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1?l=test-wkd", false);
         assertNotNull(url);
         assertEquals("openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+        assertEquals("l=test-wkd", url.getQuery());
     }
 
     @Test
     public void testWkdAdvancedURL() {
-        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("https://openpgpkey.openkeychain.org/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", false);
+        URL url = WebKeyDirectoryUtil.toWebKeyDirectoryURL("https://openpgpkey.openkeychain.org/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1?l=test-wkd", false);
         assertNotNull(url);
         assertEquals("openpgpkey.openkeychain.org", url.getHost());
         assertEquals("https", url.getProtocol());
         assertEquals("/.well-known/openpgpkey/openkeychain.org/hu/4hg7tescnttreaouu4z1izeuuyibwww1", url.getPath());
+        assertEquals("l=test-wkd", url.getQuery());
     }
 
 }


### PR DESCRIPTION
This change adds the l=LOCAL-PART query parameter to WKD URLs as
specified in RFC Draft: draft-koch-openpgp-webkey-service-09 section 3.1
since version 07.

## Motivation and Context
The current code without this change does not work with WKD servers which expect the l=LOCAL-PART query parameter specified in the RFC Draft since version 07 to be present.

## How Has This Been Tested?
I ran the test functions in the WebKeyDirectoryUtilTest.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)