### PR TITLE
Update Regex for QRcode scanned VCard

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysProxyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysProxyActivity.java
@@ -136,7 +136,20 @@ public class ImportKeysProxyActivity extends FragmentActivity
         }
     }
 
-    private static final Pattern VCARD_KEY_PATTERN = Pattern.compile("\nKEY:(.*)\n");
+// XXX : Bookmark for issues #2592 (https://github.com/open-keychain/open-keychain/issues/2592) @awbmilne
+/**
+ * ─── Regex Explaination ───
+ * (?<=\n)(?:KEY:OPENPGP4FPR:|KEY.*http.*search=0x)((?:[A-F]|[a-f]|\d){40})(?=\n)
+ * 
+ * Matches:
+ * KEY:OPENPGP4FPR:[HASH]
+ * KEY[anything]https[anything]search=0x[HASH]
+ * 
+ * Examples:
+ * KEY:OPENPGP4FPR:1234567890123456789012345678901234567890
+ * KEY;MEDIATYPE=application/pgp-keys:https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1234567890123456789012345678901234567890
+ */
+    private static final Pattern VCARD_KEY_PATTERN = Pattern.compile("(?<=\n)(?:KEY:OPENPGP4FPR:|KEY.*http.*search=0x)((?:[A-F]|[a-f]|\d){40})(?=\n)");
 
     private void processScannedContent(String content) {
         // if a VCard was scanned try to extract the KEY field


### PR DESCRIPTION
Fix issues with QRCode VCard Key importing | closes #2599 

Regex needs to be corrected for handling values in a VCard format.

It also seems possible to extend the import functionality to the URL syntax of the Vcard Standard.

## Description
Currently:
- Fix parsing of `KEY:OPENPGP4FPR:[HASH]` with better regex
- Extend regex to full-length search URLs in VCard standard format\
     For example: `KEY;MEDIATYPE=application/pgp-keys:https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x[40-CHAR-HASH]`

Prospective:
- Extend to All VCard formats using URL import
    ```
    2.1:   KEY;PGP:http://example.com/key.pgp
    3.0:   KEY;TYPE=PGP:http://example.com/key.pgp
    4.0:   4.0: KEY;MEDIATYPE=application/pgp-keys:http://example.com/key.pgp
    ```
## Motivation and Context
I have been looking to streamline my VCard Contact and PGP information, This would make it easier to deal with on android. Easier to share Keys and Contact info with same QRcode on Business card or such. Refer to #2599 

## How Has This Been Tested?
Hasnt been tested yet. Not ready for Pull yet.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
