### PR TITLE
partial fix for issue 2590

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KeyFormat.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KeyFormat.java
@@ -57,7 +57,7 @@ public abstract class KeyFormat {
                     throw new IllegalArgumentException("Bad length for EC attributes");
                 }
                 int len = bytes.length - 1;
-                if (bytes[bytes.length - 1] == (byte)0xff) {
+                if (bytes[bytes.length - 1] == (byte)0x00 || bytes[bytes.length - 1] == (byte)0xff) {
                     len -= 1;
                 }
                 final byte[] boid = new byte[2 + len];


### PR DESCRIPTION
change behavior to what GnuPG does.
c.f. `static void
parse_algorithm_attribute (app_t app, int keyno)` line 5952 in https://github.com/gpg/gnupg/blob/master/scd/app-openpgp.c#L5952

According to the spec (ftp://ftp.gnupg.org/specs/OpenPGP-smart-card-application-3.4.1.pdf Section 4.4.3.9 Algorithm Attributes) the last byte can only be optional in the sense that you set it to 0x00. The other allowed value seems to be 0xFF. It is not clear from the spec, but that is what GnuPG does.

This does not fix the problem with a Yubikey setting random values for the last byte in the first response.