### PR TITLE
set the key attr to ECDSA for AUT when using EC keys

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenUtils.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenUtils.java
@@ -42,7 +42,7 @@ public class SecurityTokenUtils {
             byte[] oid = new ASN1ObjectIdentifier(secretKey.getCurveOid()).getEncoded();
             byte[] attrs = new byte[1 + (oid.length - 2) + 1];
 
-            if (slot.equals(KeyType.SIGN))
+            if (!slot.equals(KeyType.ENCRYPT))
                 attrs[0] = ECKeyFormat.ECAlgorithmFormat.ECDSA_WITH_PUBKEY.getValue();
             else {
                 attrs[0] = ECKeyFormat.ECAlgorithmFormat.ECDH_WITH_PUBKEY.getValue();


### PR DESCRIPTION
Set the key attr to ECDSA for AUT when using EC keys.

## Description
According to the [spec](ftp://ftp.gnupg.org/specs/OpenPGP-smart-card-application-3.4.1.pdf), in Section 4.4.3.9 Algorithm Attributes, ID with ECDSA should be used for INT-AUT, which is currently set to ECDH.

## Motivation and Context
For the specification compliance.

## Types of changes
- ✅ Bug fix
