### PR TITLE
Fix ECDH decryption error using NIST curves

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/operations/PsoDecryptTokenOp.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/operations/PsoDecryptTokenOp.java
@@ -164,6 +164,10 @@ public class PsoDecryptTokenOp {
        */
         byte[] keyEncryptionKey = response.getData();
 
+        int xLen = (keyEncryptionKey.length - 1) / 2;
+        final byte[] kekX = new byte[xLen];
+        System.arraycopy(keyEncryptionKey, 1, kekX, 0, xLen);
+
         final byte[] keyEnc = new byte[encryptedSessionKeyMpi[mpiLength + 2]];
 
         System.arraycopy(encryptedSessionKeyMpi, 2 + mpiLength + 1, keyEnc, 0, keyEnc.length);
@@ -172,7 +176,7 @@ public class PsoDecryptTokenOp {
             final MessageDigest kdf = MessageDigest.getInstance(MessageDigestUtils.getDigestName(publicKey.getSecurityTokenHashAlgorithm()));
 
             kdf.update(new byte[]{(byte) 0, (byte) 0, (byte) 0, (byte) 1});
-            kdf.update(keyEncryptionKey);
+            kdf.update(kekX);
             kdf.update(publicKey.createUserKeyingMaterial(fingerprintCalculator));
 
             byte[] kek = kdf.digest();

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/operations/PsoDecryptTokenOp.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/operations/PsoDecryptTokenOp.java
@@ -164,9 +164,15 @@ public class PsoDecryptTokenOp {
        */
         byte[] keyEncryptionKey = response.getData();
 
-        int xLen = (keyEncryptionKey.length - 1) / 2;
+        int xLen;
+        boolean isCurve25519 = CryptlibObjectIdentifiers.curvey25519.equals(eckf.getCurveOID());
+        if (isCurve25519) {
+            xLen = keyEncryptionKey.length;
+        } else {
+            xLen = (keyEncryptionKey.length - 1) / 2;
+        }
         final byte[] kekX = new byte[xLen];
-        System.arraycopy(keyEncryptionKey, 1, kekX, 0, xLen);
+        System.arraycopy(keyEncryptionKey, isCurve25519 ? 0 : 1, kekX, 0, xLen);
 
         final byte[] keyEnc = new byte[encryptedSessionKeyMpi[mpiLength + 2]];
 


### PR DESCRIPTION
Fix ECDH decryption error using NIST curves: Invalid KEK

## Description
Decrypting using smart cards/tokens fails now due to "Invalid KEK". May fix #2516.

## Motivation and Context
According to [Section 7 of RFC 6637](https://tools.ietf.org/html/rfc6637#section-7), the input of KDF should be the x portion instead of the encoding of the point.

## How Has This Been Tested?
Tested using smart cards.

## Types of changes
- ✅ Bug fix
