### PR TITLE
ignore randomly generated last octet of OIDs for ECKeys. fixes #2590

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KeyFormat.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KeyFormat.java
@@ -57,7 +57,7 @@ public abstract class KeyFormat {
                     throw new IllegalArgumentException("Bad length for EC attributes");
                 }
                 int len = bytes.length - 1;
-                if (bytes[bytes.length - 1] == (byte)0xff) {
+                if (bytes[len] >= (byte)0x80) {
                     len -= 1;
                 }
                 final byte[] boid = new byte[2 + len];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
As @schch already described in more detail in https://github.com/open-keychain/open-keychain/issues/2590#issuecomment-744555326, the last octet of the OID for ECKeys is randomly generated on insertion. This leads to a crash most of the time when trying to decrypt with a ECKey on a security token.

This PR ignores this last octet of the OID. And therefor fixes this bug/crash.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes #2590. The problem was, that the OID with the random suffix was resolved to a `ECNamedCurveTable`, which was unsuccessful. As this PR removes this suffix from the OID, the resoving works again. Therefor open-keychain does not anymore crash most of the time when trying to decrypt with a security token and an ECKey.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this change with my YubiKey on my phone and I successfully ran the testsuite.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
