### PR TITLE
Fixed root property check in build.gradle

### DIFF
--- a/sshauthentication-api/build.gradle
+++ b/sshauthentication-api/build.gradle
@@ -13,11 +13,14 @@ buildscript {
 }
 
 android {
-    if (project.hasProperty('rootProject.ext.compileSdkVersion')) {
+    if (project.hasProperty('compileSdkVersion')) {
         compileSdkVersion rootProject.ext.compileSdkVersion
     } else {
         compileSdkVersion 28
     }
+    if (project.hasProperty('buildToolsVersion')) {
+        buildToolsVersion rootProject.ext.buildToolsVersion
+    } 
 
 
     defaultConfig {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The check for the compileSdkVersion property must not include the classpath
Since I'm building with current SDK and build tools I ran into this.
A suggestion for checking the buildToolsVersion in the same manner is added to this PR.

## How Has This Been Tested?
Tested with android-30 and buildToolsVersion 30.0.2

## Suggestion
Add the same checks to opengpg-lib as well since it is included in the same way as sshauthentication.


