### PR TITLE
Add missing break statement in KDF-DO parser

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KdfParameters.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KdfParameters.java
@@ -85,6 +85,7 @@ public abstract class KdfParameters {
                             case (byte)0x00:
                                 // no KDF, plain password
                                 hasUsesKdf(false);
+                                break;
                             case (byte)0x03:
                                 // using KDF
                                 hasUsesKdf(true);


### PR DESCRIPTION
## Description
The KDF-DO parser was missing a break statement, resulting in parsing a token with KDF ability, but having KDF disabled, as a token with KDF enabled, thus resulting in a Autovalue error upon trying to parse the KDF-DO returned by the token.

## Motivation and Context
Fixes #2650

## How Has This Been Tested?
Not tested, since obviously correct :).

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
