### PR TITLE
Fix KdfParameters builder

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KdfParameters.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KdfParameters.java
@@ -75,6 +75,13 @@ public abstract class KdfParameters {
 
         public Builder() {
             hasUsesKdf(false);
+            digestAlgorithm(HashType.SHA256);
+            iterations(0);
+            saltPw1(new byte[0]);
+            saltPw2(new byte[0]);
+            saltPw3(new byte[0]);
+            hashUser(new byte[0]);
+            hashAdmin(new byte[0]);
         }
 
         Builder parseKdfTLVs(Iso7816TLV[] tlvs) throws IOException {

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KdfParameters.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/KdfParameters.java
@@ -64,8 +64,8 @@ public abstract class KdfParameters {
         abstract Builder digestAlgorithm(HashType digestAlgorithm);
         abstract Builder iterations(int iterations);
         abstract Builder saltPw1(byte[] saltPw1);
-        abstract Builder saltPw2(byte[] saltPw1);
-        abstract Builder saltPw3(byte[] saltPw1);
+        abstract Builder saltPw2(byte[] saltPw2);
+        abstract Builder saltPw3(byte[] saltPw3);
         abstract Builder hashUser(byte[] hashUser);
         abstract Builder hashAdmin(byte[] hashAdmin);
 


### PR DESCRIPTION
## Description
The Autovalue builder of `KdfParameters` didn't initialize all members, thus leading to:
```
java.lang.IllegalStateException: Missing required properties: digestAlgorithm iterations saltPw1 saltPw2 saltPw3 hashUser hashAdmin
```

## Motivation and Context
Fixes #2650, this time for good :slightly_smiling_face: 

## How Has This Been Tested?
Tested with a Yubikey 5 NFC, firmware version 5.2.7, with a Ed25519 primary key (SCA) and RSA-4096 encryption subkey, and KDF disabled.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)