### PR TITLE
Allow SSH authentication using EdDSA key residing on a security token

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/CanonicalizedSecretKey.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/CanonicalizedSecretKey.java
@@ -255,7 +255,9 @@ public class CanonicalizedSecretKey extends CanonicalizedPublicKey {
 
     private PGPContentSignerBuilder getAuthenticationContentSignerBuilder(int hashAlgorithm, Map<ByteBuffer,
             byte[]> signedHashes) {
-        if (getAlgorithm() == PublicKeyAlgorithmTags.EDDSA) {
+        if (
+            getAlgorithm() == PublicKeyAlgorithmTags.EDDSA
+                && mPrivateKeyState != PRIVATE_KEY_STATE_DIVERT_TO_CARD) {
             // content signer feeding the input directly into the signature engine,
             // since EdDSA hashes the input anyway
             return new EdDsaAuthenticationContentSignerBuilder(

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/SshPublicKey.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/SshPublicKey.java
@@ -19,11 +19,13 @@ package org.sufficientlysecure.keychain.pgp;
 
 import org.bouncycastle.bcpg.DSAPublicBCPGKey;
 import org.bouncycastle.bcpg.ECPublicBCPGKey;
+import org.bouncycastle.bcpg.EdDSAPublicBCPGKey;
 import org.bouncycastle.bcpg.RSAPublicBCPGKey;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.sufficientlysecure.keychain.pgp.exception.PgpGeneralException;
 import org.sufficientlysecure.keychain.ssh.key.SshDSAPublicKey;
 import org.sufficientlysecure.keychain.ssh.key.SshECDSAPublicKey;
+import org.sufficientlysecure.keychain.ssh.key.SshEd25519PublicKey;
 import org.sufficientlysecure.keychain.ssh.key.SshRSAPublicKey;
 import org.sufficientlysecure.keychain.ssh.utils.SshUtils;
 
@@ -46,9 +48,8 @@ public class SshPublicKey {
                 return encodeRSAKey(key);
             case PGPPublicKey.ECDSA:
                 return encodeECKey(key);
-            // TODO
-//            case PGPPublicKey.EDDSA:
-//                return encodeEdDSAKey(key);
+            case PGPPublicKey.EDDSA:
+                return encodeEdDSAKey(key);
             case PGPPublicKey.DSA:
                 return encodeDSAKey(key);
             default:
@@ -73,15 +74,13 @@ public class SshPublicKey {
         return sshECDSAPublicKey.getPublicKeyBlob();
     }
 
+    private String encodeEdDSAKey(PGPPublicKey publicKey) {
+        EdDSAPublicBCPGKey publicBCPGKey = (EdDSAPublicBCPGKey) publicKey.getPublicKeyPacket().getKey();
 
+        SshEd25519PublicKey pubkey = new SshEd25519PublicKey(publicBCPGKey.getEdDSAEncodedPoint());
 
-//    private String encodeEdDSAKey(PGPPublicKey publicKey) {
-//        EdDSAPublicBCPGKey publicBCPGKey = (EdDSAPublicBCPGKey) publicKey.getPublicKeyPacket().getKey();
-//
-//        SshEd25519PublicKey pubkey = new SshEd25519PublicKey(publicBCPGKey.getEdDSAEncodedPoint());
-//
-//        return pubkey.getPublicKeyBlob();
-//    }
+        return pubkey.getPublicKeyBlob();
+    }
 
     private String encodeDSAKey(PGPPublicKey publicKey) {
         DSAPublicBCPGKey publicBCPGKey = (DSAPublicBCPGKey) publicKey.getPublicKeyPacket().getKey();


### PR DESCRIPTION
## Description
This is enough to make ssh authentication using EdDSA work for me. Depends on https://github.com/open-keychain/bouncycastle/pull/3 .

## How Has This Been Tested?
I have tested it using a Yubikey 5C NFC with an EdDSA subkey for authentication, together with openssh (termux) and OkcAgent as the ssh-agent communicating with OpenKeychain.