### PR TITLE
Don't run BouncyCastle tests (make master work)

### DIFF
--- a/.github/workflows/Android-CI-Espresso.yml
+++ b/.github/workflows/Android-CI-Espresso.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build project
         run: ./gradlew assemble
       - name: Run tests
-        run: ./gradlew test
+        run: ./gradlew :OpenKeychain:test
       - name: Archive UnitTest report
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
It prevents from 

>* What went wrong:
> Could not determine the dependencies of task ':extern:bouncycastle:test'.
>
> Task with path ':core:test' not found in project ':extern:bouncycastle'.

bouncycastle should test there own stuff in there repo