### PR TITLE
Don't explicitly clear PIN when verifying admin PIN

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenConnection.java
@@ -414,7 +414,6 @@ public class SecurityTokenConnection {
         // delete secrets from memory
         Arrays.fill(pin, (byte) 0);
         Arrays.fill(transformedPin, (byte) 0);
-        adminPin.removeFromMemory();
 
         ResponseApdu response = communicate(verifyPw3Command);
         if (!response.isSuccess()) {


### PR DESCRIPTION
The PIN is cleared anyway when the Passphrase object holding the PIN is freed.

## Description
Commit c2bab8807e8b17f73dffbd17d5662453de631471 introduced clearing the admin PIN before it is being used.

## Motivation and Context
Creating new keys was broken by c2bab8807e8b17f73dffbd17d5662453de631471.
Fixes https://github.com/open-keychain/open-keychain/issues/2684.

## How Has This Been Tested?
Tested with a Yubikey 5 NFC.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)