### PR TITLE
Fix digest handling when signing using a hardware token

### DIFF
--- a/OpenKeychain/src/main/java/org/bouncycastle/openpgp/operator/jcajce/NfcSyncPGPContentSignerBuilder.java
+++ b/OpenKeychain/src/main/java/org/bouncycastle/openpgp/operator/jcajce/NfcSyncPGPContentSignerBuilder.java
@@ -111,6 +111,8 @@ public class NfcSyncPGPContentSignerBuilder
 
         return new PGPContentSigner()
         {
+            private byte[] mDigest;
+
             public int getType()
             {
                 return signatureType;
@@ -137,19 +139,22 @@ public class NfcSyncPGPContentSignerBuilder
             }
 
             public byte[] getSignature() {
-                byte[] digest = digestCalculator.getDigest();
-                ByteBuffer buf = ByteBuffer.wrap(digest);
+                if (mDigest == null)
+		    mDigest = digestCalculator.getDigest();
+                ByteBuffer buf = ByteBuffer.wrap(mDigest);
                 if (signedHashes.containsKey(buf)) {
                     return (byte[]) signedHashes.get(buf);
                 }
                 // catch this when signatureGenerator.generate() is executed and divert digest to card,
                 // when doing the operation again reuse creationTimestamp (this will be hashed)
-                throw new NfcInteractionNeeded(digest, getHashAlgorithm());
+                throw new NfcInteractionNeeded(mDigest, getHashAlgorithm());
             }
 
             public byte[] getDigest()
             {
-                return digestCalculator.getDigest();
+                if (mDigest == null)
+		    mDigest = digestCalculator.getDigest();
+		return mDigest;
             }
         };
     }


### PR DESCRIPTION
The previous code used java.security.MessageDigest.digest()
more than once, which is incorrect because the digest is reset
after each call.

This made OpenKeychain generate invalid signatures when
using a hardware token: the two bytes called "fingerprint",
which are supposed to be the first two bytes of the unsigned
digest, were incorrectly filled inside the signature.

Some tools do not check this fingerprint, only the signed digest,
so the signature was reported as valid. GPG is one of these tools.

But some other tools (like OpenPGP.js which uses rnp) did check it,
and reported an invalid signature, assorted with an error message
saying "wrong lbits". Thunderbird is one of the users of OpenPGP.js

This fixes bug #2688 

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
