### PR TITLE
Bump openpgp-api and add a test for TLD-less email

### DIFF
--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/SplitUserIdTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/SplitUserIdTest.java
@@ -130,4 +130,12 @@ public class SplitUserIdTest {
         Assert.assertEquals("this is a comment", info.comment);
     }
 
+    @Test
+    public void splitUserIdWithInvalidEmailShouldReturnEmail() {
+        OpenPgpUtils.UserId info = KeyRing.splitUserId("Name@LooksLike.Email <Name@LooksLikeEmail>");
+        Assert.assertEquals("Name@LooksLike.Email", info.name);
+        Assert.assertEquals("Name@LooksLikeEmail", info.email);
+        Assert.assertNull(info.comment);
+    }
+
 }

--- a/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/SplitUserIdTest.java
+++ b/OpenKeychain/src/test/java/org/sufficientlysecure/keychain/pgp/SplitUserIdTest.java
@@ -131,10 +131,10 @@ public class SplitUserIdTest {
     }
 
     @Test
-    public void splitUserIdWithInvalidEmailShouldReturnEmail() {
-        OpenPgpUtils.UserId info = KeyRing.splitUserId("Name@LooksLike.Email <Name@LooksLikeEmail>");
-        Assert.assertEquals("Name@LooksLike.Email", info.name);
-        Assert.assertEquals("Name@LooksLikeEmail", info.email);
+    public void splitUserIdWithEmailWithoutTldShouldReturnNameAndEmail() {
+        OpenPgpUtils.UserId info = KeyRing.splitUserId("Max Mustermann <max@localhost>");
+        Assert.assertEquals("Max Mustermann", info.name);
+        Assert.assertEquals("max@localhost", info.email);
         Assert.assertNull(info.comment);
     }
 


### PR DESCRIPTION
## Description

Updates `openpgp-api` to its latest revision and add a backing test for the changes.

## Motivation and Context

Fixes #2579

## How Has This Been Tested?

Unit test is included

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
