### PR TITLE
fix #2497

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/operations/SecurityTokenPsoSignTokenOp.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/operations/SecurityTokenPsoSignTokenOp.java
@@ -142,8 +142,20 @@ public class SecurityTokenPsoSignTokenOp {
             if (br[0] == 0x00 && (br[1] & 0x80) == 0) {
                 br = Arrays.copyOfRange(br, 1, br.length);
             }
+            if (br[0] < 0) {
+                byte[] paddedBr = new byte[br.length + 1];
+                paddedBr[0] = 0;
+                System.arraycopy(br, 0, paddedBr, 1, br.length);
+                br = paddedBr;
+            }
             if (bs[0] == 0x00 && (bs[1] & 0x80) == 0) {
                 bs = Arrays.copyOfRange(bs, 1, bs.length);
+            }
+            if (bs[0] < 0) {
+                byte[] paddedBs = new byte[bs.length + 1];
+                paddedBs[0] = 0;
+                System.arraycopy(bs, 0, paddedBs, 1, bs.length);
+                bs = paddedBs;
             }
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ASN1OutputStream out = ASN1OutputStream.create(baos);


### PR DESCRIPTION
Fix the wrong format of the signature encoding of EC keys. (see #2497)

## Description
According to Section 8.3.2 of [X.690](https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf),
a positive number whose bit 8 of the first octet should be prepended a leading byte 0;
otherwise, it will be regarded as a negative number and causes #2497.

Therefore, a leading zero should be added if the first byte of r or s is negative (in Java).

## Motivation and Context
Fixes https://github.com/open-keychain/open-keychain/issues/2497.

## Types of changes
- ✅ Bug fix
