### PR TITLE
Fix OpenKeychain for Android 13 Security level 2022-12

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/NfcTransport.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/NfcTransport.java
@@ -82,7 +82,11 @@ public class NfcTransport implements Transport {
 
     @Override
     public boolean isConnected() {
-        return mIsoCard != null && mIsoCard.isConnected();
+        try {
+            return mIsoCard != null && mIsoCard.isConnected();
+        } catch (SecurityException e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Catch a `SecurityException` that was introduced in AOSP commit [113f3a4](https://android.googlesource.com/platform/frameworks/base/+/113f3a4a1d9171db7456aa9ae8b0a2b50545c326%5E%21/). It is thrown when an NFC tag is removed. Since the underlying method is being called in the `isConnected` method, the method can safely return `false` in this case.

## Motivation and Context

After upgrading my Pixel 6a from Android 13 Security level 2022-11 to 2022-12, Android Password Store stopped working in connection with OpenKeychain. The following exception is raised when removing an NFC tag:

```
12-07 17:09:42.982  3645 19972 D NativeNfcTag: Tag lost, restarting polling loop
12-07 17:09:42.983  3645 19972 D NfcService: Discovery configuration equal, not updating.
12-07 17:09:42.983  3645 19972 D NativeNfcTag: Stopping background presence check
12-07 17:09:43.165 19908 19927 E AndroidRuntime: FATAL EXCEPTION: AsyncTask #1
12-07 17:09:43.165 19908 19927 E AndroidRuntime: Process: org.sufficientlysecure.keychain, PID: 19908
12-07 17:09:43.165 19908 19927 E AndroidRuntime: java.lang.RuntimeException: An error occurred while executing doInBackground()
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at android.os.AsyncTask$4.done(AsyncTask.java:415)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:381)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at java.util.concurrent.FutureTask.setException(FutureTask.java:250)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at java.util.concurrent.FutureTask.run(FutureTask.java:269)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:305)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at java.lang.Thread.run(Thread.java:1012)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: Caused by: java.lang.SecurityException: Permission Denial: Tag ( ID: 27 00 00 00 xx xx xx ) is out of date
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at android.nfc.Tag.getTagService(Tag.java:381)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at android.nfc.tech.BasicTagTechnology.isConnected(BasicTagTechnology.java:63)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at android.nfc.tech.IsoDep.isConnected(IsoDep.java:40)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at nordpol.android.AndroidCard.isConnected(AndroidCard.java:1)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at org.sufficientlysecure.keychain.securitytoken.NfcTransport.isConnected(NfcTransport.java:1)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at org.sufficientlysecure.keychain.securitytoken.SecurityTokenConnection.isConnected(SecurityTokenConnection.java:1)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at org.sufficientlysecure.keychain.ui.SecurityTokenOperationActivity$3.doInBackground(SecurityTokenOperationActivity.java:2)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at org.sufficientlysecure.keychain.ui.SecurityTokenOperationActivity$3.doInBackground(SecurityTokenOperationActivity.java:1)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at android.os.AsyncTask$3.call(AsyncTask.java:394)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
12-07 17:09:43.165 19908 19927 E AndroidRuntime: 	... 4 more
12-07 17:09:43.173  1492 19982 I DropBoxManagerService: add tag=data_app_crash isTagEnabled=true flags=0x2
12-07 17:09:43.174  1492 10926 W ActivityTaskManager:   Force finishing activity org.sufficientlysecure.keychain/.remote.ui.RemoteSecurityTokenOperationActivity
12-07 17:09:43.198  1492 10926 W ActivityTaskManager:   Force finishing activity dev.msfjarvis.aps/com.zeapo.pwdstore.crypto.DecryptActivity
12-07 17:09:43.205  1492  1530 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
12-07 17:09:43.205 19908 19927 I Process : Sending signal. PID: 19908 SIG: 9
12-07 17:09:43.206  1492  1530 W BroadcastQueue: Background execution not allowed: receiving Intent { act=android.intent.action.DROPBOX_ENTRY_ADDED flg=0x10 (has extras) } to com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
12-07 17:09:43.280  1492 10926 I ActivityManager: Process org.sufficientlysecure.keychain (pid 19908) has died: fg  TOP 
12-07 17:09:43.281  1492 14003 I WindowManager: WIN DEATH: Window{b29ba2e u0 org.sufficientlysecure.keychain/org.sufficientlysecure.keychain.remote.ui.RemoteSecurityTokenOperationActivity}
12-07 17:09:43.281  1492 14003 W InputManager-JNI: Input channel object 'b29ba2e org.sufficientlysecure.keychain/org.sufficientlysecure.keychain.remote.ui.RemoteSecurityTokenOperationActivity (client)' was disposed without first being removed with the input manager!
```

My fix catches that exception and lets the method return `false` when a tag has been removed.

## How Has This Been Tested?
Compiled locally, installed via ADB and tested successfully on my Pixel 6a in combination with Android Password Store.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
