### PR TITLE
Fix: #2694 openkeychain stopped on processing

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeychainServiceTask.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/KeychainServiceTask.java
@@ -25,6 +25,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Parcelable;
+import android.os.SystemClock;
 
 import androidx.core.os.CancellationSignal;
 import org.sufficientlysecure.keychain.daos.KeyWritableRepository;
@@ -76,8 +77,12 @@ public class KeychainServiceTask {
                     @Override
                     protected OperationResult doInBackground(Void... voids) {
                         BaseOperation op;
-
-                        if (inputParcel instanceof SignEncryptParcel) {
+                        
+                        // Prevent Dialog from calling close before it is created
+                        if(operationCallback.haveProgressDialog())
+                            SystemClock.sleep(200);
+                        
+                            if (inputParcel instanceof SignEncryptParcel) {
                             op = new SignEncryptOperation(context, keyRepository, asyncProgressable,
                                     operationCancelledBoolean);
                         } else if (inputParcel instanceof PgpDecryptVerifyInputParcel) {
@@ -163,6 +168,7 @@ public class KeychainServiceTask {
     }
 
     public interface OperationCallback {
+        boolean haveProgressDialog();
         void setProgress(Integer message, int current, int total);
         void setPreventCancel();
         void operationFinished(OperationResult data);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/CryptoOperationHelper.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/base/CryptoOperationHelper.java
@@ -284,6 +284,11 @@ public class CryptoOperationHelper<T extends Parcelable, S extends OperationResu
         KeychainServiceTask keychainServiceTask = KeychainServiceTask.create(activity);
         OperationCallback operationCallback = new OperationCallback() {
             @Override
+            public boolean haveProgressDialog() {
+                return (mProgressMessageResource != null);
+            }
+
+            @Override
             public void operationFinished(OperationResult result) {
                 if (progressDialogManager != null) {
                     progressDialogManager.dismissAllowingStateLoss();


### PR DESCRIPTION
Prevent Dialog from calling close before it is created.

## Motivation and Context
For encryption and signature of text and small files, it is possible to call close before the processing box is created, which will lead to the phenomenon in #2694 .

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)