### PR TITLE
Enable Curve25519 key generation for encryption and make it the default key type

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/Constants.java
@@ -180,13 +180,13 @@ public final class Constants {
     }
 
     /**
-     * Default key configuration: 3072 bit RSA (certify + sign, encrypt)
+     * Default key configuration: EDDSA (certify + sign), Curve25519 ECDH (encrypt)
      */
     public static void addDefaultSubkeys(SaveKeyringParcel.Builder builder) {
-        builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(SaveKeyringParcel.Algorithm.RSA,
-                3072, null, KeyFlags.CERTIFY_OTHER | KeyFlags.SIGN_DATA, 0L));
-        builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(SaveKeyringParcel.Algorithm.RSA,
-                3072, null, KeyFlags.ENCRYPT_COMMS | KeyFlags.ENCRYPT_STORAGE, 0L));
+        builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(SaveKeyringParcel.Algorithm.EDDSA,
+                null, null, KeyFlags.CERTIFY_OTHER | KeyFlags.SIGN_DATA, 0L));
+        builder.addSubkeyAdd(SubkeyAdd.createSubkeyAdd(SaveKeyringParcel.Algorithm.ECDH,
+                null, SaveKeyringParcel.Curve.CV25519, KeyFlags.ENCRYPT_COMMS | KeyFlags.ENCRYPT_STORAGE, 0L));
     }
 
     /**

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpKeyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpKeyOperation.java
@@ -251,7 +251,7 @@ public class PgpKeyOperation {
 
                 case EDDSA: {
                     if ((add.getFlags() & (PGPKeyFlags.CAN_ENCRYPT_COMMS | PGPKeyFlags.CAN_ENCRYPT_STORAGE)) > 0) {
-                        log.add(LogType.MSG_CR_ERROR_FLAGS_ECDSA, indent);
+                        log.add(LogType.MSG_CR_ERROR_FLAGS_EDDSA, indent);
                         return null;
                     }
                     progress(R.string.progress_generating_eddsa, 30);

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpKeyOperation.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/pgp/PgpKeyOperation.java
@@ -269,9 +269,14 @@ public class PgpKeyOperation {
                         return null;
                     }
                     progress(R.string.progress_generating_ecdh, 30);
-                    ECGenParameterSpec ecParamSpec = getEccParameterSpec(add.getCurve());
-                    keyGen = KeyPairGenerator.getInstance("ECDH", Constants.BOUNCY_CASTLE_PROVIDER_NAME);
-                    keyGen.initialize(ecParamSpec, new SecureRandom());
+                    if (add.getCurve() == Curve.CV25519) {
+                        keyGen = KeyPairGenerator.getInstance("X25519");
+                        keyGen.initialize(255);
+                    } else {
+                        ECGenParameterSpec ecParamSpec = getEccParameterSpec(add.getCurve());
+                        keyGen = KeyPairGenerator.getInstance("ECDH", Constants.BOUNCY_CASTLE_PROVIDER_NAME);
+                        keyGen.initialize(ecParamSpec, new SecureRandom());
+                    }
 
                     algorithm = PGPPublicKey.ECDH;
                     break;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/SaveKeyringParcel.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/service/SaveKeyringParcel.java
@@ -324,7 +324,7 @@ public abstract class SaveKeyringParcel implements Parcelable {
     // All curves defined in the standard
     // http://www.bouncycastle.org/wiki/pages/viewpage.action?pageId=362269
     public enum Curve {
-        NIST_P256, NIST_P384, NIST_P521,
+        NIST_P256, NIST_P384, NIST_P521, CV25519
 
         // these are supported by gpg, but they are not in rfc6637 and not supported by BouncyCastle yet
         // (adding support would be trivial though -> JcaPGPKeyConverter.java:190)

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
@@ -165,9 +165,9 @@ public class AddSubkeyDialogFragment extends DialogFragment {
             TwoLineArrayAdapter adapter = new TwoLineArrayAdapter(context,
                     android.R.layout.simple_spinner_item, choices);
             mKeyTypeSpinner.setAdapter(adapter);
-            // make RSA 3072 the default
+            // make EDDSA the default
             for (int i = 0; i < choices.size(); ++i) {
-                if (choices.get(i).getId() == SupportedKeyType.RSA_3072) {
+                if (choices.get(i).getId() == SupportedKeyType.EDDSA) {
                     mKeyTypeSpinner.setSelection(i);
                     break;
                 }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
@@ -197,19 +197,18 @@ public class AddSubkeyDialogFragment extends DialogFragment {
                     mUsageNone.setChecked(true);
                 }
 
-                if (keyType == SupportedKeyType.ECC_P521 || keyType == SupportedKeyType.ECC_P256) {
-                    mUsageSignAndEncrypt.setEnabled(false);
-                    if (mWillBeMasterKey) {
-                        mUsageEncrypt.setEnabled(false);
-                    }
-                } else if (keyType == SupportedKeyType.EDDSA) {
-                    mUsageSignAndEncrypt.setEnabled(false);
-                    mUsageEncrypt.setEnabled(false);
-                } else {
-                    // need to enable if previously disabled for ECC masterkey
-                    mUsageEncrypt.setEnabled(true);
-                    mUsageSignAndEncrypt.setEnabled(true);
+                boolean signAndEncryptAvailable = true;
+                boolean encryptAvailable = true;
+                switch (keyType) {
+                    case ECC_P256:
+                    case ECC_P521:
+                    case EDDSA:
+                        signAndEncryptAvailable = false;
+                        if (mWillBeMasterKey) encryptAvailable = false;
+                        break;
                 }
+                mUsageSignAndEncrypt.setEnabled(signAndEncryptAvailable);
+                mUsageEncrypt.setEnabled(encryptAvailable);
             }
 
             @Override

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java
@@ -262,6 +262,10 @@ public class AddSubkeyDialogFragment extends DialogFragment {
                             curve = Curve.NIST_P521;
                             break;
                         }
+                        case EDDSA: {
+                            curve = Curve.CV25519;
+                            break;
+                        }
                     }
 
                     // set algorithm
@@ -283,7 +287,11 @@ public class AddSubkeyDialogFragment extends DialogFragment {
                             break;
                         }
                         case EDDSA: {
-                            algorithm = Algorithm.EDDSA;
+                            if(mUsageEncrypt.isChecked()) {
+                                algorithm = Algorithm.ECDH;
+                            } else {
+                                algorithm = Algorithm.EDDSA;
+                            }
                         }
                     }
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/KeyFormattingUtils.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/util/KeyFormattingUtils.java
@@ -188,6 +188,8 @@ public class KeyFormattingUtils {
                 return "NIST P-384";
             case NIST_P521:
                 return "NIST P-521";
+            case CV25519:
+                return "Curve25519";
 
             /* see SaveKeyringParcel
             case BRAINPOOL_P256:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
**I'm not very sure whether the key generation code is correct, although it seems to work during my test.**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`mKeyTypeSpinner` has an inconsistency here: https://github.com/open-keychain/open-keychain/blob/8d69181b65c2d5364f40845466a9e5305ca8c91b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/dialog/AddSubkeyDialogFragment.java#L202-L204

If `mUsageEncrypt` is disabled because EDDSA was once selected, it won't be re-enabled on ECC_P521 or ECC_P256 being re-selected.

Actually I see Curve25519 encrypt/decrypt is supported (#2269), so that I think this should be just enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built & tested on my device running Android 12L, together with Gpg4win.

Sent encrypted file and then decrypted on the target device successfully. (both PC <=> Android)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
