### PR TITLE
Add support for NitroKey v3

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
@@ -127,7 +127,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
             TokenType.NITROKEY_STORAGE,
             TokenType.NITROKEY_START_OLD,
             TokenType.NITROKEY_START_1_25_AND_NEWER,
-	    TokenType.NITROKEY_3,
+            TokenType.NITROKEY_3,
             TokenType.GNUK_OLD,
             TokenType.GNUK_1_25_AND_NEWER,
             TokenType.LEDGER_NANO_S,
@@ -140,7 +140,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
             TokenType.NITROKEY_PRO,
             TokenType.NITROKEY_STORAGE,
             TokenType.NITROKEY_START_1_25_AND_NEWER,
-	    TokenType.NITROKEY_3,
+            TokenType.NITROKEY_3,
             TokenType.GNUK_1_25_AND_NEWER,
             TokenType.SECALOT
     )));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/SecurityTokenInfo.java
@@ -117,7 +117,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
 
     public enum TokenType {
         YUBIKEY_NEO, YUBIKEY_4_5, FIDESMO, NITROKEY_PRO, NITROKEY_STORAGE, NITROKEY_START_OLD,
-        NITROKEY_START_1_25_AND_NEWER, GNUK_OLD, GNUK_1_25_AND_NEWER, LEDGER_NANO_S, SECALOT, UNKNOWN
+        NITROKEY_START_1_25_AND_NEWER, NITROKEY_3, GNUK_OLD, GNUK_1_25_AND_NEWER, LEDGER_NANO_S, SECALOT, UNKNOWN
     }
 
     public static final Set<TokenType> SUPPORTED_USB_TOKENS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
@@ -127,6 +127,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
             TokenType.NITROKEY_STORAGE,
             TokenType.NITROKEY_START_OLD,
             TokenType.NITROKEY_START_1_25_AND_NEWER,
+	    TokenType.NITROKEY_3,
             TokenType.GNUK_OLD,
             TokenType.GNUK_1_25_AND_NEWER,
             TokenType.LEDGER_NANO_S,
@@ -139,6 +140,7 @@ public abstract class SecurityTokenInfo implements Parcelable {
             TokenType.NITROKEY_PRO,
             TokenType.NITROKEY_STORAGE,
             TokenType.NITROKEY_START_1_25_AND_NEWER,
+	    TokenType.NITROKEY_3,
             TokenType.GNUK_1_25_AND_NEWER,
             TokenType.SECALOT
     )));

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
@@ -247,7 +247,16 @@ public class CcidTransceiver {
     }
 
     private CcidDataBlock receiveDataBlockImmediate(byte expectedSequenceNumber) throws UsbTransportException {
+        Timber.d("Receive data block immediate seq=" + expectedSequenceNumber);
         int readBytes = usbConnection.bulkTransfer(usbBulkIn, inputBuffer, inputBuffer.length, DEVICE_COMMUNICATE_TIMEOUT_MILLIS);
+        Timber.d("Received " + readBytes + " bytes: " + toHexString(inputBuffer));
+        if (readBytes == 0) {
+            Timber.d("Poking device again due to zero-sized read");
+            sendRaw(new byte[0], 0, 0);
+            readBytes = usbConnection.bulkTransfer(usbBulkIn, inputBuffer, inputBuffer.length, DEVICE_COMMUNICATE_TIMEOUT_MILLIS);
+            Timber.d("(on retry) Received " + readBytes + " bytes: " + toHexString(inputBuffer));
+        }
+
         if (readBytes < CCID_HEADER_LENGTH) {
             throw new UsbTransportException("USB-CCID error - failed to receive CCID header");
         }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
@@ -267,6 +267,12 @@ public class CcidTransceiver {
     }
 
     private CcidDataBlock receiveDataBlockImmediate(byte expectedSequenceNumber) throws UsbTransportException {
+        /*
+         * Some USB CCID devices (notably NitroKey 3) may time-out and need a subsequent poke to
+         * carry on communications.  No particular reason why the number 3 was chosen.  If we get a
+         * zero-sized reply (or a time-out), we try again.  Clamped retries prevent an infinite loop
+         * if things really turn sour.
+         */
         int attempts = 3;
         Timber.d("Receive data block immediate seq=" + expectedSequenceNumber);
         int readBytes;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
@@ -202,8 +202,8 @@ public class CcidTransceiver {
                 SLOT_NUMBER,
                 sequenceNumber,
                 blockWaitingTime,
-                (byte)(levelParam >> 8),
-                (byte)(levelParam & 0x00ff)
+                (byte)(levelParam & 0x00ff),
+                (byte)(levelParam >> 8)
         };
         byte[] data = Arrays.concatenate(headerData, payload);
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/CcidTransceiver.java
@@ -48,29 +48,49 @@ public class CcidTransceiver {
     private static final int COMMAND_STATUS_TIME_EXTENSION_RQUESTED = 2;
 
     /**
-     * the command APDU begins and ends with this command
+     * Level Parameter: APDU is a single command.
+     *
+     * "the command APDU begins and ends with this command"
+     * -- DWG Smart-Card USB Integrated Circuit(s) Card Devices rev 1.0
+     *    § 6.1.1.3
      */
     public static final short LEVEL_PARAM_START_SINGLE_CMD_APDU = 0x0000;
 
     /**
-     * the command APDU begins with this command, and continue in the
-     * next PC_to_RDR_XfrBlock
+     * Level Parameter: First APDU in a multi-command APDU.
+     *
+     * "the command APDU begins with this command, and continue in the
+     * next PC_to_RDR_XfrBlock"
+     * -- DWG Smart-Card USB Integrated Circuit(s) Card Devices rev 1.0
+     *    § 6.1.1.3
      */
     public static final short LEVEL_PARAM_START_MULTI_CMD_APDU = 0x0001;
 
     /**
-     * this abData field continues a command APDU and ends the command APDU
+     * Level Parameter: Final APDU in a multi-command APDU.
+     *
+     * "this abData field continues a command APDU and ends the command APDU"
+     * -- DWG Smart-Card USB Integrated Circuit(s) Card Devices rev 1.0
+     *    § 6.1.1.3
      */
     public static final short LEVEL_PARAM_END_MULTI_CMD_APDU = 0x0002;
 
     /**
-     * the abData field continues a command APDU and another block is to follow
+     * Level Parameter: Next command in a multi-command APDU.
+     *
+     * "the abData field continues a command APDU and another block is to follow"
+     * -- DWG Smart-Card USB Integrated Circuit(s) Card Devices rev 1.0
+     *    § 6.1.1.3
      */
     public static final short LEVEL_PARAM_CONTINUE_MULTI_CMD_APDU = 0x0003;
 
     /**
-     * empty abData field, continuation of response APDU is expected in the
-     * next RDR_to_PC_DataBlock
+     * Level Parameter: Request the device continue sending APDU.
+     *
+     * "empty abData field, continuation of response APDU is expected in the next
+     * RDR_to_PC_DataBlock"
+     * -- DWG Smart-Card USB Integrated Circuit(s) Card Devices rev 1.0
+     *    § 6.1.1.3
      */
     public static final short LEVEL_PARAM_CONTINUE_RESPONSE = 0x0010;
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/UsbTransport.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/UsbTransport.java
@@ -66,6 +66,7 @@ public class UsbTransport implements Transport {
     private static final int PRODUCT_NITROKEY_PRO = 16648;
     private static final int PRODUCT_NITROKEY_START = 16913;
     private static final int PRODUCT_NITROKEY_STORAGE = 16649;
+    private static final int PRODUCT_NITROKEY_3 = 17074;
 
     private static final int VENDOR_FSIJ = 9035;
     private static final int VENDOR_LEDGER = 11415;
@@ -245,6 +246,8 @@ public class UsbTransport implements Transport {
                         return versionGreaterEquals125 ? TokenType.NITROKEY_START_1_25_AND_NEWER : TokenType.NITROKEY_START_OLD;
                     case PRODUCT_NITROKEY_STORAGE:
                         return TokenType.NITROKEY_STORAGE;
+                    case PRODUCT_NITROKEY_3:
+                        return TokenType.NITROKEY_3;
                 }
                 break;
             }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T1ShortApduProtocol.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T1ShortApduProtocol.java
@@ -62,6 +62,13 @@ public class T1ShortApduProtocol implements CcidTransportProtocol {
             throw new UsbTransportException("Failed to write block to temporary buffer", e);
         }
 
+        /*
+         * Handle multi-block responses in accordance with DWG Smart-Card USB Integrated Circut(s)
+         * Card Devices v1.0 § 6.1.1.  If we receive a response with a chain parameter indicating
+         * more data is to come, then instruct the device to continue and append the response to our
+         * output buffer.
+         */
+
         while (
                 (response.getChainParameter() == CHAIN_PARAM_APDU_MULTIBLOCK_START)
                 || (response.getChainParameter() == CHAIN_PARAM_APDU_MULTIBLOCK_MORE)

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T1ShortApduProtocol.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T1ShortApduProtocol.java
@@ -74,8 +74,7 @@ public class T1ShortApduProtocol implements CcidTransportProtocol {
                 || (response.getChainParameter() == CHAIN_PARAM_APDU_MULTIBLOCK_MORE)
         ) {
             response = ccidTransceiver.sendXfrBlock(
-                new byte[0], (byte)0,
-                CcidTransceiver.LEVEL_PARAM_CONTINUE_RESPONSE
+                new byte[0], (byte)0, CcidTransceiver.LEVEL_PARAM_CONTINUE_RESPONSE
             );
             try {
                 output.write(response.getData());

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T1ShortApduProtocol.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/securitytoken/usb/tpdu/T1ShortApduProtocol.java
@@ -29,12 +29,18 @@ import org.sufficientlysecure.keychain.securitytoken.usb.UsbTransportException;
 
 public class T1ShortApduProtocol implements CcidTransportProtocol {
     /**
-     * The response APDU begins with this command and is to continue
+     * Chain Parameter: Start of multi-command APDU response.
+     *
+     * "The response APDU begins with this command and is to continue"
+     * -- DWG Smart-Card USB Integrated Circuit(s) Card Devices v1.0 § 6.1.1.3
      */
     public static final byte CHAIN_PARAM_APDU_MULTIBLOCK_START = 1;
 
     /**
-     * This abData field continues the response APDU and another block is to follow
+     * Chain Parameter: Continued multi-command APDU response with more data.
+     *
+     * "This abData field continues the response APDU and another block is to follow"
+     * -- DWG Smart-Card USB Integrated Circuit(s) Card Devices v1.0 § 6.1.1.3
      */
     public static final byte CHAIN_PARAM_APDU_MULTIBLOCK_MORE = 3;
 


### PR DESCRIPTION
## Description

This branch adds support for the NitroKey v3 family USB VID/PID to OpenKeychain.

Closes #2840

## Motivation and Context

Plug in a NitroKey 3A Mini, at present it says it's not supported.  The NFC version is not in stock, and it'll never be possible to do NFC with a NFC-free 3A mini.

https://github.com/open-keychain/open-keychain/issues/2840

## How Has This Been Tested?

It has now, although I'd appreciate others giving this a shot.

## Screenshots (if appropriate):

https://github.com/open-keychain/open-keychain/pull/2842#issuecomment-1656550875

## Types of changes

- ✅ New feature (non-breaking change which adds functionality)