### PR TITLE
Fix: transfer code text color in dark mode

### DIFF
--- a/OpenKeychain/src/main/res/values-night/styles.xml
+++ b/OpenKeychain/src/main/res/values-night/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="TransferCodeText" parent="TransferCodeTextBase">
+        <item name="android:textColor">#FFF</item>
+    </style>
+
+</resources>

--- a/OpenKeychain/src/main/res/values/styles.xml
+++ b/OpenKeychain/src/main/res/values/styles.xml
@@ -65,7 +65,7 @@
         <item name="android:textSize" tools:ignore="SpUsage">14dp</item>
     </style>
 
-    <style name="TransferCodeText">
+    <style name="TransferCodeTextBase">
         <item name="android:gravity">center_vertical</item>
         <item name="android:singleLine">true</item>
         <item name="android:hint">1234</item>
@@ -77,6 +77,10 @@
         <item name="android:typeface">monospace</item>
         <item name="android:textColor">#000</item>
         <item name="android:inputType">numberPassword|textVisiblePassword</item>
+    </style>
+
+    <style name="TransferCodeText" parent="TransferCodeTextBase">
+        <item name="android:textColor">#000</item>
     </style>
 
     <style name="TransferCodeTextSep" parent="TransferCodeText">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
I adjusted the transfer code color to white (#FFF) in dark mode while keeping it black (#000) in light mode.

## Motivation and Context
The transfer code is barely visible in dark mode.

## How Has This Been Tested?
Switched the system theme from light to dark mode.

## Screenshots (if appropriate):
![Bildschirmfoto vom 2023-11-12 15-40-55](https://github.com/open-keychain/open-keychain/assets/17480795/5a58222b-fc65-4bac-937c-a85dbd2c7766) ![Bildschirmfoto vom 2023-11-12 15-50-07](https://github.com/open-keychain/open-keychain/assets/17480795/2c5cc264-e2df-4744-84a1-0a8cd046a8b3)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
