### PR TITLE
Improve PassphraseDialog lifecycle logic

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -134,29 +134,6 @@ public class PassphraseDialogActivity extends FragmentActivity {
         frag.show(getSupportFragmentManager(), "passphraseDialog");
     }
 
-    @Override
-    protected void onResumeFragments() {
-        super.onResumeFragments();
-
-        /* Show passphrase dialog to cache a new passphrase the user enters for using it later for
-         * encryption. Based on mSecretKeyId it asks for a passphrase to open a private key or it asks
-         * for a symmetric passphrase
-         */
-        /*PassphraseDialogFragment frag = new PassphraseDialogFragment();
-        frag.setArguments(getIntent().getExtras());
-        frag.show(getSupportFragmentManager(), "passphraseDialog");*/
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-
-        DialogFragment dialog = (DialogFragment) getSupportFragmentManager().findFragmentByTag("passphraseDialog");
-        /*if (dialog != null) {
-            dialog.dismiss();
-        }*/
-    }
-
     public static class PassphraseDialogFragment extends DialogFragment implements TextView.OnEditorActionListener {
         private EditText mPassphraseEditText;
         private TextView mPassphraseText;

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/PassphraseDialogActivity.java
@@ -129,6 +129,9 @@ public class PassphraseDialogActivity extends FragmentActivity {
             finish();
         }
 
+        PassphraseDialogFragment frag = new PassphraseDialogFragment();
+        frag.setArguments(getIntent().getExtras());
+        frag.show(getSupportFragmentManager(), "passphraseDialog");
     }
 
     @Override
@@ -139,9 +142,9 @@ public class PassphraseDialogActivity extends FragmentActivity {
          * encryption. Based on mSecretKeyId it asks for a passphrase to open a private key or it asks
          * for a symmetric passphrase
          */
-        PassphraseDialogFragment frag = new PassphraseDialogFragment();
+        /*PassphraseDialogFragment frag = new PassphraseDialogFragment();
         frag.setArguments(getIntent().getExtras());
-        frag.show(getSupportFragmentManager(), "passphraseDialog");
+        frag.show(getSupportFragmentManager(), "passphraseDialog");*/
     }
 
     @Override
@@ -149,9 +152,9 @@ public class PassphraseDialogActivity extends FragmentActivity {
         super.onPause();
 
         DialogFragment dialog = (DialogFragment) getSupportFragmentManager().findFragmentByTag("passphraseDialog");
-        if (dialog != null) {
+        /*if (dialog != null) {
             dialog.dismiss();
-        }
+        }*/
     }
 
     public static class PassphraseDialogFragment extends DialogFragment implements TextView.OnEditorActionListener {


### PR DESCRIPTION
## Description
In the current implementation of the lifecycle of the Passphrase dialog, the dialog gets dismissed and re-created in onPause and onResumeFragments. For the user, it seems as if the input is cleared if he switches apps, turns phone to standby or uses autofill (e.g. password managers). This PR modifies the lifecylce logic, such that the dialog does not get dismissed in this occations.

## Motivation and Context
The current implementation made it impossible to switch to another app to copy the password for a key; one had to copy it before opening the dialog.
Using the autofill feature (implemented by most password managers) was also not possible.
This change fixes #2449 / also fixes #2828

## How Has This Been Tested?
Only PassphraseDialogActivity.java has been modified. I opened the dialog (select key > export key) and tested using autofill, switching between apps and back to OpenKeychain and turning the phone off (to standby) and on again.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
