### PR TITLE
🐛fix Issue #2881: avoid NullPointerException in selectUserIdStatusByEmailLike

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
@@ -36,7 +36,7 @@ public class UserIdDao extends AbstractDao {
 
     public UidStatus getUidStatusByEmailLike(String emailLike) {
         return getDatabase().getUserPacketsQueries().selectUserIdStatusByEmailLike(emailLike)
-                .executeAsOne();
+                .executeAsOneOrNull();
     }
 
     public Map<String, UidStatus> getUidStatusByEmail(String... emails) {


### PR DESCRIPTION
## Description
after upgrade of sqlitedb library sqldelight in commit 5d84bd838744f63d46d5a08110bad13b5192ae6a the method getUidStatusByEmailLike may suddenly raise a NullPointerException. This fix attempts to restore the prior behavior or simply returning null.

## Motivation and Context
It attempts to fix Issue #2881.

## How Has This Been Tested?
I did not yet test this change, this is merely a proposal, as described in Issue #2881.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
