### PR TITLE
🐛fix Issue #2881: avoid IllegalStateException in selectUserIdStatusByEmailLike

### DIFF
--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
@@ -37,8 +37,8 @@ public class UserIdDao extends AbstractDao {
     public UidStatus getUidStatusByEmailLike(String emailLike) {
         List<UidStatus> uidStatusList = getDatabase().getUserPacketsQueries()
             .selectUserIdStatusByEmailLike(emailLike).executeAsList();
-        if (length(uidStatusList) > 0){
-            return uidStatusList[0]
+        if (uidStatusList.size() > 0){
+            return uidStatusList.get(0)
         }
         return null
     }

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/daos/UserIdDao.java
@@ -35,8 +35,12 @@ public class UserIdDao extends AbstractDao {
     }
 
     public UidStatus getUidStatusByEmailLike(String emailLike) {
-        return getDatabase().getUserPacketsQueries().selectUserIdStatusByEmailLike(emailLike)
-                .executeAsOneOrNull();
+        List<UidStatus> uidStatusList = getDatabase().getUserPacketsQueries()
+            .selectUserIdStatusByEmailLike(emailLike).executeAsList();
+        if (length(uidStatusList) > 0){
+            return uidStatusList[0]
+        }
+        return null
     }
 
     public Map<String, UidStatus> getUidStatusByEmail(String... emails) {


### PR DESCRIPTION
## Description
MY first attempt to fix was in https://github.com/open-keychain/open-keychain/commit/f008f27843ae223e02d6939b1d1ca6b11a10bb11

After upgrade of sqlitedb library sqldelight in commit https://github.com/open-keychain/open-keychain/commit/5d84bd838744f63d46d5a08110bad13b5192ae6a the method `getUidStatusByEmailLike` may suddenly raise a `NullPointerException` or a `IllegalStateException`. This fix attempts to restore the prior behavior or simply returning null in both cases: no result, multiple results

## Motivation and Context
A fix for Issues #2891 and #2881 and a follow-up to PR #2882

## How Has This Been Tested?
Did not test or build this myself yet.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

