### PR TITLE
Fix: add package queries

### DIFF
--- a/OpenKeychain/src/main/AndroidManifest.xml
+++ b/OpenKeychain/src/main/AndroidManifest.xml
@@ -73,6 +73,12 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
+    <queries>
+        <package android:name="com.fsck.k9" />
+        <package android:name="dev.msfjarvis.aps" />
+        <package android:name="eu.siacs.conversations" />
+    </queries>
+
     <!-- android:allowBackup="false": Don't allow backup over adb backup or other apps! -->
     <application
         android:name=".KeychainApplication"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Detecting installed apps is currently not working properly in API level 30+, see [here](https://stackoverflow.com/questions/34709873/packagemanager-namenotfoundexception).

## Motivation and Context
In order to fix installed app detection.

## How Has This Been Tested?
By installing the advertised apps.

## Screenshots (if appropriate):
This screenshot shows the current behavior when Conversations and K9 is installed, and K9 is already set up with OpenKeychain. Both are not detected as installed (tapping them will open the download pages) and the already set up K9 is only displayed as package ID instead of the correct app name.
![Bildschirmfoto vom 2024-03-15 00-28-59](https://github.com/open-keychain/open-keychain/assets/17480795/3c2a6e1b-9076-475b-bf50-b011d2cce107)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
