### PR TITLE
Improve vCard KEY parsing

### DIFF
--- a/OpenKeychain/build.gradle
+++ b/OpenKeychain/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'com.cocosw:bottomsheet:1.5.0@aar'
 
     // RecyclerView
-    implementation 'eu.davidea:flexible-adapter:5.1.0'
+    implementation 'eu.davidea:flexible-adapter:5.1.0-SNAPSHOT'
     implementation 'eu.davidea:flexible-adapter-ui:1.0.0-b5'
     implementation 'eu.davidea:flexible-adapter-livedata:1.0.0-b2'
 

--- a/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysProxyActivity.java
+++ b/OpenKeychain/src/main/java/org/sufficientlysecure/keychain/ui/ImportKeysProxyActivity.java
@@ -135,7 +135,12 @@ public class ImportKeysProxyActivity extends FragmentActivity
         }
     }
 
-    private static final Pattern VCARD_KEY_PATTERN = Pattern.compile("\nKEY:(.*)\n");
+    private static final Pattern VCARD_KEY_PATTERN = Pattern.compile(
+        "^KEY(?:;(?:\"[^\"]*\"|[^\":])*)*:(" +
+            Constants.FINGERPRINT_SCHEME.toUpperCase(Locale.ENGLISH) +
+            ":.*)$",
+        Pattern.MULTILINE
+    );
 
     private void processScannedContent(String content) {
         // if a VCard was scanned try to extract the KEY field
@@ -229,7 +234,6 @@ public class ImportKeysProxyActivity extends FragmentActivity
 
         mImportOpHelper.cryptoOperation();
     }
-
 
     // CryptoOperationHelper.Callback methods
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ allprojects {
         mavenCentral()
         // needed for some legacy libs that aren't available on mavenCentral
         jcenter()
+        maven { url 'https://artifactory.appodeal.com/appodeal-public/' }
+        // See https://github.com/davideas/FlexibleAdapter/issues/780#issuecomment-4034248885
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     }
 }
 


### PR DESCRIPTION
## Description
This changes the regular expression used to extract the KEY property from a scanned vCard file to one that aims to support every standard vCard file, versions 3 or 4.

The new regular expression, expanded, is:
```
^KEY(?:;(?:"[^"]*"|[^":])*)*:(OPENPGP4FPR:.*)$
```
It's meant to be used in MULTILINE mode, so `^` matches the start of a line. It then matches for the `KEY` literal, that marks the start of the KEY property, consumes any parameters with `(;(?:"[^"]*"|[^":])*)*:` (first a `;`, then a sequence of quoted and/or unquoted strings that ultimately ends with an unquoted `:`), then matches an OPENPGP4FPR URI, and finally EOL.

Most of the complexity comes from the requirement of allowing quoted parameter values, which may contain the `:` character. The expression is very sloppy, so many invalid vCards will be accepted. I chose it because it's simple to understand, as I don't think false positives are a problem.

### Building

Some dependencies of this project cannot be found on the registered repositories anymore. I thus added the `maven { url 'https://artifactory.appodeal.com/appodeal-public/' }` repository, where most of the missing ones can be found, and `maven { url "https://central.sonatype.com/repository/maven-snapshots/" }`, because the regular `eu.davidea:flexible-adapter:5.1.0` one finds on the internet is not compatible with SDK version 34 anymore: See <https://github.com/davideas/FlexibleAdapter/issues/780>. If another solution is desired, I can remove these changes from the pull request.

## Motivation and Context
The app claims to support importing keys from vCards encoded in QR codes: <https://github.com/open-keychain/open-keychain/wiki/QR-Codes#vcard-support>.

However, the current implementation of that feature has many problems:
1. As noted in #2601, the algorithm expects Unix style / LF line endings, which are not what vCard files use;
2. It assumes there will only be one KEY field;
3. It assumes that the KEY field will not contain any parameters.

This changes addresses problems 1 and 3 and partially problem 2.

- Problem 1 is solved by using the `Pattern.MULTILINE` flag and matching on `^` and `$` instead of `\n`. Note that this also works for Unix-style line endings;
- Problem 3 is solved by considering possible parameters in the regular expression, as explained above;
- Problem 2 is partially solved by matching specifically against a KEY with an `OPENPGP4FPR` URI, instead of any `KEY` property, as that lets us ignore every key that's not relevant to us. This does not handle the case where the vCard contains more than one KEY with an `OPENPGP4FPR` URI, however.

This pull request is in contrast to #2600, which solves similar problems, but this one refrains from adding any new capabilities, instead only improving on what's already there (or was supposed to be). It's also simpler.

## How Has This Been Tested?
I used the following files: <https://github.com/veigaribo/open-keychain-vcard-qr-tests/tree/main>.

For each vcf file, each containing one vCard 4.0, I generated a corresponding QR code, using the provided `encoded.sh` script. I then used the app to scan each of them, and checked that the app was able to import my keys in each case.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
